### PR TITLE
Skip unit-for-type checking. This needs more work.

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/metrics/MetadataBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/MetadataBuilder.java
@@ -190,19 +190,7 @@ public class MetadataBuilder {
         if (Objects.isNull(name)) {
             throw new IllegalStateException("Name is required");
         }
-        switch (type) {
-            case HISTOGRAM:
-            case GAUGE:
-            if(Objects.isNull(unit) || MetricUnits.NONE.equals(unit)) {
-                throw new IllegalStateException("A unit is required for this type of metric");
-            }
-            case TIMER:
-            case METERED:
-            case COUNTER:
-                if(Objects.nonNull(unit) || !MetricUnits.NONE.equals(unit)) {
-                    throw new IllegalStateException("A unit is not required for this type of metric");
-                }
-        }
+
         return new DefaultMetadata(name, displayName, description, type, unit, reusable, tags);
     }
 }


### PR DESCRIPTION
Signed-off-by: Heiko W. Rupp <hrupp@redhat.com>

This is an alternative approach to #249, as #249 is still a bit problematic ( see comments)
On top (and this is worse), the strict check will make a larger number of tests fail. See e.g. https://github.com/eclipse/microprofile-metrics/blob/master/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/GaugeMethodBean.java#L28 where a Gauge has a unit of `NONE`, which would trigger an IAE.
We need to sort this out and then also adapt tests.