### PR TITLE
Disable brittle tests.

### DIFF
--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/MeterTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/MeterTest.java
@@ -93,7 +93,7 @@ public class MeterTest {
         Assert.assertEquals(count / (beforeUptime), rate, delta);
     }
 
-    @Test
+//    @Test
     public void testRates() throws Exception {
 
         /* testMeterRates1 */

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/TimerTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/TimerTest.java
@@ -83,7 +83,7 @@ public class TimerTest {
         isInitialized = true;
     }
 
-    @Test
+//    @Test
     @InSequence(1)
     public void testRates() throws Exception {
         double beforeStartTime = System.nanoTime();


### PR DESCRIPTION
Addresses #160 and #190

I think we should disable them until we have better tests that also work on Windows or on slow computers.

cc @fmhwong @donbourne 

Signed-off-by: Heiko W. Rupp <hrupp@redhat.com>