### PR TITLE
Comment out timerRate references since the test was disabled

### DIFF
--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/TimerTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/TimerTest.java
@@ -137,7 +137,7 @@ public class TimerTest {
     @InSequence(3)
     public void testTimerRegistry() throws Exception {
         String timerLongName = "test.longData.timer";
-        String timerRateName = "testRate";
+        //String timerRateName = "testRate";
         String timerTimeName = "testTime";
 
         SortedMap<String, Timer> timers = registry.getTimers();
@@ -146,8 +146,8 @@ public class TimerTest {
         Assert.assertTrue(timers.containsKey(timerLongName));
         Assert.assertTrue(timers.containsKey(timerTimeName));
 
-        Assert.assertEquals(1, timers.get(timerRateName).getCount(), 0);
-        Assert.assertEquals(1, registry.timer("testRate").getCount(), 0);
+        //Assert.assertEquals(1, timers.get(timerRateName).getCount(), 0);
+        //Assert.assertEquals(1, registry.timer("testRate").getCount(), 0);
         Assert.assertEquals(480, timers.get(timerLongName).getSnapshot().getValue(0.5), 0);
     }
 


### PR DESCRIPTION
Add on to #191. Should be re-enabled when #193 gets resolved.

Signed-off-by: Raymond Lam <lamr@ca.ibm.com>