### PR TITLE
Make DefaultMetadata public. Fixes #252

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/metrics/DefaultMetadata.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/DefaultMetadata.java
@@ -32,7 +32,7 @@ import java.util.stream.Collectors;
 /**
  * The default implementation of {@link Metadata}
  */
-class DefaultMetadata implements Metadata {
+public class DefaultMetadata implements Metadata {
 
     /**
      * Name of the metric.

--- a/api/src/main/java/org/eclipse/microprofile/metrics/DefaultMetadata.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/DefaultMetadata.java
@@ -98,7 +98,7 @@ public class DefaultMetadata implements Metadata {
      */
     private final Map<String, String> tags;
 
-    public DefaultMetadata(String name, String displayName, String description,
+    protected DefaultMetadata(String name, String displayName, String description,
                            MetricType type, String unit, boolean reusable,
                            Map<String, String> tags) {
         this.name = name;


### PR DESCRIPTION
Signed-off-by: Heiko W. Rupp <hrupp@redhat.com>

Making this public allows implementations to extend it.