### PR TITLE
Calls a method on the MetricProducerMethodBean to instantiate it.

### DIFF
--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MetricProducerFieldBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MetricProducerFieldBeanTest.java
@@ -35,6 +35,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -52,6 +53,16 @@ public class MetricProducerFieldBeanTest {
 
     @Inject
     private MetricRegistry registry;
+
+    @Inject
+    private MetricProducerFieldBean bean;
+
+    @Before
+    public void instantiateApplicationScopedBean() {
+        // Let's trigger the instantiation of the application scoped bean explicitly
+        // as only a proxy gets injected otherwise
+        bean.toString();
+    }
 
     @Test
     @InSequence(1)

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MetricProducerMethodBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MetricProducerMethodBeanTest.java
@@ -34,6 +34,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -60,6 +61,13 @@ public class MetricProducerMethodBeanTest {
 
     @Inject
     private MetricProducerMethodBean bean;
+
+    @Before
+    public void instantiateApplicationScopedBean() {
+        // Let's trigger the instantiation of the application scoped bean explicitly
+        // as only a proxy gets injected otherwise
+        bean.toString();
+    }
 
     @Test
     @InSequence(1)


### PR DESCRIPTION
Fixes #187 

Added `@Inject private MetricProducerFieldBean bean` for MetricProducerFieldBeanTest.java to be safe. The metrics were injected in `incrementCountersFromInjection` (test sequence 3) but are referenced since the first test.