### PR TITLE
Fixed parent pom path location for tcks

### DIFF
--- a/tck/api/pom.xml
+++ b/tck/api/pom.xml
@@ -14,6 +14,7 @@
         <groupId>org.eclipse.microprofile.metrics</groupId>
         <artifactId>microprofile-metrics-parent</artifactId>
         <version>1.1-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
 
 	<artifactId>microprofile-metrics-api-tck</artifactId>

--- a/tck/rest/pom.xml
+++ b/tck/rest/pom.xml
@@ -21,6 +21,7 @@
         <groupId>org.eclipse.microprofile.metrics</groupId>
         <artifactId>microprofile-metrics-parent</artifactId>
         <version>1.1-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
     </parent>
 
     <artifactId>microprofile-metrics-rest-tck</artifactId>


### PR DESCRIPTION
Occurs if you run mvn for the first time (when the parent artifact does not already exist) due to the folder locations of the tck modules.

Signed-off-by: Raymond Lam <lamr@ca.ibm.com>