### PR TITLE
Remove redundant public in the interface

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/metrics/Counter.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/Counter.java
@@ -30,26 +30,26 @@ public interface Counter extends Metric, Counting {
     /**
      * Increment the counter by one.
      */
-    public void inc();
+    void inc();
 
     /**
      * Increment the counter by {@code n}.
      *
      * @param n the amount by which the counter will be increased
      */
-    public void inc(long n);
+    void inc(long n);
 
     /**
      * Decrement the counter by one.
      */
-    public void dec();
+    void dec();
 
     /**
      * Decrement the counter by {@code n}.
      *
      * @param n the amount by which the counter will be decreased
      */
-    public void dec(long n);
+    void dec(long n);
 
     /**
      * Returns the counter's current value.
@@ -57,5 +57,5 @@ public interface Counter extends Metric, Counting {
      * @return the counter's current value
      */
     @Override
-    public long getCount();
+    long getCount();
 }

--- a/api/src/main/java/org/eclipse/microprofile/metrics/Histogram.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/Histogram.java
@@ -35,14 +35,14 @@ public interface Histogram extends Metric, Sampling, Counting {
      *
      * @param value the length of the value
      */
-    public void update(int value);
+    void update(int value);
 
     /**
      * Adds a recorded value.
      *
      * @param value the length of the value
      */
-    public void update(long value);
+    void update(long value);
 
     /**
      * Returns the number of values recorded.
@@ -50,8 +50,8 @@ public interface Histogram extends Metric, Sampling, Counting {
      * @return the number of values recorded
      */
     @Override
-    public long getCount();
+    long getCount();
 
     @Override
-    public Snapshot getSnapshot();
+    Snapshot getSnapshot();
 }

--- a/api/src/main/java/org/eclipse/microprofile/metrics/Meter.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/Meter.java
@@ -32,27 +32,27 @@ public interface Meter extends Metered {
     /**
      * Mark the occurrence of an event.
      */
-    public void mark();
+    void mark();
 
     /**
      * Mark the occurrence of a given number of events.
      *
      * @param n the number of events
      */
-    public void mark(long n);
+    void mark(long n);
 
     @Override
-    public long getCount();
+    long getCount();
 
     @Override
-    public double getFifteenMinuteRate();
+    double getFifteenMinuteRate();
 
     @Override
-    public double getFiveMinuteRate();
+    double getFiveMinuteRate();
 
     @Override
-    public double getMeanRate();
+    double getMeanRate();
 
     @Override
-    public double getOneMinuteRate();
+    double getOneMinuteRate();
 }

--- a/api/src/main/java/org/eclipse/microprofile/metrics/MetricFilter.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/MetricFilter.java
@@ -29,12 +29,7 @@ public interface MetricFilter {
     /**
      * Matches all metrics, regardless of type or name.
      */
-    MetricFilter ALL = new MetricFilter() {
-        @Override
-        public boolean matches(String name, Metric metric) {
-            return true;
-        }
-    };
+    MetricFilter ALL = (name, metric) -> true;
 
     /**
      * Returns {@code true} if the metric matches the filter; {@code false} otherwise.

--- a/api/src/main/java/org/eclipse/microprofile/metrics/Timer.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/Timer.java
@@ -39,18 +39,18 @@ public interface Timer extends Metered, Sampling {
      *
      * @see Timer#time()
      */
-    public interface Context extends Closeable {
+    interface Context extends Closeable {
 
         /**
          * Updates the timer with the difference between current and start time. Call to this method will
          * not reset the start time. Multiple calls result in multiple updates.
          * @return the elapsed time in nanoseconds
          */
-        public long stop();
+        long stop();
 
         /** Equivalent to calling {@link #stop()}. */
         @Override
-        public void close();
+        void close();
     }
     /**
      * Adds a recorded duration.
@@ -58,7 +58,7 @@ public interface Timer extends Metered, Sampling {
      * @param duration the length of the duration
      * @param unit     the scale unit of {@code duration}
      */
-    public void update(long duration, TimeUnit unit);
+    void update(long duration, TimeUnit unit);
 
     /**
      * Times and records the duration of event.
@@ -69,7 +69,7 @@ public interface Timer extends Metered, Sampling {
      * @return the value returned by {@code event}
      * @throws Exception if {@code event} throws an {@link Exception}
      */
-    public <T> T time(Callable<T> event) throws Exception;
+    <T> T time(Callable<T> event) throws Exception;
 
     /**
      * Times and records the duration of event.
@@ -77,7 +77,7 @@ public interface Timer extends Metered, Sampling {
      * @param event a {@link Runnable} whose {@link Runnable#run()} method implements a process
      *              whose duration should be timed
      */
-    public void time(Runnable event);
+    void time(Runnable event);
 
     /**
      * Returns a new {@link Context}.
@@ -85,23 +85,23 @@ public interface Timer extends Metered, Sampling {
      * @return a new {@link Context}
      * @see Context
      */
-    public Context time();
+    Context time();
 
     @Override
-    public long getCount();
+    long getCount();
 
     @Override
-    public double getFifteenMinuteRate();
+    double getFifteenMinuteRate();
 
     @Override
-    public double getFiveMinuteRate();
+    double getFiveMinuteRate();
 
     @Override
-    public double getMeanRate();
+    double getMeanRate();
 
     @Override
-    public double getOneMinuteRate();
+    double getOneMinuteRate();
 
     @Override
-    public Snapshot getSnapshot();
+    Snapshot getSnapshot();
 }


### PR DESCRIPTION
> * Every method declaration in the body of an interface is implicitly public (§6.6).
> * Every method declaration in the body of an interface is implicitly abstract, so its body is always represented by a semicolon, not a block.
> * It is permitted, but discouraged as a matter of style, to redundantly specify the public and/or abstract modifier for a method declared in an interface.
> 

https://docs.oracle.com/javase/specs/jls/se7/html/jls-9.html#jls-9.4