### PR TITLE
Added a tolerance to Histogram, Meter and Timer tests results

### DIFF
--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/HistogramTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/HistogramTest.java
@@ -45,7 +45,9 @@ public class HistogramTest {
 
     @Deployment
     public static JavaArchive createDeployment() {
-        return ShrinkWrap.create(JavaArchive.class).addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+        return ShrinkWrap.create(JavaArchive.class)
+                .addClass(TestUtils.class)
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
     @Inject
@@ -104,8 +106,8 @@ public class HistogramTest {
         Assert.assertTrue(histograms.containsKey(histogramIntName));
         Assert.assertTrue(histograms.containsKey(histogramLongName));
 
-        Assert.assertEquals(48, histograms.get(histogramIntName).getSnapshot().getValue(0.5), 0);
-        Assert.assertEquals(480, histograms.get(histogramLongName).getSnapshot().getValue(0.5), 0);
+        TestUtils.assertEqualsWithTolerance(48, histograms.get(histogramIntName).getSnapshot().getValue(0.5));
+        TestUtils.assertEqualsWithTolerance(480, histograms.get(histogramLongName).getSnapshot().getValue(0.5));
     }
 
     @Test
@@ -126,67 +128,69 @@ public class HistogramTest {
 
     @Test
     public void testSnapshot75thPercentile() throws Exception {
-        Assert.assertEquals(75, histogramInt.getSnapshot().get75thPercentile(), 0);
-        Assert.assertEquals(750, histogramLong.getSnapshot().get75thPercentile(), 0);
+        TestUtils.assertEqualsWithTolerance(75, histogramInt.getSnapshot().get75thPercentile());
+        TestUtils.assertEqualsWithTolerance(750, histogramLong.getSnapshot().get75thPercentile());
     }
 
     @Test
     public void testSnapshot95thPercentile() throws Exception {
-        Assert.assertEquals(96, histogramInt.getSnapshot().get95thPercentile(), 0);
-        Assert.assertEquals(960, histogramLong.getSnapshot().get95thPercentile(), 0);
+        TestUtils.assertEqualsWithTolerance(96, histogramInt.getSnapshot().get95thPercentile());
+        TestUtils.assertEqualsWithTolerance(960, histogramLong.getSnapshot().get95thPercentile());
     }
 
     @Test
     public void testSnapshot98thPercentile() throws Exception {
-        Assert.assertEquals(98, histogramInt.getSnapshot().get98thPercentile(), 0);
-        Assert.assertEquals(980, histogramLong.getSnapshot().get98thPercentile(), 0);
+        TestUtils.assertEqualsWithTolerance(98, histogramInt.getSnapshot().get98thPercentile());
+        TestUtils.assertEqualsWithTolerance(980, histogramLong.getSnapshot().get98thPercentile());
     }
 
     @Test
     public void testSnapshot99thPercentile() throws Exception {
-        Assert.assertEquals(98, histogramInt.getSnapshot().get99thPercentile(), 0);
-        Assert.assertEquals(980, histogramLong.getSnapshot().get99thPercentile(), 0);
+        TestUtils.assertEqualsWithTolerance(98, histogramInt.getSnapshot().get99thPercentile());
+        TestUtils.assertEqualsWithTolerance(980, histogramLong.getSnapshot().get99thPercentile());
     }
 
     @Test
     public void testSnapshot999thPercentile() throws Exception {
-        Assert.assertEquals(99, histogramInt.getSnapshot().get999thPercentile(), 0);
-        Assert.assertEquals(990, histogramLong.getSnapshot().get999thPercentile(), 0);
+        TestUtils.assertEqualsWithTolerance(99, histogramInt.getSnapshot().get999thPercentile());
+        TestUtils.assertEqualsWithTolerance(990, histogramLong.getSnapshot().get999thPercentile());
     }
 
     @Test
     public void testSnapshotMax() throws Exception {
-        Assert.assertEquals(99.0, histogramInt.getSnapshot().getMax(), 0);
-        Assert.assertEquals(990.0, histogramLong.getSnapshot().getMax(), 0);
+        Assert.assertEquals(99, histogramInt.getSnapshot().getMax());
+        Assert.assertEquals(990, histogramLong.getSnapshot().getMax());
     }
 
     @Test
     public void testSnapshotMin() throws Exception {
-        Assert.assertEquals(0.0, histogramInt.getSnapshot().getMin(), 0);
-        Assert.assertEquals(0.0, histogramLong.getSnapshot().getMin(), 0);
+        Assert.assertEquals(0, histogramInt.getSnapshot().getMin());
+        Assert.assertEquals(0, histogramLong.getSnapshot().getMin());
     }
 
     @Test
     public void testSnapshotMean() throws Exception {
-        Assert.assertEquals(50.6, histogramInt.getSnapshot().getMean(), 0.1);
-        Assert.assertEquals(506.3, histogramLong.getSnapshot().getMean(), 0.1);
+        TestUtils.assertEqualsWithTolerance(50.6, histogramInt.getSnapshot().getMean());
+        TestUtils.assertEqualsWithTolerance(506.3, histogramLong.getSnapshot().getMean());
     }
 
     @Test
     public void testSnapshotMedian() throws Exception {
-        Assert.assertEquals(48, histogramInt.getSnapshot().getMedian(), 0);
-        Assert.assertEquals(480, histogramLong.getSnapshot().getMedian(), 0);
+        TestUtils.assertEqualsWithTolerance(48, histogramInt.getSnapshot().getMedian());
+        TestUtils.assertEqualsWithTolerance(480, histogramLong.getSnapshot().getMedian());
     }
 
     @Test
     public void testSnapshotStdDev() throws Exception {
-        Assert.assertEquals(29.4, histogramInt.getSnapshot().getStdDev(), 0.1);
-        Assert.assertEquals(294.3, histogramLong.getSnapshot().getStdDev(), 0.1);
+        TestUtils.assertEqualsWithTolerance(29.4, histogramInt.getSnapshot().getStdDev());
+        TestUtils.assertEqualsWithTolerance(294.3, histogramLong.getSnapshot().getStdDev());
     }
 
     @Test
     public void testSnapshotSize() throws Exception {
-        Assert.assertEquals(200.0, histogramInt.getSnapshot().size(), 0);
-        Assert.assertEquals(200.0, histogramLong.getSnapshot().size(), 0);
+        Assert.assertEquals(200, histogramInt.getSnapshot().size());
+        Assert.assertEquals(200, histogramLong.getSnapshot().size());
     }
+    
+
 }

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/TestUtils.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/TestUtils.java
@@ -1,0 +1,43 @@
+/*
+ **********************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICES file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+package org.eclipse.microprofile.metrics.tck;
+
+import org.junit.Assert;
+
+public class TestUtils {
+    
+    public static final double TOLERANCE = 0.025;
+    
+    // private constructor
+    private TestUtils() {
+    }
+    
+    /**
+     * Assert equals with a tolerance factor of {@link #TOLERANCE} times the expected value
+     * 
+     * @param expected expected value
+     * @param actual the actual value
+     */
+    public static void assertEqualsWithTolerance(double expected, double actual) {
+        Assert.assertEquals(expected, actual, expected * TOLERANCE);
+    }
+}

--- a/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MetricAppBean.java
+++ b/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MetricAppBean.java
@@ -64,7 +64,6 @@ public class MetricAppBean {
     private Histogram jellybeanHistogram;
 
     @Inject
-    // @RegistryType(type=MetricRegistry.Type.BASE)
     private MetricRegistry metrics;
 
     @Inject
@@ -106,8 +105,10 @@ public class MetricAppBean {
         Metadata metadata = new Metadata("metricTest.test1.histogram", MetricType.HISTOGRAM, MetricUnits.BYTES);
         Histogram histogram = metrics.histogram(metadata);
 
-        for (int i = 0; i < 1000; i++) {
+        // Go both ways to minimize error due to decay
+        for (int i = 0; i < 500; i++) {
             histogram.update(i);
+            histogram.update(999 - i);
         }
 
         Metadata metadata2 = new Metadata("metricTest.test1.histogram2", MetricType.HISTOGRAM,MetricUnits.NONE);

--- a/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MpMetricTest.java
+++ b/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MpMetricTest.java
@@ -28,6 +28,8 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.allOf;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertNotNull;
@@ -54,6 +56,7 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.hamcrest.Matcher;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
@@ -85,6 +88,8 @@ public class MpMetricTest {
     private static final String DEFAULT_PROTOCOL = "http";
     private static final String DEFAULT_HOST = "localhost";
     private static final int DEFAULT_PORT = 8080;
+
+    public static final double TOLERANCE = 0.025;
 
     @Inject
     private MetricAppBean metricAppBean;
@@ -442,14 +447,14 @@ public class MpMetricTest {
 
                 .body("'metricTest.test1.histogram'.count", equalTo(1000))
                 .body("'metricTest.test1.histogram'.max", equalTo(999))
-                .body("'metricTest.test1.histogram'.mean", equalTo((float) 499.5))
+                .body("'metricTest.test1.histogram'.mean", closeTo(499.5))
                 .body("'metricTest.test1.histogram'.min", equalTo(0))
-                .body("'metricTest.test1.histogram'.p50", equalTo((float) 499.0))
-                .body("'metricTest.test1.histogram'.p75", equalTo((float) 749))
-                .body("'metricTest.test1.histogram'.p95", equalTo((float) 949))
-                .body("'metricTest.test1.histogram'.p98", equalTo((float) 979))
-                .body("'metricTest.test1.histogram'.p99", equalTo((float) 989))
-                .body("'metricTest.test1.histogram'.p999", equalTo((float) 998))
+                .body("'metricTest.test1.histogram'.p50", closeTo(499.0))
+                .body("'metricTest.test1.histogram'.p75", closeTo(749))
+                .body("'metricTest.test1.histogram'.p95", closeTo(949))
+                .body("'metricTest.test1.histogram'.p98", closeTo(979))
+                .body("'metricTest.test1.histogram'.p99", closeTo(989))
+                .body("'metricTest.test1.histogram'.p999", closeTo(998))
                 .body("'metricTest.test1.histogram'", hasKey("stddev"))
 
                 .body("'metricTest.test1.meter'.count", equalTo(1))
@@ -756,6 +761,19 @@ public class MpMetricTest {
             .body(containsString("pm_counter_accent_"));
     }
 
+    /**
+     * Checks that the value is within tolerance of the expected value
+     * 
+     * Note: The JSON parser only returns float for earlier versions of restassured,
+     * so we need to return a float Matcher.
+     * @param operand
+     * @return
+     */
+    private Matcher<Float> closeTo (double operand) {
+        double delta = Math.abs(operand) * TOLERANCE;
+        return allOf(greaterThan((float) (operand - delta)), lessThan((float) (operand + delta)));
+    }
+    
     private Map<String, MiniMeta> getExpectedMetadataFromXmlFile(MetricRegistry.Type scope) {
       ClassLoader cl = this.getClass().getClassLoader();
       String fileName;


### PR DESCRIPTION
Modified Meter/Timer rate tests to be less implementation dependent. I've set the tolerance to a very generous +/- 2.5% which should cover slow running machines.

Fixes #225 - Histogram
Fixes #160 - Meter/Timer
Fixes #190 - Meter/Timer