### PR TITLE
Provide missing unit in example for @Gauge

### DIFF
--- a/spec/src/main/asciidoc/metrics_spec.adoc
+++ b/spec/src/main/asciidoc/metrics_spec.adoc
@@ -1220,11 +1220,12 @@ When a method is annotated, the implementation must register a gauge for the met
 .Example of an annotated method
 [source, java]
 ----
-@Gauge
+@Gauge(unit = MetricUnits.KILOBITS) // <1>
 public long getValue() {
   return value;
 }
 ----
+<1> Gauges require a unit to be set explicitly.
 
 
 ==== @Metered


### PR DESCRIPTION
The example in the spec was missing the required unit.

Signed-off-by: Heiko W. Rupp <hrupp@redhat.com>