### PR TITLE
Clarify metric name rules for Prometheus output and add tests

### DIFF
--- a/spec/src/main/asciidoc/metrics_spec.adoc
+++ b/spec/src/main/asciidoc/metrics_spec.adoc
@@ -587,8 +587,9 @@ base:bar_val_bytes{component="backend", app="webshop"} 42000 <3>
 ==== Translation rules for metric names
 
 Prometheus text format does not allow for all characters and adds the base unit of a family to the name.
+Characters allowed are `[a-zA-Z0-9_]` (Ascii alphabet, numbers and underscore).
 
-* Dot (`.`), Space ( ), Dash (`-`) are translated to underscore (`_`).
+* Characters that do not fall in above category are translated to underscore (`_`).
 * Scope is always specified at the start of the metric name.
 * Scope and name are separated by colon (`:`).
 * camelCase is translated to camel_case

--- a/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MetricAppBean.java
+++ b/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MetricAppBean.java
@@ -151,4 +151,20 @@ public class MetricAppBean {
     public String getGlobalTags() {
         return globalTags;
     }
+
+    /**
+     * We create a few metrics with names that are outside the
+     * characters that prometheus allows which is [a-zA-Z0-9_]
+     */
+    public void createPromMetrics() {
+
+        metrics.counter("pm_counter-with-dashes");
+
+        metrics.counter("pm_counter#hash_x'y_");
+
+        metrics.counter("pm_counter-umlaut-äöü");
+
+        metrics.counter("pm_counter+accent_ê_");
+
+    }
 }

--- a/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MpMetricTest.java
+++ b/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MpMetricTest.java
@@ -728,6 +728,28 @@ public class MpMetricTest {
       assert "tier=integration".equals(metricAppBean.getGlobalTags());
     }
 
+    @Test
+    @InSequence(33)
+    public void testSetupPromNoBadCharsInNames() {
+        metricAppBean.createPromMetrics();
+    }
+
+    @Test
+    @RunAsClient
+    @InSequence(34)
+    public void testPromNoBadCharsInNames() {
+        given().header("Accept", TEXT_PLAIN).when().get("/metrics/application")
+            .then().statusCode(200)
+            .and()
+                // metrics.counter("pm_counter-with-dashes");
+            .body(containsString("pm_counter_with_dashes"))
+                // metrics.counter("pm_counter#hash_x'y_");
+            .body(containsString("pm_counter_hash_x_y_"))
+                // metrics.counter("pm_counter-umlaut-äöü");
+            .body(containsString("pm_counter_umlaut_"))
+                // metrics.counter("pm_counter+accent_ê_");
+            .body(containsString("pm_counter_accent_"));
+    }
 
     private Map<String, MiniMeta> getExpectedMetadataFromXmlFile(MetricRegistry.Type scope) {
       ClassLoader cl = this.getClass().getClassLoader();


### PR DESCRIPTION
Technically Prometheus also allows a colon, but as Brian says that this should not show up in a name, I am translating that as well.

Signed-off-by: Heiko W. Rupp <hrupp@redhat.com>