### PR TITLE
Allow to test application metadata for unit and type

### DIFF
--- a/tck/rest/src/main/resources/application_metrics.xml
+++ b/tck/rest/src/main/resources/application_metrics.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+    Copyright (c) 2017 Contributors to the Eclipse Foundation
+
+    See the NOTICES file(s) distributed with this work for additional
+    information regarding copyright ownership.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    You may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+    SPDX-License-Identifier: Apache-2.0
+-->
+<config>
+  <metric multi="false" name="org.eclipse.microprofile.metrics.test.MetricAppBean.redCount" type="counter" unit="none"/>
+  <metric multi="false" name="org.eclipse.microprofile.metrics.test.MetricAppBean.blue" type="counter" unit="none"/>
+  <metric multi="false" name="greenCount" type="counter" unit="none"/>
+  <metric multi="false" name="purple" type="counter" unit="none"/>
+  <metric multi="false" name="metricTest.test1.countMeA" type="counter" unit="none"/>
+  <metric multi="false" name="org.eclipse.microprofile.metrics.test.MetricAppBean.gaugeMeA" type="gauge" unit="kibibits"/>
+  <metric multi="false" name="meterMeA" type="meter" unit="per_second"/>
+  <metric multi="false" name="org.eclipse.microprofile.metrics.test.MetricAppBean.timeMeA" type="timer" unit="nanoseconds"/>
+</config>


### PR DESCRIPTION
Like for the base metrics, check the application metrics (that are coming from annotations) for their name , unit and type.

Signed-off-by: Heiko W. Rupp <hrupp@redhat.com>