### PR TITLE
Switching MetricUnits to use String instead of Enum.

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/metrics/Metadata.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/Metadata.java
@@ -65,7 +65,7 @@ public class Metadata {
      * An optional field which holds the Unit of the metric object.
      * </p>
      */
-    private MetricUnit unit = MetricUnit.NONE;
+    private String unit = MetricUnit.NONE;
     
     /**
      * Tags of the metric. Augmented by global tags.
@@ -105,8 +105,10 @@ public class Metadata {
         // Assign default units
         switch (type) {
         case TIMER:
+            this.unit = MetricUnit.NANOSECONDS;
+            break;
         case METERED:
-            this.unit = MetricUnit.NANOSECOND;
+            this.unit = MetricUnit.PER_SECOND;
             break;
         case HISTOGRAM:
         case GAUGE:
@@ -124,7 +126,7 @@ public class Metadata {
      * @param type The type of the metric
      * @param unit The units of the metric
      */
-    public Metadata(String name, MetricType type, MetricUnit unit) {
+    public Metadata(String name, MetricType type, String unit) {
         this();
         this.name = name;
         this.type = type;
@@ -140,7 +142,7 @@ public class Metadata {
      * @param type The type of the metric
      * @param unit The units of the metric
      */
-    public Metadata(String name, String displayName, String description, MetricType type, MetricUnit unit) {
+    public Metadata(String name, String displayName, String description, MetricType type, String unit) {
         this();
         this.name = name;
         this.displayName = displayName;
@@ -159,7 +161,7 @@ public class Metadata {
      * @param unit The units of the metric
      * @param tags The tags of the metric
      */
-    public Metadata(String name, String displayName, String description, MetricType type, MetricUnit unit, String tags) {
+    public Metadata(String name, String displayName, String description, MetricType type, String unit, String tags) {
         this();
         this.name = name;
         this.displayName = displayName;
@@ -229,18 +231,10 @@ public class Metadata {
     }
 
     public String getUnit() {
-        return unit.toString();
-    }
-
-    public MetricUnit getUnitRaw() {
         return unit;
     }
 
     public void setUnit(String unit) {
-        this.unit = MetricUnit.from(unit);
-    }
-
-    public void setUnit(MetricUnit unit) {
         this.unit = unit;
     }
 

--- a/api/src/main/java/org/eclipse/microprofile/metrics/MetricUnit.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/MetricUnit.java
@@ -16,85 +16,50 @@
  */
 package org.eclipse.microprofile.metrics;
 
-
-import java.util.EnumSet;
-
 /**
  * Units for the metrics.
  *
  * @author hrupp
  */
-public enum MetricUnit {
+public final class MetricUnit {
   /** Dummy to say that this has no unit */
-  NONE ("none", Family.NONE),
+  public static final String NONE = "none";
 
   /** A single Bit. Not defined by SI, but by IEC 60027 */
-  BIT("bit", Family.BIT),
-  /** 1000 {@link #BIT} */
-  KILOBIT("kilobit", Family.BIT),
-  /** 1000 {@link #KIBIBIT} */
-  MEGABIT("megabit", Family.BIT),
-  /** 1000 {@link #MEGABIT} */
-  GIGABIT("gigabit", Family.BIT),
-  /** 1024 {@link #BIT} */
-  KIBIBIT("kibibit", Family.BIT),
-  /** 1024 {@link #KIBIBIT}  */
-  MEBIBIT("mebibit", Family.BIT),
-  /** 1024 {@link #MEBIBIT} */
-  GIBIBIT("gibibit", Family.BIT), /* 1024 mebibit */
+  public static final String BITS = "bits";
+  /** 1000 {@link #BITS} */
+  public static final String KILOBITS = "kilobits";
+  /** 1000 {@link #KIBIBITS} */
+  public static final String MEGABITS = "megabits";
+  /** 1000 {@link #MEGABITS} */
+  public static final String GIGABITS = "gigabits";
+  /** 1024 {@link #BITS} */
+  public static final String KIBIBITS = "kibibits";
+  /** 1024 {@link #KIBIBITS}  */
+  public static final String MEBIBITS = "mebibits";
+  /** 1024 {@link #MEBIBITS} */
+  public static final String GIBIBITS = "gibibits";
 
-  /** 8 {@link #BIT} */
-  BYTE ("byte", Family.BYTE),
-  /** 1024 {@link #BYTE} */
-  KILOBYTE("kbyte", Family.BYTE), // 1024 bytes
-  /** 1024 {@link #KILOBYTE} */
-  MEGABYTE("mbyte", Family.BYTE), // 1024 kilo bytes
-  /** 1024 {@link #MEGABYTE} */
-  GIGABYTE("gbyte", Family.BYTE),
+  /** 8 {@link #BITS} */
+  public static final String BYTES = "bytes";
+  /** 1024 {@link #BYTES} */
+  public static final String KILOBYTES = "kilobytes";
+  /** 1024 {@link #KILOBYTES} */
+  public static final String MEGABYTES = "megabytes";
+  /** 1024 {@link #MEGABYTES} */
+  public static final String GIGABYTES = "gigabytes";
 
-  NANOSECOND("ns", Family.TIME),
-  MICROSECOND("us", Family.TIME),
-  MILLISECOND("ms", Family.TIME),
-  SECOND("s", Family.TIME),
-  MINUTE("m", Family.TIME),
-  HOUR("h", Family.TIME),
-  DAY("d", Family.TIME),
+  public static final String NANOSECONDS = "nanoseconds";
+  public static final String MICROSECONDS = "microseconds";
+  public static final String MILLISECONDS = "milliseconds";
+  public static final String SECONDS = "seconds";
+  public static final String MINUTES = "minutes";
+  public static final String HOURS = "hours";
+  public static final String DAYS = "days";
 
-  PERCENT("%", Family.RATE)
-
-  ;
-
-
-  private final String name;
-  private final Family family;
-
-  MetricUnit(String name, Family family) {
-    this.name = name;
-    this.family = family;
-  }
-
-  @Override
-  public String toString() {
-    return name;
-  }
-
-  public static MetricUnit from(String in) {
-    EnumSet<MetricUnit> enumSet = EnumSet.allOf(MetricUnit.class);
-    for (MetricUnit u : enumSet) {
-      if (u.name.equals(in)) {
-        return u;
-      }
-    }
-    throw new IllegalArgumentException(in + " is not a valid MetricUnit");
-  }
-
-
-  private enum Family {
-    BIT,
-    BYTE,
-    TIME,
-    RATE,
-    NONE
-  }
-
+  public static final String PERCENT = "%";
+  public static final String PER_SECOND = "per_second";
+  
+  
+  private MetricUnit() {}
 }

--- a/api/src/main/java/org/eclipse/microprofile/metrics/annotation/Counted.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/annotation/Counted.java
@@ -106,6 +106,6 @@ public @interface Counted {
     *
     */
     @Nonbinding
-    MetricUnit unit() default MetricUnit.NONE;
+    String unit() default MetricUnit.NONE;
 
 }

--- a/api/src/main/java/org/eclipse/microprofile/metrics/annotation/Gauge.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/annotation/Gauge.java
@@ -31,8 +31,6 @@ import java.lang.annotation.Target;
 import javax.enterprise.util.Nonbinding;
 import javax.interceptor.InterceptorBinding;
 
-import org.eclipse.microprofile.metrics.MetricUnit;
-
 /**
  * An annotation for marking a method of an annotated object as a gauge.
  * Given a method like this:
@@ -90,6 +88,6 @@ public @interface Gauge {
     *
     */
     @Nonbinding
-    MetricUnit unit();
+    String unit();
 
 }

--- a/api/src/main/java/org/eclipse/microprofile/metrics/annotation/Metered.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/annotation/Metered.java
@@ -92,6 +92,6 @@ public @interface Metered {
     *
     */
     @Nonbinding
-    MetricUnit unit() default MetricUnit.NANOSECOND;
+    String unit() default MetricUnit.PER_SECOND;
 
 }

--- a/api/src/main/java/org/eclipse/microprofile/metrics/annotation/Metric.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/annotation/Metric.java
@@ -97,6 +97,6 @@ public @interface Metric {
     *
     */
     @Nonbinding
-    MetricUnit unit() default MetricUnit.NONE;
+    String unit() default MetricUnit.NONE;
 
 }

--- a/api/src/main/java/org/eclipse/microprofile/metrics/annotation/Timed.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/annotation/Timed.java
@@ -94,6 +94,6 @@ public @interface Timed {
     *
     */
     @Nonbinding
-    MetricUnit unit() default MetricUnit.NANOSECOND;
+    String unit() default MetricUnit.NANOSECONDS;
 
 }

--- a/spec/src/main/asciidoc/metrics_spec.adoc
+++ b/spec/src/main/asciidoc/metrics_spec.adoc
@@ -447,7 +447,7 @@ then `OPTIONS /metrics/base/fooVal` will expose:
 
 {
   "fooVal": {
-    "unit": "ms",
+    "unit": "milliseconds",
     "type": "gauge",
     "description": "The size of foo after each request",
     "displayName": "Size of foo",
@@ -475,14 +475,14 @@ then `OPTIONS /metrics/base` exposes:
 ----
 {
   "fooVal": {
-    "unit": "ms",
+    "unit": "milliseconds",
     "type": "gauge",
     "description": "The average duration of foo requests during last 5 minutes",
     "displayName": "Duration of foo",
     "tags": "app=webshop"
   },
   "barVal": {
-    "unit": "mbytes",
+    "unit": "megabytes",
     "type": "gauge",
     "tags": "component=backend,app=webshop"
   }
@@ -552,8 +552,8 @@ Families and Prometheus base units are:
 |===
 | Family | Base unit
 
-| Bit    | bytes
-| Byte   | bytes
+| Bits    | bytes
+| Bytes   | bytes
 | Time   | seconds
 | Percent | ratio (normally ratio is A_per_B, but there are exceptions like `disk_usage_ratio`)
 |===
@@ -990,7 +990,7 @@ In order to make setting the values easier, Annotations are made available.
 .Example set-up of two Gauge metrics
 [source,java]
 ----
-@Gauge(unit = MetricUnit.MEGABYTE) <1>
+@Gauge(unit = MetricUnit.MEGABYTES) <1>
 int diskUsage;
 
 @Gauge(name = "queueSize")         <2>
@@ -1048,7 +1048,7 @@ The following Annotations exist, see below for common fields:
 
 |@Counted | M, C, T | Denotes a counter, which counts the invocations of the annotated object. | MetricUnit.NONE
 |@Gauge   | M, F | Denotes a gauge, which samples the value of the annotated object.  | _none_ Must be supplied by the user
-|@Metered | M, C, T  | Denotes a meter, which tracks the frequency of invocations of the annotated object. | MetricUnit.NANOSECOND
+|@Metered | M, C, T  | Denotes a meter, which tracks the frequency of invocations of the annotated object. | MetricUnit.NANOSECONDS
 |@Metric  | M, F, P | An annotation requesting that a metric should be injected. This annotation can be used on the fields
     of type `Meter`, `Timer`, `Counter`, and `Histogram`. | MetricUnit.NONE
 |@Timed   | M, C, T | Denotes a timer, which tracks duration of the annotated object. | MetricUnit.NONE
@@ -1406,7 +1406,7 @@ MetricRegistry vendorRegistry;
 
 ==== Metadata
 
-[source]
+[source, java]
 ----
 /**
  * Bean holding the metadata of one single metric
@@ -1436,7 +1436,7 @@ public class Metadata {
   /**
    * Unit of the metric.
    */
-  private MetricUnit unit = MetricUnit.NONE;
+  private String unit = MetricUnit.NONE;
 
   /**
    * Tags of the metric. Augmented by global tags.
@@ -1451,7 +1451,7 @@ public class Metadata {
   * @param type The type of the metric
   * @param unit The units of the metric
   */
-  public Metadata(String name, MetricType type, MetricUnit unit) {
+  public Metadata(String name, MetricType type, String unit) {
     this();
     this.name = name;
     this.type = type;
@@ -1464,7 +1464,7 @@ public class Metadata {
 
 ==== Metric type
 
-[source]
+[source, java]
 ----
 public enum MetricType {
   /**
@@ -1486,7 +1486,10 @@ public enum MetricType {
    * and usually exposes them in buckets.
    */
   HISTOGRAM("histogram"),
-
+  /**
+   * A timer aggregates timing durations and provides duration
+   * statistics, plus throughput statistics
+   */
   TIMER("timer"),
   /**
    * Invalid - just a placeholder
@@ -1509,55 +1512,47 @@ public enum MetricType {
 [[metric_units]]
 ==== Units
 
-[source]
+[source, java]
 ----
-public enum MetricUnit {
+public final class MetricUnit {
   /** Dummy to say that this has no unit */
-  NONE ("none"),
+  public static final String NONE = "none";
 
   /** A single Bit. Not defined by SI, but by IEC 60027 */
-  BIT("bit"),
-  /** 1000 {@link #BIT} */
-  KILOBIT("kilobit"),
-  /** 1000 {@link #KIBIBIT} */
-  MEGABIT("megabit"),
-  /** 1000 {@link #MEGABIT} */
-  GIGABIT("gigabit"),
-  /** 1024 {@link #BIT} */
-  KIBIBIT("kibibit"),
-  /** 1024 {@link #KIBIBIT}  */
-  MEBIBIT("mebibit"),
-  /** 1024 {@link #MEBIBIT} */
-  GIBIBIT("gibibit"), /* 1024 mebibit */
+  public static final String BITS = "bits";
+  /** 1000 {@link #BITS} */
+  public static final String KILOBITS = "kilobits";
+  /** 1000 {@link #KIBIBITS} */
+  public static final String MEGABITS = "megabits";
+  /** 1000 {@link #MEGABITS} */
+  public static final String GIGABITS = "gigabits";
+  /** 1024 {@link #BITS} */
+  public static final String KIBIBITS = "kibibits";
+  /** 1024 {@link #KIBIBITS}  */
+  public static final String MEBIBITS = "mebibits";
+  /** 1024 {@link #MEBIBITS} */
+  public static final String GIBIBITS = "gibibits";
 
-  /** 8 {@link #BIT} */
-  BYTE ("byte"),
-  /** 1024 {@link #BYTE} */
-  KILOBYTE ("kbyte"),
-  /** 1024 {@link #KILO_BYTE} */
-  MEGABYTE ("mbyte"),
-  /** 1024 {@link #MEGA_BYTE} */
-  GIGABYTE("gbyte"),
+  /** 8 {@link #BITS} */
+  public static final String BYTES = "bytes";
+  /** 1024 {@link #BYTES} */
+  public static final String KILOBYTES = "kilobytes";
+  /** 1024 {@link #KILOBYTES} */
+  public static final String MEGABYTES = "megabytes";
+  /** 1024 {@link #MEGABYTES} */
+  public static final String GIGABYTES = "gigabytes";
 
-  NANOSECOND("ns"),
-  MICROSECOND("us"),
-  MILLISECOND("ms"),
-  SECOND("s"),
-  MINUTE("m"),
-  HOUR("h"),
-  DAY("d"),
+  public static final String NANOSECOND = "nanoseconds";
+  public static final String MICROSECOND = "microseconds";
+  public static final String MILLISECOND = "milliseconds";
+  public static final String SECONDS = "seconds";
+  public static final String MINUTES = "minutes";
+  public static final String HOURS = "hours";
+  public static final String DAYS = "days";
 
-  PERCENT("%")
+  public static final String PERCENT = "%";
+  public static final String PER_SECOND = "per_second";
 
-  ;
-
-  /**
-   * Convert the string representation in to an enum
-   * @param in the String representation
-   * @return the matching Enum
-   * @throws IllegalArgumentException if in is not a valid enum value
-   */
-  public static MetricUnit from(String in) { [..] }
 
   [...]
 }


### PR DESCRIPTION
Fixes #67, fixes #56, fixes #54, fixes #50, and fixes #44.

Signed-off-by: Raymond Lam <lamr@ca.ibm.com>