### PR TITLE
Test application level tags

### DIFF
--- a/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MetricAppBean.java
+++ b/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MetricAppBean.java
@@ -53,7 +53,7 @@ public class MetricAppBean {
     private Counter greenCount;
 
     @Inject
-    @Metric(name = "purple", absolute = true)
+    @Metric(name = "purple", absolute = true, tags = "app=myShop")
     private Counter purpleCount;
 
     @Inject

--- a/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MpMetricTest.java
+++ b/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MpMetricTest.java
@@ -518,6 +518,31 @@ public class MpMetricTest {
 
     }
 
+    @Test
+    @RunAsClient
+    @InSequence(21)
+    public void testApplicationTagJson() {
+
+        JsonPath jsonPath =  given().header("Accept", APPLICATION_JSON)
+            .when()
+            .options("/metrics/application/purple").jsonPath();
+        String tags = jsonPath.getString("purple.tags");
+        assert tags != null;
+        assert tags.contains("app=myShop");
+        assert tags.contains("tier=integration");
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(22)
+    public void testApplicationTagPrometheus() {
+
+        given().header("Accept", TEXT_PLAIN).when().get("/metrics/application/purple")
+            .then().statusCode(200)
+            .and()
+            .body(containsString("tier=\"integration\""))
+            .body(containsString("app=\"myShop\""));
+    }
 
     private Map<String, MiniMeta> getExpectedMetadataFromXmlFile(MetricRegistry.Type scope) {
       ClassLoader cl = this.getClass().getClassLoader();


### PR DESCRIPTION
Make sure that tags on application level Metrics are propagated to the output.
Could potentially test more, but I did not want to pollute the `MetricAppBean` too much with it.

Signed-off-by: Heiko W. Rupp <hrupp@redhat.com>