### PR TITLE
Hit par count

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/metrics/DefaultMetadata.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/DefaultMetadata.java
@@ -174,4 +174,16 @@ class DefaultMetadata implements Metadata {
     public int hashCode() {
         return Objects.hashCode(name);
     }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("DefaultMetadata{");
+        sb.append("name='").append(name).append('\'');
+        sb.append(", type=").append(type);
+        sb.append(", unit='").append(unit).append('\'');
+        sb.append(", reusable=").append(reusable);
+        sb.append(", tags=").append(tags);
+        sb.append('}');
+        return sb.toString();
+    }
 }

--- a/api/src/main/java/org/eclipse/microprofile/metrics/HitCounter.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/HitCounter.java
@@ -1,0 +1,62 @@
+/*
+ * ********************************************************************
+ *  Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ *  See the NOTICES file(s) distributed with this work for additional
+ *  information regarding copyright ownership.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  You may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ * ********************************************************************
+ *
+ */
+package org.eclipse.microprofile.metrics;
+
+/**
+ * An incrementing and decrementing counter metric.
+ */
+public interface HitCounter extends Metric, Counting {
+
+    /**
+     * Increment the counter by one.
+     */
+    void inc();
+
+    /**
+     * Increment the counter by {@code n}.
+     *
+     * @param n the amount by which the counter will be increased
+     */
+    void inc(long n);
+
+    /**
+     * Decrement the counter by one.
+     */
+    void dec();
+
+    /**
+     * Decrement the counter by {@code n}.
+     *
+     * @param n the amount by which the counter will be decreased
+     */
+    void dec(long n);
+
+    /**
+     * Returns the counter's current value.
+     *
+     * @return the counter's current value
+     */
+    @Override
+    long getCount();
+}

--- a/api/src/main/java/org/eclipse/microprofile/metrics/MetricRegistry.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/MetricRegistry.java
@@ -120,7 +120,9 @@ public abstract class MetricRegistry {
      * @param <T>    the type of the metric
      * @return {@code metric}
      * @throws IllegalArgumentException if the name is already registered
+     * @deprecated Use {@link #register(Metadata, Metric)} instead.
      */
+    @Deprecated
     public abstract <T extends Metric> T register(String name, T metric) throws IllegalArgumentException;
 
     /**
@@ -463,6 +465,7 @@ public abstract class MetricRegistry {
 
     /**
      * Returns a map of all the metrics in the registry and their names.
+     * Note that there may be duplicate keys
      *
      * @return all the metrics in the registry
      */
@@ -470,6 +473,7 @@ public abstract class MetricRegistry {
 
     /**
      * Returns a map of all the metadata in the registry and their names.
+     * Note that there may be duplicate keys
      *
      * @return all the metadata in the registry
      */

--- a/api/src/main/java/org/eclipse/microprofile/metrics/MetricRegistry.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/MetricRegistry.java
@@ -29,12 +29,12 @@ import java.util.SortedSet;
 /**
  * The registry that stores metrics and their metadata.
  * The MetricRegistry provides methods to register, create and retrieve metrics and their respective metadata.
- * 
- * 
+ *
+ *
  * @see MetricFilter
  */
 public abstract class MetricRegistry {
-    
+
     /**
      * An enumeration representing the scopes of the MetricRegistry
      */
@@ -43,26 +43,26 @@ public abstract class MetricRegistry {
          * The Application (default) scoped MetricRegistry.
          * Any metric registered/accessed via CDI will use this MetricRegistry.
          */
-        APPLICATION("application"), 
-        
+        APPLICATION("application"),
+
         /**
          * The Base scoped MetricRegistry.
          * This MetricRegistry will contain required metrics specified in the MicroProfile Metrics specification.
          */
         BASE("base"),
-        
+
         /**
          * The Vendor scoped MetricRegistry.
          * This MetricRegistry will contain vendor provided metrics which may vary between different vendors.
          */
         VENDOR("vendor");
-    
+
         private String name;
-        
-        private Type(String name) {
+
+        Type(String name) {
             this.name = name;
         }
-        
+
         /**
          * Returns the name of the MetricRegistry scope.
          * @return the scope
@@ -98,7 +98,7 @@ public abstract class MetricRegistry {
             builder.append(part);
         }
     }
-    
+
     /**
      * Concatenates a class name and elements to form a dotted name, eliding any null values or
      * empty strings.
@@ -112,7 +112,7 @@ public abstract class MetricRegistry {
     }
 
     /**
-     * Given a {@link Metric}, registers it under the given name. 
+     * Given a {@link Metric}, registers it under the given name.
      * A {@link Metadata} object will be registered with the name and type.
      *
      * @param name   the name of the metric
@@ -122,7 +122,7 @@ public abstract class MetricRegistry {
      * @throws IllegalArgumentException if the name is already registered
      */
     public abstract <T extends Metric> T register(String name, T metric) throws IllegalArgumentException;
-    
+
     /**
      * Given a {@link Metric}, registers it under the given name along with the provided {@link Metadata}.
      *
@@ -138,7 +138,7 @@ public abstract class MetricRegistry {
     @Deprecated
     public abstract <T extends Metric> T register(String name, T metric, Metadata metadata) throws IllegalArgumentException;
 
-    
+
     /**
      * Given a {@link Metric}, registers it under the provided {@link Metadata}.
      *
@@ -147,39 +147,89 @@ public abstract class MetricRegistry {
      * @param <T>       the type of the metric
      * @return {@code metric}
      * @throws IllegalArgumentException if the name is already registered
-     * 
+     *
      * @since 1.1
      */
     public abstract <T extends Metric> T register(Metadata metadata, T metric) throws IllegalArgumentException;
 
 
     /**
-     * Return the {@link Counter} registered under this name; or create and register 
+     * Return the {@link Counter} registered under this name; or create and register
+     * a new {@link Counter} if none is registered.
+     * If a {@link Counter} was created, a {@link Metadata} object will be registered with the name and type.
+     *
+     * @param name the name of the metric
+     * @return a new or pre-existing {@link Counter}
+     * @deprecated Use #hitCounter() or #parallelCounter() instead
+     */
+    @Deprecated
+    public abstract Counter counter(String name);
+
+    /**
+     * Return the {@link Counter} registered under the {@link Metadata}'s name; or create and register
+     * a new {@link Counter} if none is registered.
+     * If a {@link Counter} was created, the provided {@link Metadata} object will be registered.
+     * <p>
+     * Note: The {@link Metadata} will not be updated if the metric is already registered.
+     * </p>
+     *
+     * @param metadata the name of the metric
+     * @return a new or pre-existing {@link Counter}
+     * @deprecated Use #hitCounter() or #parallelCounter() instead
+     */
+    @Deprecated
+    public abstract Counter counter(Metadata metadata);
+
+    /**
+     * Return the {@link Counter} registered under this name; or create and register
      * a new {@link Counter} if none is registered.
      * If a {@link Counter} was created, a {@link Metadata} object will be registered with the name and type.
      *
      * @param name the name of the metric
      * @return a new or pre-existing {@link Counter}
      */
-    public abstract Counter counter(String name);
-    
+    public abstract HitCounter hitCounter(String name);
+
     /**
-     * Return the {@link Counter} registered under the {@link Metadata}'s name; or create and register 
+     * Return the {@link Counter} registered under the {@link Metadata}'s name; or create and register
      * a new {@link Counter} if none is registered.
      * If a {@link Counter} was created, the provided {@link Metadata} object will be registered.
      * <p>
      * Note: The {@link Metadata} will not be updated if the metric is already registered.
      * </p>
-     * 
+     *
      * @param metadata the name of the metric
      * @return a new or pre-existing {@link Counter}
      */
-    public abstract Counter counter(Metadata metadata);
+    public abstract HitCounter hitCounter(Metadata metadata);
+
+    /**
+     * Return the {@link Counter} registered under this name; or create and register
+     * a new {@link Counter} if none is registered.
+     * If a {@link Counter} was created, a {@link Metadata} object will be registered with the name and type.
+     *
+     * @param name the name of the metric
+     * @return a new or pre-existing {@link Counter}
+     */
+    public abstract ParallelCounter parallelCounter(String name);
+
+    /**
+     * Return the {@link Counter} registered under the {@link Metadata}'s name; or create and register
+     * a new {@link Counter} if none is registered.
+     * If a {@link Counter} was created, the provided {@link Metadata} object will be registered.
+     * <p>
+     * Note: The {@link Metadata} will not be updated if the metric is already registered.
+     * </p>
+     *
+     * @param metadata the name of the metric
+     * @return a new or pre-existing {@link Counter}
+     */
+    public abstract ParallelCounter parallelCounter(Metadata metadata);
 
 
 
     /**
-     * Return the {@link Histogram} registered under this name; or create and register 
+     * Return the {@link Histogram} registered under this name; or create and register
      * a new {@link Histogram} if none is registered.
      * If a {@link Histogram} was created, a {@link Metadata}  object will be registered with the name and type.
      *
@@ -187,15 +237,15 @@ public abstract class MetricRegistry {
      * @return a new or pre-existing {@link Histogram}
      */
     public abstract Histogram histogram(String name);
-    
+
     /**
-     * Return the {@link Histogram} registered under the {@link Metadata}'s name; or create and register 
+     * Return the {@link Histogram} registered under the {@link Metadata}'s name; or create and register
      * a new {@link Histogram} if none is registered.
      * If a {@link Histogram} was created, the provided {@link Metadata} object will be registered.
      * <p>
      * Note: The {@link Metadata} will not be updated if the metric is already registered.
      * </p>
-     * 
+     *
      * @param metadata the name of the metric
      * @return a new or pre-existing {@link Histogram}
      */
@@ -211,15 +261,15 @@ public abstract class MetricRegistry {
      * @return a new or pre-existing {@link Meter}
      */
     public abstract Meter meter(String name);
-    
+
     /**
-     * Return the {@link Meter} registered under the {@link Metadata}'s name; or create and register 
+     * Return the {@link Meter} registered under the {@link Metadata}'s name; or create and register
      * a new {@link Meter} if none is registered.
      * If a {@link Meter} was created, the provided {@link Metadata} object will be registered.
      * <p>
      * Note: The {@link Metadata} will not be updated if the metric is already registered.
      * </p>
-     * 
+     *
      * @param metadata the name of the metric
      * @return a new or pre-existing {@link Meter}
      */
@@ -235,20 +285,20 @@ public abstract class MetricRegistry {
      * @return a new or pre-existing {@link Timer}
      */
     public abstract Timer timer(String name);
-    
+
     /**
-     * Return the {@link Timer} registered under the {@link Metadata}'s name; or create and register 
+     * Return the {@link Timer} registered under the {@link Metadata}'s name; or create and register
      * a new {@link Timer} if none is registered.
      * If a {@link Timer} was created, the provided {@link Metadata} object will be registered.
      * <p>
      * Note: The {@link Metadata} will not be updated if the metric is already registered.
      * </p>
-     * 
+     *
      * @param metadata the name of the metric
      * @return a new or pre-existing {@link Timer}
      */
     public abstract Timer timer(Metadata metadata);
- 
+
 
 
     /**
@@ -256,8 +306,26 @@ public abstract class MetricRegistry {
      *
      * @param name the name of the metric
      * @return whether or not the metric was removed
+     * @deprecated Use {@link #unregister(String, MetricType)} instead.
      */
+    @Deprecated
     public abstract boolean remove(String name);
+
+    /**
+     * Removes the metric with the given name and type.
+     *
+     * @param name the name of the metric
+     * @return whether or not the metric was removed
+     */
+    public abstract boolean unregister(String name, MetricType type);
+
+    /**
+     * Removes the metric with the given name and type inside the passed Metadata.
+     *
+     * @param metadata A metadata object with name and type
+     * @return whether or not the metric was removed
+     */
+    public abstract boolean unregister(Metadata metadata);
 
     /**
      * Removes all metrics which match the given filter.
@@ -272,7 +340,15 @@ public abstract class MetricRegistry {
      *
      * @return the names of all the metrics
      */
+    @Deprecated
     public abstract SortedSet<String> getNames();
+
+    /**
+     * Returns a set of the names of all the metrics for a type in the registry.
+     *
+     * @return the names of all the metrics
+     */
+    public abstract SortedSet<String> getNames(MetricType type);
 
     /**
      * Returns a map of all the gauges in the registry and their names.
@@ -294,7 +370,22 @@ public abstract class MetricRegistry {
      *
      * @return all the counters in the registry
      */
+    @Deprecated
     public abstract SortedMap<String, Counter> getCounters();
+
+    /**
+     * Returns a map of all the hit counters in the registry and their names.
+     *
+     * @return all the counters in the registry
+     */
+    public abstract SortedMap<String, HitCounter> getHitCounters();
+
+    /**
+     * Returns a map of all the parallel counters in the registry and their names.
+     *
+     * @return all the counters in the registry
+     */
+    public abstract SortedMap<String, ParallelCounter> getParallelCounters();
 
     /**
      * Returns a map of all the counters in the registry and their names which match the given
@@ -303,7 +394,26 @@ public abstract class MetricRegistry {
      * @param filter    the metric filter to match
      * @return all the counters in the registry
      */
+    @Deprecated
     public abstract SortedMap<String, Counter> getCounters(MetricFilter filter);
+
+    /**
+     * Returns a map of all the hit counters in the registry and their names which match the given
+     * filter.
+     *
+     * @param filter    the metric filter to match
+     * @return all the hit counters in the registry
+     */
+    public abstract SortedMap<String, HitCounter> getHitCounters(MetricFilter filter);
+
+    /**
+     * Returns a map of all the parallel counters in the registry and their names which match the given
+     * filter.
+     *
+     * @param filter    the metric filter to match
+     * @return all the parallel counters in the registry
+     */
+    public abstract SortedMap<String, ParallelCounter> getParallelCounters(MetricFilter filter);
 
     /**
      * Returns a map of all the histograms in the registry and their names.
@@ -364,5 +474,5 @@ public abstract class MetricRegistry {
      * @return all the metadata in the registry
      */
     public abstract Map<String, Metadata> getMetadata();
-    
+
 }

--- a/api/src/main/java/org/eclipse/microprofile/metrics/MetricType.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/MetricType.java
@@ -27,7 +27,7 @@ import java.util.EnumSet;
 
 /**
  * An enumeration representing the different types of metrics.
- * 
+ *
  * @author hrupp, Raymond Lam, Ouyang Zhou
  */
 public enum MetricType {
@@ -36,6 +36,10 @@ public enum MetricType {
      * An example could be the number of Transactions committed.
      */
     COUNTER("counter", Counter.class),
+
+    HIT_COUNTER("hit-counter", HitCounter.class),
+
+    PARALLEL_COUNTER("parallel-counter", ParallelCounter.class),
 
     /**
      * A Gauge has values that 'arbitrarily' goes up/down at each
@@ -55,11 +59,11 @@ public enum MetricType {
     HISTOGRAM("histogram", Histogram.class),
 
     /**
-     * A timer aggregates timing durations and provides duration 
+     * A timer aggregates timing durations and provides duration
      * statistics, plus throughput statistics
      */
     TIMER("timer", Timer.class),
-    
+
     /**
      * Invalid - Placeholder
      */

--- a/api/src/main/java/org/eclipse/microprofile/metrics/ParallelCounter.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/ParallelCounter.java
@@ -1,0 +1,62 @@
+/*
+ * ********************************************************************
+ *  Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ *  See the NOTICES file(s) distributed with this work for additional
+ *  information regarding copyright ownership.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  You may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ * ********************************************************************
+ *
+ */
+package org.eclipse.microprofile.metrics;
+
+/**
+ * An incrementing and decrementing counter metric.
+ */
+public interface ParallelCounter extends Metric, Counting {
+
+    /**
+     * Increment the counter by one.
+     */
+    void inc();
+
+    /**
+     * Increment the counter by {@code n}.
+     *
+     * @param n the amount by which the counter will be increased
+     */
+    void inc(long n);
+
+    /**
+     * Decrement the counter by one.
+     */
+    void dec();
+
+    /**
+     * Decrement the counter by {@code n}.
+     *
+     * @param n the amount by which the counter will be decreased
+     */
+    void dec(long n);
+
+    /**
+     * Returns the counter's current value.
+     *
+     * @return the counter's current value
+     */
+    @Override
+    long getCount();
+}

--- a/api/src/main/java/org/eclipse/microprofile/metrics/annotation/HitCounted.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/annotation/HitCounted.java
@@ -1,25 +1,26 @@
 /*
- **********************************************************************
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
- *               2012 Ryan W Tenney (ryan@10e.us)
+ * ********************************************************************
+ *  Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
- * See the NOTICES file(s) distributed with this work for additional
- * information regarding copyright ownership.
+ *  See the NOTICES file(s) distributed with this work for additional
+ *  information regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  You may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  *
- * SPDX-License-Identifier: Apache-2.0
- **********************************************************************/
+ *  SPDX-License-Identifier: Apache-2.0
+ * ********************************************************************
+ *
+ */
 package org.eclipse.microprofile.metrics.annotation;
 
 import java.lang.annotation.Documented;
@@ -28,10 +29,8 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
 import javax.enterprise.util.Nonbinding;
 import javax.interceptor.InterceptorBinding;
-
 import org.eclipse.microprofile.metrics.MetricUnits;
 
 /**
@@ -39,44 +38,40 @@ import org.eclipse.microprofile.metrics.MetricUnits;
  * The metric will be registered in the application MetricRegistry.
  *
  * <p>
- * Given a method annotated with {@literal @}Counted like this:
+ * Given a method annotated with {@literal @}HitCounted like this:
  * </p>
  * <pre><code>
- *     {@literal @}Counted(name = "fancyName")
+ *     {@literal @}HitCounted(name = "fancyName")
  *     public String fancyName(String name) {
  *         return "Sir Captain " + name;
  *     }
  * </code></pre>
  * A counter with the fully qualified class name + {@code fancyName} will be created and each time the
- * {@code #fancyName(String)} method is invoked, the counter will be marked.
+ * {@code #fancyName(String)} method is invoked, the counter will be increased by one.
  * Similarly, the same applies for a constructor annotated with counted.
- * (See {@link #monotonic()} for how the counter will be incremented).
  *
  * <p>
- * Given a class annotated with {@literal @}Counted like this:
+ * Given a class annotated with {@literal @}HitCounted like this:
  * </p>
  * <pre><code>
- *     {@literal @}Counted
+ *     {@literal @}HitCounted
  *     public class CounterBean {
  *         public void countMethod1() {}
  *         public void countMethod2() {}
  *     }
  * </code></pre>
  * A counter for the defining class will be created for each of the constructors/methods.
- * Each time the constructor/method is invoked, the respective counter will be marked.
- * (See {@link #monotonic()} for how the counter will be incremented)
+ * Each time the constructor/method is invoked, the respective counter will be increased by one.
  *
- * @deprecated Since MP-Metrics 2.0. Use @HitCounted and @ParallelCounted instead
- * @see HitCounted
+ * @since MP-Metrics 2.0.
  * @see ParallelCounted
  */
-@Deprecated
 @Inherited
 @Documented
 @InterceptorBinding
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.TYPE, ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.ANNOTATION_TYPE })
-public @interface Counted {
+public @interface HitCounted {
 
     /**
      * @return The name of the counter.
@@ -101,16 +96,6 @@ public @interface Counted {
     boolean absolute() default false;
 
     /**
-     * @return
-     * If {@code false} (default), the counter is decremented when the annotated
-     * method returns, counting current invocations of the annotated method.
-     * If {@code true}, the counter increases monotonically, counting total
-     * invocations of the annotated method.
-     */
-    @Nonbinding
-    boolean monotonic() default false;
-
-    /**
      * @return The display name of the counter.
      *
      * @see org.eclipse.microprofile.metrics.Metadata
@@ -131,7 +116,7 @@ public @interface Counted {
      * @return The unit of the counter. By default, the value is {@link MetricUnits#NONE}.
      *
      * @see org.eclipse.microprofile.metrics.Metadata
-     * @see org.eclipse.microprofile.metrics.MetricUnits
+     * @see MetricUnits
      */
     @Nonbinding
     String unit() default MetricUnits.NONE;

--- a/api/src/main/java/org/eclipse/microprofile/metrics/annotation/ParallelCounted.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/annotation/ParallelCounted.java
@@ -1,25 +1,26 @@
 /*
- **********************************************************************
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
- *               2012 Ryan W Tenney (ryan@10e.us)
+ * ********************************************************************
+ *  Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
- * See the NOTICES file(s) distributed with this work for additional
- * information regarding copyright ownership.
+ *  See the NOTICES file(s) distributed with this work for additional
+ *  information regarding copyright ownership.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * You may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  You may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  *
- * SPDX-License-Identifier: Apache-2.0
- **********************************************************************/
+ *  SPDX-License-Identifier: Apache-2.0
+ * ********************************************************************
+ *
+ */
 package org.eclipse.microprofile.metrics.annotation;
 
 import java.lang.annotation.Documented;
@@ -28,10 +29,8 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-
 import javax.enterprise.util.Nonbinding;
 import javax.interceptor.InterceptorBinding;
-
 import org.eclipse.microprofile.metrics.MetricUnits;
 
 /**
@@ -39,44 +38,43 @@ import org.eclipse.microprofile.metrics.MetricUnits;
  * The metric will be registered in the application MetricRegistry.
  *
  * <p>
- * Given a method annotated with {@literal @}Counted like this:
+ * Given a method annotated with {@literal @}ParallelCounted like this:
  * </p>
  * <pre><code>
- *     {@literal @}Counted(name = "fancyName")
+ *     {@literal @}ParallelCounted(name = "fancyName")
  *     public String fancyName(String name) {
  *         return "Sir Captain " + name;
  *     }
  * </code></pre>
  * A counter with the fully qualified class name + {@code fancyName} will be created and each time the
- * {@code #fancyName(String)} method is invoked, the counter will be marked.
+ * {@code #fancyName(String)} method is invoked, the counter will be increased by one and upon leaving
+ * the method the counter will be decreased by one, thus counting the parallel invocations of the
+ * {@code #fancyName(String)} method.
  * Similarly, the same applies for a constructor annotated with counted.
- * (See {@link #monotonic()} for how the counter will be incremented).
  *
  * <p>
- * Given a class annotated with {@literal @}Counted like this:
+ * Given a class annotated with {@literal @}ParallelCounted like this:
  * </p>
  * <pre><code>
- *     {@literal @}Counted
+ *     {@literal @}ParallelCounted
  *     public class CounterBean {
  *         public void countMethod1() {}
  *         public void countMethod2() {}
  *     }
  * </code></pre>
  * A counter for the defining class will be created for each of the constructors/methods.
- * Each time the constructor/method is invoked, the respective counter will be marked.
- * (See {@link #monotonic()} for how the counter will be incremented)
+ * Each time the constructor/method is invoked, the respective counter will be increased by one and upon leaving
+ * the method the counter will be decreased by one, thus counting the parallel invocations of the
  *
- * @deprecated Since MP-Metrics 2.0. Use @HitCounted and @ParallelCounted instead
+ * @since MP-Metrics 2.0.
  * @see HitCounted
- * @see ParallelCounted
  */
-@Deprecated
 @Inherited
 @Documented
 @InterceptorBinding
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.TYPE, ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.ANNOTATION_TYPE })
-public @interface Counted {
+public @interface ParallelCounted {
 
     /**
      * @return The name of the counter.
@@ -101,16 +99,6 @@ public @interface Counted {
     boolean absolute() default false;
 
     /**
-     * @return
-     * If {@code false} (default), the counter is decremented when the annotated
-     * method returns, counting current invocations of the annotated method.
-     * If {@code true}, the counter increases monotonically, counting total
-     * invocations of the annotated method.
-     */
-    @Nonbinding
-    boolean monotonic() default false;
-
-    /**
      * @return The display name of the counter.
      *
      * @see org.eclipse.microprofile.metrics.Metadata
@@ -131,7 +119,7 @@ public @interface Counted {
      * @return The unit of the counter. By default, the value is {@link MetricUnits#NONE}.
      *
      * @see org.eclipse.microprofile.metrics.Metadata
-     * @see org.eclipse.microprofile.metrics.MetricUnits
+     * @see MetricUnits
      */
     @Nonbinding
     String unit() default MetricUnits.NONE;

--- a/spec/src/main/asciidoc/app-programming-model.adoc
+++ b/spec/src/main/asciidoc/app-programming-model.adoc
@@ -107,7 +107,9 @@ The following Annotations exist, see below for common fields:
 |===
 |Annotation | Applies to |  Description | Default Unit
 
-|@Counted | M, C, T | Denotes a counter, which counts the invocations of the annotated object. | MetricUnits.NONE
+|@Counted | M, C, T | DEPRECATED Denotes a counter, which counts the invocations of the annotated object. | MetricUnits.NONE
+|@HitCounted | M, C, T | Denotes a counter, which counts the invocations of the annotated object. | MetricUnits.NONE
+|@ParallelCounted | M, C, T | Denotes a counter, which counts the invocations of the annotated object. | MetricUnits.NONE
 |@Gauge   | M | Denotes a gauge, which samples the value of the annotated object.  | _none_ Must be supplied by the user
 |@Metered | M, C, T  | Denotes a meter, which tracks the frequency of invocations of the annotated object. | MetricUnits.PER_SECOND
 |@Metric  | M, F, P | An annotation that contains the metadata information when requesting a metric to be injected or produced. This annotation can be used on fields
@@ -181,7 +183,7 @@ greenCount
 purple
 ----
 
-==== @Counted
+==== @Counted / @HitCounted / @ParallelCounted
 An annotation for marking a method, constructor, or type as a counter.
 
 The implementation must support the following annotation targets:
@@ -189,6 +191,9 @@ The implementation must support the following annotation targets:
   * `CONSTRUCTOR`
   * `METHOD`
   * `TYPE`
+
+WARNING: `@Counted` is deprecated, please use `@HitCounted` / `@ParallelCounted`.
+`@Counted` will be removed in MicroProfile-Metrics 3.0.
 
 In addition to the metadata fields, `@Counted` has the following field:
 
@@ -201,6 +206,9 @@ WARNING: The intuitive expectation is that each invocation of a method marked wi
 respective counter being increased by one. This is not the case with the default semantics of the `monotonic` flag.
  +
 If you want the counter being increased on each invocation you need to use `@Counted(monotonic = true)`.
++
+NOTE: `@HitCounted` is the equivalent of the deprecated `@Counted(monotonic = true)` and `@ParallelCounted` the equivalent
+of the deprecated `@Counted` or  `@Counted(monotonic = false)`
 
 The following lists the behavior for each annotation target.
 

--- a/spec/src/main/asciidoc/app-programming-model.adoc
+++ b/spec/src/main/asciidoc/app-programming-model.adoc
@@ -107,9 +107,9 @@ The following Annotations exist, see below for common fields:
 |===
 |Annotation | Applies to |  Description | Default Unit
 
-|@Counted | M, C, T | DEPRECATED Denotes a counter, which counts the invocations of the annotated object. | MetricUnits.NONE
-|@HitCounted | M, C, T | Denotes a counter, which counts the invocations of the annotated object. | MetricUnits.NONE
-|@ParallelCounted | M, C, T | Denotes a counter, which counts the invocations of the annotated object. | MetricUnits.NONE
+|@Counted | M, C, T | DEPRECATED Denotes a counter, which counts the invocations of the annotated object. This can be the number of parallel or absolute invocations. To be replaced by @HitCounted and @ParallelCounted | MetricUnits.NONE
+|@HitCounted | M, C, T | Denotes a counter, which counts the invocations of the annotated object. Each invocation increases the counter by 1.| MetricUnits.NONE
+|@ParallelCounted | M, C, T | Denotes a counter, which counts the parallel invocations of the annotated object. | MetricUnits.NONE
 |@Gauge   | M | Denotes a gauge, which samples the value of the annotated object.  | _none_ Must be supplied by the user
 |@Metered | M, C, T  | Denotes a meter, which tracks the frequency of invocations of the annotated object. | MetricUnits.PER_SECOND
 |@Metric  | M, F, P | An annotation that contains the metadata information when requesting a metric to be injected or produced. This annotation can be used on fields
@@ -193,7 +193,7 @@ The implementation must support the following annotation targets:
   * `TYPE`
 
 WARNING: `@Counted` is deprecated, please use `@HitCounted` / `@ParallelCounted`.
-`@Counted` will be removed in MicroProfile-Metrics 3.0.
+`@Counted` will be removed in a future release of MicroProfile-Metrics.
 
 In addition to the metadata fields, `@Counted` has the following field:
 

--- a/spec/src/main/asciidoc/architecture.adoc
+++ b/spec/src/main/asciidoc/architecture.adoc
@@ -182,10 +182,10 @@ to `true` and have multiple methods annotated as metric that have the same metho
 .Example of reused counters
 [source,java]
 ----
-    @HitCounted(name = "countMe", absolute = true, reusable = true)
+    @Counted(name = "countMe", absolute = true, reusable = true)
     public void countMeA() { }
 
-    @HitCounted(name = "countMe", absolute = true, reusable = true)
+    @Counted(name = "countMe", absolute = true, reusable = true)
     public void countMeB() { }
 ----
 
@@ -193,7 +193,6 @@ In the above examples both `countMeA()` and `countMeB()` will share a single Cou
 
 The implementation must throw an 'IllegalArgumentException' if a counter defined via `@HitCounted` is reused as `@ParallelCounted` or vice versa.
 
-TODO: is it allowed to mark a method/... both as @HitCounted and @ParallelCounted? Yes, but what about naming?
 
 [[rest-api]]
 === Exposing metrics via REST API

--- a/spec/src/main/asciidoc/architecture.adoc
+++ b/spec/src/main/asciidoc/architecture.adoc
@@ -182,14 +182,18 @@ to `true` and have multiple methods annotated as metric that have the same metho
 .Example of reused counters
 [source,java]
 ----
-    @Counted(name = "countMe", absolute = true, reusable = true)
+    @HitCounted(name = "countMe", absolute = true, reusable = true)
     public void countMeA() { }
 
-    @Counted(name = "countMe", absolute = true, reusable = true)
+    @HitCounted(name = "countMe", absolute = true, reusable = true)
     public void countMeB() { }
 ----
 
 In the above examples both `countMeA()` and `countMeB()` will share a single Counter with registered name `countMe` in application scope.
+
+The implementation must throw an 'IllegalArgumentException' if a counter defined via `@HitCounted` is reused as `@ParallelCounted` or vice versa.
+
+TODO: is it allowed to mark a method/... both as @HitCounted and @ParallelCounted? Yes, but what about naming?
 
 [[rest-api]]
 === Exposing metrics via REST API

--- a/spec/src/main/asciidoc/architecture.adoc
+++ b/spec/src/main/asciidoc/architecture.adoc
@@ -136,7 +136,7 @@ The Metadata:
 * displayName (optional): A human readable name of the metric for display purposes if the metric name is not
 human readable. This could e.g. be the case when the metric name is a uuid.
 * tags (optional): A list of `key=value` pairs, which are separated by comma. See also <<supplying_of_tags>>.
-* reusable (optional): If set to `true`, then it is allowed to register a metric multiple times under the same name.
+* reusable (optional): If set to `true`, then it is allowed to register a metric (of a type) multiple times under the same name.
 Note that all such instances must set `reusable` to `true`.
 Default is `false`.
 See <<reusing_of_metrics>> for more details.
@@ -162,9 +162,9 @@ Metrics can be added to or retrieved from the registry either using the `@Metric
 [[reusing_of_metrics]]
 ==== Reusing of Metrics
 
-By default it is not allowed to register more than one metric under a certain name in a scope. This is done
-to prevent hard to spot copy & paste errors, where for example all methods of a Jax-Rs class are marked with
-`@Timed(name="myApp", absolute=true)`.
+By default it is not allowed to register more than one metric under a certain name and type in a scope.
+This is done to prevent hard to spot copy & paste errors, where for example all methods of a Jax-Rs class
+are marked with `@Timed(name="myApp", absolute=true)`.
 
 If this behaviour is required, then it is possible to mark all such instances as _reusable_ by passing
 the respective flag via Metadata or field in the Annotation. Gauges are not reusable.
@@ -172,9 +172,6 @@ the respective flag via Metadata or field in the Annotation. Gauges are not reus
 The implementation must throw an 'IllegalArgumentException' during a metric registration call when the call would result
 in the reuse of a metric where that metric was either previously declared not reusable or where the registration call itself
 declares the metric to not be reusable.
-
-Only metrics of the same type can be reused under the same name.
-Trying to reuse a name for different types will result in an `IllegalArgumentException`.
 
 TIP: If you want to re-use a metric name, then you need to also explicitly set the `name` field OR set `absolute`
 to `true` and have multiple methods annotated as metric that have the same method name.
@@ -190,8 +187,6 @@ to `true` and have multiple methods annotated as metric that have the same metho
 ----
 
 In the above examples both `countMeA()` and `countMeB()` will share a single Counter with registered name `countMe` in application scope.
-
-The implementation must throw an 'IllegalArgumentException' if a counter defined via `@HitCounted` is reused as `@ParallelCounted` or vice versa.
 
 
 [[rest-api]]

--- a/spec/src/main/asciidoc/changelog.adoc
+++ b/spec/src/main/asciidoc/changelog.adoc
@@ -19,8 +19,13 @@
 
 === Major changes to previous versions
 
+* Since 2.0
+** Deprecate `@Counted` in favour of `@HitCounted` and `@ParallelCounted`
+
+
 * Since 1.1
 ** Removed unnecessary `@InterceptorBinding` annotation from `org.eclipse.microprofile.metrics.annotation.Metric`.
+
 
 * Since 1.0
 ** Improved TCK

--- a/spec/src/main/asciidoc/rest-endpoints.adoc
+++ b/spec/src/main/asciidoc/rest-endpoints.adoc
@@ -80,7 +80,7 @@ The value of the gauge must be equivalent to a call to the instance Gauge's `get
 }
 ----
 
-==== Counter JSON Format
+==== Counter / HitCounter / ParallelCounter JSON Format
 
 The value of the counter must be equivalent to a call to the instance Counter's  `getCount()`.
 
@@ -375,7 +375,7 @@ The value of the gauge must be the value of `getValue()` with appropriate naming
 application:cost_dollars 80
 ----
 
-==== Counter Prometheus Text Format
+==== Counter / HitCounter / ParallelCounter Prometheus Text Format
 
 The value of the counter must be the value of `getCount()`.
 
@@ -388,6 +388,28 @@ NOTE: Implementors must not convert the unit of Counters or append the unit suff
 # HELP application:visitors The number of unique visitors
 application:visitors 80
 ----
+
+===== HitCounter / ParallelCounter
+
+HitCounters and ParallelCounters get an additional label, that spefify their type
+
+.Example Prometheus text format for a HitCounter.
+[source, ruby]
+----
+# TYPE application:visitors counter
+# HELP application:visitors The number of unique visitors
+application:visitors{_ctype=hit_counter} 80
+----
+
+.Example Prometheus text format for a ParallelCounter.
+[source, ruby]
+----
+# TYPE application:visitors counter
+# HELP application:visitors The number of unique visitors
+application:visitors{_ctype=parallel_counter} 80
+----
+
+
 
 ==== Meter Prometheus Text Format
 

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/BothCountedMethodBean.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/BothCountedMethodBean.java
@@ -1,0 +1,41 @@
+/*
+ * ********************************************************************
+ *  Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ *  See the NOTICES file(s) distributed with this work for additional
+ *  information regarding copyright ownership.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  You may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ * ********************************************************************
+ *
+ */
+package io.astefanutti.metrics.cdi.se;
+
+import org.eclipse.microprofile.metrics.annotation.HitCounted;
+import org.eclipse.microprofile.metrics.annotation.ParallelCounted;
+
+public class BothCountedMethodBean<T> {
+
+    @ParallelCounted
+    @HitCounted
+    public void countedMethodOne() {
+    }
+
+    @ParallelCounted(absolute = true, name = "bla")
+    @HitCounted(absolute = true, name = "bla")
+    public void countedMethodTwo() {
+    }
+
+}

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CountedClassBean.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CountedClassBean.java
@@ -15,9 +15,9 @@
  */
 package io.astefanutti.metrics.cdi.se;
 
-import org.eclipse.microprofile.metrics.annotation.Counted;
+import org.eclipse.microprofile.metrics.annotation.ParallelCounted;
 
-@Counted(name = "countedClass")
+@ParallelCounted(name = "countedClass")
 public class CountedClassBean {
 
     public void countedMethodOne() {

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CountedClassBean.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CountedClassBean.java
@@ -15,9 +15,9 @@
  */
 package io.astefanutti.metrics.cdi.se;
 
-import org.eclipse.microprofile.metrics.annotation.ParallelCounted;
+import org.eclipse.microprofile.metrics.annotation.Counted;
 
-@ParallelCounted(name = "countedClass")
+@Counted(name = "countedClass")
 public class CountedClassBean {
 
     public void countedMethodOne() {

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CountedConstructorBean.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CountedConstructorBean.java
@@ -15,11 +15,11 @@
  */
 package io.astefanutti.metrics.cdi.se;
 
-import org.eclipse.microprofile.metrics.annotation.Counted;
+import org.eclipse.microprofile.metrics.annotation.HitCounted;
 
 public class CountedConstructorBean {
 
-    @Counted(name = "countedConstructor", monotonic = true)
+    @HitCounted(name = "countedConstructor")
     public CountedConstructorBean() {
     }
 }

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CountedConstructorBean.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CountedConstructorBean.java
@@ -15,11 +15,11 @@
  */
 package io.astefanutti.metrics.cdi.se;
 
-import org.eclipse.microprofile.metrics.annotation.HitCounted;
+import org.eclipse.microprofile.metrics.annotation.Counted;
 
 public class CountedConstructorBean {
 
-    @HitCounted(name = "countedConstructor")
+    @Counted(name = "countedConstructor", monotonic = true)
     public CountedConstructorBean() {
     }
 }

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CountedMethodBean.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CountedMethodBean.java
@@ -15,17 +15,16 @@
  */
 package io.astefanutti.metrics.cdi.se;
 
-import org.eclipse.microprofile.metrics.annotation.Counted;
-
 import java.util.concurrent.Callable;
+import org.eclipse.microprofile.metrics.annotation.ParallelCounted;
 
 public class CountedMethodBean<T> {
 
-    @Counted(name = "countedMethod", absolute = true)
+    @ParallelCounted(name = "countedMethod", absolute = true)
     public T countedMethod(Callable<T> callable) {
         try {
             return callable.call();
-        } 
+        }
         catch (Exception cause) {
             throw new RuntimeException(cause);
         }

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CountedMethodBean.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CountedMethodBean.java
@@ -15,12 +15,13 @@
  */
 package io.astefanutti.metrics.cdi.se;
 
+import org.eclipse.microprofile.metrics.annotation.Counted;
+
 import java.util.concurrent.Callable;
-import org.eclipse.microprofile.metrics.annotation.ParallelCounted;
 
 public class CountedMethodBean<T> {
 
-    @ParallelCounted(name = "countedMethod", absolute = true)
+    @Counted(name = "countedMethod", absolute = true)
     public T countedMethod(Callable<T> callable) {
         try {
             return callable.call();

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CountedMethodBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CountedMethodBeanTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.concurrent.Callable;
@@ -33,6 +34,7 @@ import javax.inject.Inject;
 
 import org.eclipse.microprofile.metrics.Counter;
 import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.MetricType;
 import org.eclipse.microprofile.metrics.annotation.Metric;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -146,13 +148,13 @@ public class CountedMethodBeanTest {
         Counter counter = registry.getCounters().get(COUNTER_NAME);
 
         // Remove the counter from metrics registry
-        registry.remove(COUNTER_NAME);
+        assertTrue(registry.unregister(COUNTER_NAME, MetricType.COUNTER));
 
         try {
             // Call the counted method and assert an exception is thrown
             bean.countedMethod(new Callable<Long>() {
                 @Override
-                public Long call() throws Exception {
+                public Long call() {
                     return null;
                 }
             });

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/DefaultNameMetricMethodBean.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/DefaultNameMetricMethodBean.java
@@ -15,17 +15,17 @@
  */
 package io.astefanutti.metrics.cdi.se;
 
-import org.eclipse.microprofile.metrics.annotation.Counted;
 import org.eclipse.microprofile.metrics.annotation.Metered;
+import org.eclipse.microprofile.metrics.annotation.ParallelCounted;
 import org.eclipse.microprofile.metrics.annotation.Timed;
 
 public class DefaultNameMetricMethodBean {
 
-    @Counted
+    @ParallelCounted
     public void defaultNameCountedMethod() {
     }
 
-    @Counted(absolute = true)
+    @ParallelCounted(absolute = true)
     public void absoluteDefaultNameCountedMethod() {
     }
 

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/DefaultNameMetricMethodBean.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/DefaultNameMetricMethodBean.java
@@ -15,17 +15,27 @@
  */
 package io.astefanutti.metrics.cdi.se;
 
+import org.eclipse.microprofile.metrics.annotation.Counted;
+import org.eclipse.microprofile.metrics.annotation.HitCounted;
 import org.eclipse.microprofile.metrics.annotation.Metered;
 import org.eclipse.microprofile.metrics.annotation.ParallelCounted;
 import org.eclipse.microprofile.metrics.annotation.Timed;
 
 public class DefaultNameMetricMethodBean {
 
-    @ParallelCounted
+    @Counted
     public void defaultNameCountedMethod() {
     }
 
-    @ParallelCounted(absolute = true)
+    @ParallelCounted
+    public void defaultNamePCountedMethod() {
+    }
+
+    @HitCounted
+    public void defaultNameHCountedMethod() {
+    }
+
+    @Counted(absolute = true)
     public void absoluteDefaultNameCountedMethod() {
     }
 

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/DefaultNameMetricMethodBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/DefaultNameMetricMethodBeanTest.java
@@ -37,7 +37,8 @@ import io.astefanutti.metrics.cdi.se.util.MetricsUtil;
 @RunWith(Arquillian.class)
 public class DefaultNameMetricMethodBeanTest {
 
-    private final static String[] METRIC_NAMES = { "defaultNameCountedMethod", "defaultNameMeteredMethod", "defaultNameTimedMethod" };
+    private final static String[] METRIC_NAMES = { "defaultNameCountedMethod", "defaultNamePCountedMethod",
+        "defaultNameHCountedMethod", "defaultNameMeteredMethod", "defaultNameTimedMethod" };
 
     private final static String[] ABSOLUTE_METRIC_NAMES = { "absoluteDefaultNameCountedMethod", "absoluteDefaultNameMeteredMethod",
             "absoluteDefaultNameTimedMethod" };

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/HitCountedClassBean.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/HitCountedClassBean.java
@@ -1,0 +1,45 @@
+/*
+ * ********************************************************************
+ *  Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ *  See the NOTICES file(s) distributed with this work for additional
+ *  information regarding copyright ownership.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  You may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ * ********************************************************************
+ *
+ */
+package io.astefanutti.metrics.cdi.se;
+
+import org.eclipse.microprofile.metrics.annotation.HitCounted;
+
+@HitCounted(name = "hitCountedClass")
+public class HitCountedClassBean {
+
+    public void countedMethodOne() {
+    }
+
+    public void countedMethodTwo() {
+    }
+
+    protected void countedMethodProtected() {
+    }
+
+    void countedMethodPackagedPrivate() {
+    }
+
+    private void countedMethodPrivate() {
+    }
+}

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/HitCountedClassBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/HitCountedClassBeanTest.java
@@ -93,23 +93,27 @@ public class HitCountedClassBeanTest {
     @InSequence(1)
     public void countedMethodsNotCalledYet() {
 
-       assertThat("Counters are not registered correctly", registry.getCounters().keySet(), is(equalTo(COUNTER_NAMES)));
+       assertThat("Counters are not registered correctly", registry.getHitCounters().keySet(), is(equalTo
+                                                                                                    (COUNTER_NAMES)));
 
-        assertThat("Constructor hit counter count is incorrect", registry.getCounters().get(CONSTRUCTOR_COUNTER_NAME)
+        assertThat("Constructor hit counter count is incorrect", registry.getHitCounters().get(CONSTRUCTOR_COUNTER_NAME)
                        .getCount(),
                 is(equalTo(CONSTRUCTOR_COUNT.incrementAndGet())));
 
         // Make sure that the counters haven't been incremented
-        assertThat("HitCounter counts are incorrect", registry.getCounters(METHOD_COUNTERS).values(), everyItem(Matchers.hasProperty
+        assertThat("HitCounter counts are incorrect", registry.getHitCounters(METHOD_COUNTERS).values(), everyItem
+            (Matchers.hasProperty
             ("count", equalTo(0L))));
     }
 
     @Test
     @InSequence(2)
     public void callCountedMethodsOnce() {
-        assertThat("Counters are not registered correctly", registry.getCounters().keySet(), is(equalTo(COUNTER_NAMES)));
+        assertThat("Counters are not registered correctly", registry.getHitCounters().keySet(), is(equalTo
+                                                                                                     (COUNTER_NAMES)));
 
-        assertThat("Constructor timer count is incorrect", registry.getCounters().get(CONSTRUCTOR_COUNTER_NAME).getCount(),
+        assertThat("Constructor timer count is incorrect", registry.getHitCounters().get(CONSTRUCTOR_COUNTER_NAME)
+                       .getCount(),
                 is(equalTo(CONSTRUCTOR_COUNT.incrementAndGet())));
 
         // Call the counted methods and assert they've been incremented
@@ -120,7 +124,7 @@ public class HitCountedClassBeanTest {
         bean.countedMethodPackagedPrivate();
 
         // Make sure that the counters have been incremented
-        assertThat("Method counter counts are incorrect", registry.getCounters(METHOD_COUNTERS).values(),
+        assertThat("Method counter counts are incorrect", registry.getHitCounters(METHOD_COUNTERS).values(),
                 everyItem(Matchers.hasProperty("count", equalTo(1L))));
     }
 }

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/HitCountedClassBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/HitCountedClassBeanTest.java
@@ -1,17 +1,25 @@
-/**
- * Copyright © 2013 Antonin Stefanutti (antonin.stefanutti@gmail.com)
+/*
+ * ********************************************************************
+ *  Copyright (c) 2018 Contributors to the Eclipse Foundation
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *  See the NOTICES file(s) distributed with this work for additional
+ *  information regarding copyright ownership.
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  You may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ * ********************************************************************
+ *
  */
 package io.astefanutti.metrics.cdi.se;
 
@@ -20,11 +28,10 @@ import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
+import io.astefanutti.metrics.cdi.se.util.MetricsUtil;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
-
 import javax.inject.Inject;
-
 import org.eclipse.microprofile.metrics.Counter;
 import org.eclipse.microprofile.metrics.Metric;
 import org.eclipse.microprofile.metrics.MetricFilter;
@@ -40,23 +47,24 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import io.astefanutti.metrics.cdi.se.util.MetricsUtil;
-
 @RunWith(Arquillian.class)
-public class MonotonicCountedClassBeanTest {
+public class HitCountedClassBeanTest {
 
-    private static final String CONSTRUCTOR_NAME = "MonotonicCountedClassBean";
+    private static final String CONSTRUCTOR_NAME = "HitCountedClassBean";
 
-    private static final String CONSTRUCTOR_COUNTER_NAME = MetricsUtil.absoluteMetricName(MonotonicCountedClassBean.class, "monotonicCountedClass",
+    private static final String CONSTRUCTOR_COUNTER_NAME = MetricsUtil.absoluteMetricName(HitCountedClassBean.class,
+                                                                                          "hitCountedClass",
             CONSTRUCTOR_NAME);
 
     private static final String[] METHOD_NAMES = { "countedMethodOne", "countedMethodTwo", "countedMethodProtected", "countedMethodPackagedPrivate" };
 
-    private static final Set<String> METHOD_COUNTER_NAMES = MetricsUtil.absoluteMetricNames(MonotonicCountedClassBean.class, "monotonicCountedClass",
+    private static final Set<String> METHOD_COUNTER_NAMES = MetricsUtil.absoluteMetricNames(HitCountedClassBean.class,
+                                                                                            "hitCountedClass",
             METHOD_NAMES);
-
-    private static final Set<String> COUNTER_NAMES = MetricsUtil.absoluteMetricNames(MonotonicCountedClassBean.class, "monotonicCountedClass",
-            METHOD_NAMES, CONSTRUCTOR_NAME);
+    private static final Set<String> COUNTER_NAMES = MetricsUtil.absoluteMetricNames(HitCountedClassBean.class,
+                                                                                     "hitCountedClass",
+                                                                                     METHOD_NAMES,
+                                                                                     CONSTRUCTOR_NAME);
 
     private static final MetricFilter METHOD_COUNTERS = new MetricFilter() {
         @Override
@@ -71,7 +79,7 @@ public class MonotonicCountedClassBeanTest {
     static Archive<?> createTestArchive() {
         return ShrinkWrap.create(JavaArchive.class)
                 // Test bean
-                .addClasses(MonotonicCountedClassBean.class, MetricsUtil.class)
+                .addClasses(HitCountedClassBean.class, MetricsUtil.class)
                 // Bean archive deployment descriptor
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
     }
@@ -80,19 +88,21 @@ public class MonotonicCountedClassBeanTest {
     private MetricRegistry registry;
 
     @Inject
-    private MonotonicCountedClassBean bean;
+    private HitCountedClassBean bean;
 
     @Test
     @InSequence(1)
     public void countedMethodsNotCalledYet() {
-        assertThat("Counters are not registered correctly", registry.getCounters().keySet(), is(equalTo(COUNTER_NAMES)));
 
-        assertThat("Constructor timer count is incorrect", registry.getCounters().get(CONSTRUCTOR_COUNTER_NAME).getCount(),
+       assertThat("Counters are not registered correctly", registry.getCounters().keySet(), is(equalTo(COUNTER_NAMES)));
+
+        assertThat("Constructor hit counter count is incorrect", registry.getCounters().get(CONSTRUCTOR_COUNTER_NAME)
+                       .getCount(),
                 is(equalTo(CONSTRUCTOR_COUNT.incrementAndGet())));
 
         // Make sure that the counters haven't been incremented
-        assertThat("Method counter counts are incorrect", registry.getCounters(METHOD_COUNTERS).values(),
-                everyItem(Matchers.hasProperty("count", equalTo(0L))));
+        assertThat("HitCounter counts are incorrect", registry.getCounters(METHOD_COUNTERS).values(), everyItem(Matchers.hasProperty
+            ("count", equalTo(0L))));
     }
 
     @Test

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/HitCountedClassBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/HitCountedClassBeanTest.java
@@ -32,7 +32,6 @@ import io.astefanutti.metrics.cdi.se.util.MetricsUtil;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.inject.Inject;
-import org.eclipse.microprofile.metrics.Counter;
 import org.eclipse.microprofile.metrics.Metric;
 import org.eclipse.microprofile.metrics.MetricFilter;
 import org.eclipse.microprofile.metrics.MetricRegistry;

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MeteredMethodBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MeteredMethodBeanTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.concurrent.atomic.AtomicLong;
@@ -28,6 +29,7 @@ import javax.inject.Inject;
 
 import org.eclipse.microprofile.metrics.Meter;
 import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.MetricType;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
@@ -90,7 +92,7 @@ public class MeteredMethodBeanTest {
         Meter meter = registry.getMeters().get(METER_NAME);
 
         // Remove the meter from metrics registry
-        registry.remove(METER_NAME);
+        assertTrue(registry.unregister(METER_NAME, MetricType.METERED));
 
         try {
             // Call the metered method and assert an exception is thrown

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MonotonicCountedClassBean.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MonotonicCountedClassBean.java
@@ -15,9 +15,9 @@
  */
 package io.astefanutti.metrics.cdi.se;
 
-import org.eclipse.microprofile.metrics.annotation.HitCounted;
+import org.eclipse.microprofile.metrics.annotation.Counted;
 
-@HitCounted(name = "monotonicCountedClass")
+@Counted(name = "monotonicCountedClass", monotonic = true)
 public class MonotonicCountedClassBean {
 
     public void countedMethodOne() {

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MonotonicCountedClassBean.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MonotonicCountedClassBean.java
@@ -15,9 +15,9 @@
  */
 package io.astefanutti.metrics.cdi.se;
 
-import org.eclipse.microprofile.metrics.annotation.Counted;
+import org.eclipse.microprofile.metrics.annotation.HitCounted;
 
-@Counted(name = "monotonicCountedClass", monotonic = true)
+@HitCounted(name = "monotonicCountedClass")
 public class MonotonicCountedClassBean {
 
     public void countedMethodOne() {

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MonotonicCountedClassBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MonotonicCountedClassBeanTest.java
@@ -25,7 +25,6 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import javax.inject.Inject;
 
-import org.eclipse.microprofile.metrics.Counter;
 import org.eclipse.microprofile.metrics.Metric;
 import org.eclipse.microprofile.metrics.MetricFilter;
 import org.eclipse.microprofile.metrics.MetricRegistry;

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MonotonicCountedMethodBean.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MonotonicCountedMethodBean.java
@@ -18,11 +18,10 @@ package io.astefanutti.metrics.cdi.se;
 import org.eclipse.microprofile.metrics.annotation.Counted;
 
 import java.util.concurrent.Callable;
-import org.eclipse.microprofile.metrics.annotation.HitCounted;
 
 public class MonotonicCountedMethodBean<T> {
 
-    @HitCounted(name = "monotonicCountedMethod", absolute = true)
+    @Counted(name = "monotonicCountedMethod", absolute = true, monotonic = true)
     public T monotonicCountedMethod(Callable<T> callable) {
         try {
             return callable.call();

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MonotonicCountedMethodBean.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MonotonicCountedMethodBean.java
@@ -18,10 +18,11 @@ package io.astefanutti.metrics.cdi.se;
 import org.eclipse.microprofile.metrics.annotation.Counted;
 
 import java.util.concurrent.Callable;
+import org.eclipse.microprofile.metrics.annotation.HitCounted;
 
 public class MonotonicCountedMethodBean<T> {
 
-    @Counted(name = "monotonicCountedMethod", absolute = true, monotonic = true)
+    @HitCounted(name = "monotonicCountedMethod", absolute = true)
     public T monotonicCountedMethod(Callable<T> callable) {
         try {
             return callable.call();

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MonotonicCountedMethodBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MonotonicCountedMethodBeanTest.java
@@ -32,6 +32,7 @@ import javax.inject.Inject;
 
 import org.eclipse.microprofile.metrics.Counter;
 import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.MetricType;
 import org.eclipse.microprofile.metrics.annotation.Metric;
 import org.hamcrest.Matchers;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -146,19 +147,19 @@ public class MonotonicCountedMethodBeanTest {
         Counter counter = registry.getCounters().get(COUNTER_NAME);
 
         // Remove the counter from metrics registry
-        registry.remove(COUNTER_NAME);
+        registry.unregister(COUNTER_NAME, MetricType.COUNTER);
 
         try {
             // Call the counted method and assert an exception is thrown
             bean.monotonicCountedMethod(new Callable<Long>() {
                 @Override
-                public Long call() throws Exception {
+                public Long call() {
                     return null;
                 }
             });
         }
         catch (Exception cause) {
-            assertThat(cause, is(Matchers.<Exception>instanceOf(IllegalStateException.class)));
+            assertThat(cause, is(Matchers.instanceOf(IllegalStateException.class)));
             assertThat(cause.getMessage(), is(equalTo("No counter with name [" + COUNTER_NAME + "] found in registry [" + registry + "]")));
             // Make sure that the counter hasn't been called
             assertThat("Counter count is incorrect", counter.getCount(), is(equalTo(COUNTER_COUNT.get())));

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MultipleMetricsConstructorBean.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MultipleMetricsConstructorBean.java
@@ -15,7 +15,6 @@
  */
 package io.astefanutti.metrics.cdi.se;
 
-import org.eclipse.microprofile.metrics.annotation.Counted;
 import org.eclipse.microprofile.metrics.annotation.HitCounted;
 import org.eclipse.microprofile.metrics.annotation.Metered;
 import org.eclipse.microprofile.metrics.annotation.Timed;

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MultipleMetricsConstructorBean.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MultipleMetricsConstructorBean.java
@@ -17,10 +17,12 @@ package io.astefanutti.metrics.cdi.se;
 
 import org.eclipse.microprofile.metrics.annotation.HitCounted;
 import org.eclipse.microprofile.metrics.annotation.Metered;
+import org.eclipse.microprofile.metrics.annotation.ParallelCounted;
 import org.eclipse.microprofile.metrics.annotation.Timed;
 
 public class MultipleMetricsConstructorBean {
 
+    @ParallelCounted(name = "counter")
     @HitCounted(name = "counter")
     @Metered(name = "meter")
     @Timed(name = "timer")

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MultipleMetricsConstructorBean.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MultipleMetricsConstructorBean.java
@@ -16,12 +16,13 @@
 package io.astefanutti.metrics.cdi.se;
 
 import org.eclipse.microprofile.metrics.annotation.Counted;
+import org.eclipse.microprofile.metrics.annotation.HitCounted;
 import org.eclipse.microprofile.metrics.annotation.Metered;
 import org.eclipse.microprofile.metrics.annotation.Timed;
 
 public class MultipleMetricsConstructorBean {
 
-    @Counted(name = "counter", monotonic = true)
+    @HitCounted(name = "counter")
     @Metered(name = "meter")
     @Timed(name = "timer")
     public MultipleMetricsConstructorBean() {

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MultipleMetricsConstructorBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MultipleMetricsConstructorBeanTest.java
@@ -73,7 +73,8 @@ public class MultipleMetricsConstructorBeanTest {
         }
 
         // Make sure that the metrics have been called
-        assertThat("Counter count is incorrect", registry.getCounters().get(absoluteMetricName("counter")).getCount(), is(equalTo(count)));
+        assertThat("HitCounter count is incorrect", registry.getHitCounters().get(absoluteMetricName("counter")).getCount(), is(equalTo(count)));
+        assertThat("ParCounter count is incorrect", registry.getParallelCounters().get(absoluteMetricName("counter")).getCount(), is(0L));
         assertThat("Meter count is incorrect", registry.getMeters().get(absoluteMetricName("meter")).getCount(), is(equalTo(count)));
         assertThat("Timer count is incorrect", registry.getTimers().get(absoluteMetricName("timer")).getCount(), is(equalTo(count)));
     }

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MultipleMetricsMethodBean.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MultipleMetricsMethodBean.java
@@ -15,17 +15,18 @@
  */
 package io.astefanutti.metrics.cdi.se;
 
+import javax.enterprise.context.ApplicationScoped;
 import org.eclipse.microprofile.metrics.MetricUnits;
+import org.eclipse.microprofile.metrics.annotation.Counted;
 import org.eclipse.microprofile.metrics.annotation.Gauge;
 import org.eclipse.microprofile.metrics.annotation.HitCounted;
 import org.eclipse.microprofile.metrics.annotation.Metered;
 import org.eclipse.microprofile.metrics.annotation.Timed;
 
-import javax.enterprise.context.ApplicationScoped;
-
 @ApplicationScoped
 public class MultipleMetricsMethodBean {
 
+    @Counted(name = "counter", monotonic = true)
     @HitCounted(name = "counter")
     @Gauge(name = "gauge", unit=MetricUnits.NONE)
     @Metered(name = "meter")

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MultipleMetricsMethodBean.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MultipleMetricsMethodBean.java
@@ -18,6 +18,7 @@ package io.astefanutti.metrics.cdi.se;
 import org.eclipse.microprofile.metrics.MetricUnits;
 import org.eclipse.microprofile.metrics.annotation.Counted;
 import org.eclipse.microprofile.metrics.annotation.Gauge;
+import org.eclipse.microprofile.metrics.annotation.HitCounted;
 import org.eclipse.microprofile.metrics.annotation.Metered;
 import org.eclipse.microprofile.metrics.annotation.Timed;
 
@@ -26,7 +27,7 @@ import javax.enterprise.context.ApplicationScoped;
 @ApplicationScoped
 public class MultipleMetricsMethodBean {
 
-    @Counted(name = "counter", monotonic = true)
+    @HitCounted(name = "counter")
     @Gauge(name = "gauge", unit=MetricUnits.NONE)
     @Metered(name = "meter")
     @Timed(name = "timer")

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MultipleMetricsMethodBean.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MultipleMetricsMethodBean.java
@@ -16,7 +16,6 @@
 package io.astefanutti.metrics.cdi.se;
 
 import org.eclipse.microprofile.metrics.MetricUnits;
-import org.eclipse.microprofile.metrics.annotation.Counted;
 import org.eclipse.microprofile.metrics.annotation.Gauge;
 import org.eclipse.microprofile.metrics.annotation.HitCounted;
 import org.eclipse.microprofile.metrics.annotation.Metered;

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MultipleMetricsMethodBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MultipleMetricsMethodBeanTest.java
@@ -90,6 +90,7 @@ public class MultipleMetricsMethodBeanTest {
 
         // Make sure that the metrics have been called
         assertThat("Counter count is incorrect", registry.getCounters().get(absoluteMetricName("counter")).getCount(), is(equalTo(1L)));
+        assertThat("HitCounter count is incorrect", registry.getHitCounters().get(absoluteMetricName("counter")).getCount(), is(equalTo(1L)));
         assertThat("Meter count is incorrect", registry.getMeters().get(absoluteMetricName("meter")).getCount(), is(equalTo(1L)));
         assertThat("Timer count is incorrect", registry.getTimers().get(absoluteMetricName("timer")).getCount(), is(equalTo(1L)));
         // Let's call the gauge at the end as Weld is intercepting the gauge

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/ParallelCountedClassBean.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/ParallelCountedClassBean.java
@@ -1,0 +1,45 @@
+/*
+ * ********************************************************************
+ *  Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ *  See the NOTICES file(s) distributed with this work for additional
+ *  information regarding copyright ownership.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  You may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ * ********************************************************************
+ *
+ */
+package io.astefanutti.metrics.cdi.se;
+
+import org.eclipse.microprofile.metrics.annotation.ParallelCounted;
+
+@ParallelCounted(name = "countedClass")
+public class ParallelCountedClassBean {
+
+    public void countedMethodOne() {
+    }
+
+    public void countedMethodTwo() {
+    }
+
+    protected void countedMethodProtected() {
+    }
+
+    void countedMethodPackagedPrivate() {
+    }
+
+    private void countedMethodPrivate() {
+    }
+}

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/ParallelCountedClassBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/ParallelCountedClassBeanTest.java
@@ -1,0 +1,101 @@
+/*
+ * ********************************************************************
+ *  Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ *  See the NOTICES file(s) distributed with this work for additional
+ *  information regarding copyright ownership.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  You may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ * ********************************************************************
+ *
+ */
+package io.astefanutti.metrics.cdi.se;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import io.astefanutti.metrics.cdi.se.util.MetricsUtil;
+import java.util.Set;
+import javax.inject.Inject;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.hamcrest.Matchers;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class ParallelCountedClassBeanTest {
+
+    private static final String CONSTRUCTOR_NAME = "ParallelCountedClassBean";
+
+    private static final String[] METHOD_NAMES = { "countedMethodOne", "countedMethodTwo", "countedMethodProtected", "countedMethodPackagedPrivate" };
+
+    private static final Set<String> COUNTER_NAMES = MetricsUtil.absoluteMetricNames(ParallelCountedClassBean.class,
+                                                                                     "countedClass",
+                                                                                     METHOD_NAMES,
+                                                                                     CONSTRUCTOR_NAME);
+
+    @Deployment
+    static Archive<?> createTestArchive() {
+        return ShrinkWrap.create(JavaArchive.class)
+                // Test bean
+                .addClasses(ParallelCountedClassBean.class, MetricsUtil.class)
+                // Bean archive deployment descriptor
+                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Inject
+    private MetricRegistry registry;
+
+    @Inject
+    private ParallelCountedClassBean bean;
+
+    @Test
+    @InSequence(1)
+    public void countedMethodsNotCalledYet() {
+
+        for (String s: registry.getCounters().keySet()) {
+            System.err.println("|> " + s);
+        }
+
+       assertThat("Counters are not registered correctly", registry.getCounters().keySet(), is(equalTo(COUNTER_NAMES)));
+        // Make sure that the counters haven't been incremented
+        assertThat("Counter counts are incorrect", registry.getCounters().values(), everyItem(Matchers.hasProperty("count", equalTo(0L))));
+    }
+
+    @Test
+    @InSequence(2)
+    public void callCountedMethodsOnce() {
+        assertThat("Counters are not registered correctly", registry.getCounters().keySet(), is(equalTo(COUNTER_NAMES)));
+
+        // Call the counted methods and assert they're back to zero
+        bean.countedMethodOne();
+        bean.countedMethodTwo();
+        // Let's call the non-public methods as well
+        bean.countedMethodProtected();
+        bean.countedMethodPackagedPrivate();
+
+        // Make sure that the counters are back to zero
+        assertThat("Counter counts are incorrect", registry.getCounters().values(), everyItem(Matchers.hasProperty("count", equalTo(0L))));
+    }
+}

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/TimedMethodBeanLookupTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/TimedMethodBeanLookupTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.concurrent.atomic.AtomicLong;
@@ -28,6 +29,7 @@ import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.MetricType;
 import org.eclipse.microprofile.metrics.Timer;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -100,7 +102,7 @@ public class TimedMethodBeanLookupTest {
         Timer timer = registry.getTimers().get(TIMER_NAME);
 
         // Remove the timer from metrics registry
-        registry.remove(TIMER_NAME);
+        assertTrue(registry.unregister(TIMER_NAME, MetricType.TIMER));
 
         try {
             // Call the timed method and assert an exception is thrown

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/TimedMethodBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/TimedMethodBeanTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.util.concurrent.atomic.AtomicLong;
@@ -27,6 +28,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.MetricType;
 import org.eclipse.microprofile.metrics.Timer;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -107,7 +109,7 @@ public class TimedMethodBeanTest {
         Timer timer = registry.getTimers().get(TIMER_NAME);
 
         // Remove the timer from metrics registry
-        registry.remove(TIMER_NAME);
+        assertTrue(registry.unregister(TIMER_NAME, MetricType.TIMER));
 
         try {
             // Call the timed method and assert an exception is thrown

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/HitCounterTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/HitCounterTest.java
@@ -1,0 +1,83 @@
+/*
+ * ********************************************************************
+ *  Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ *  See the NOTICES file(s) distributed with this work for additional
+ *  information regarding copyright ownership.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  You may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ * ********************************************************************
+ *
+ */
+
+package org.eclipse.microprofile.metrics.tck;
+
+import javax.inject.Inject;
+import org.eclipse.microprofile.metrics.HitCounter;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class HitCounterTest {
+
+    @Deployment
+    public static JavaArchive createDeployment() {
+        return ShrinkWrap.create(JavaArchive.class).addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Inject
+    private HitCounter count;
+
+    @Test
+    @InSequence(1)
+    public void getCountTest() {
+        Assert.assertEquals(0, count.getCount());
+    }
+
+    @Test
+    @InSequence(2)
+    public void incrementTest() {
+        count.inc();
+        Assert.assertEquals(1, count.getCount());
+    }
+
+    @Test
+    @InSequence(3)
+    public void incrementLongTest() {
+        count.inc(4);
+        Assert.assertEquals(5, count.getCount());
+    }
+
+    @Test
+    @InSequence(4)
+    public void decrementTest() {
+        count.dec();
+        Assert.assertEquals(4, count.getCount());
+    }
+
+    @Test
+    @InSequence(5)
+    public void decrementLongTest() {
+        count.dec(4);
+        Assert.assertEquals(0, count.getCount());
+    }
+}

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/MetricRegistryTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/MetricRegistryTest.java
@@ -28,6 +28,7 @@ import org.eclipse.microprofile.metrics.Counter;
 import org.eclipse.microprofile.metrics.Histogram;
 import org.eclipse.microprofile.metrics.Meter;
 import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.MetricType;
 import org.eclipse.microprofile.metrics.Timer;
 import org.eclipse.microprofile.metrics.annotation.Metric;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -93,8 +94,8 @@ public class MetricRegistryTest {
     @Test
     @InSequence(3)
     public void removeTest() {
-        metrics.remove("nameTest");
-        Assert.assertFalse(metrics.getNames().contains("nameTest"));
+        metrics.unregister("nameTest", MetricType.COUNTER);
+        Assert.assertFalse(metrics.getNames(MetricType.COUNTER).contains("nameTest"));
     }
 
 }

--- a/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MetricAppBean.java
+++ b/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MetricAppBean.java
@@ -22,6 +22,8 @@
 
 package org.eclipse.microprofile.metrics.test;
 
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.metrics.Counter;
 import org.eclipse.microprofile.metrics.Gauge;
@@ -32,13 +34,12 @@ import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.MetricType;
 import org.eclipse.microprofile.metrics.MetricUnits;
 import org.eclipse.microprofile.metrics.Timer;
+import org.eclipse.microprofile.metrics.annotation.Counted;
 import org.eclipse.microprofile.metrics.annotation.HitCounted;
 import org.eclipse.microprofile.metrics.annotation.Metered;
 import org.eclipse.microprofile.metrics.annotation.Metric;
+import org.eclipse.microprofile.metrics.annotation.ParallelCounted;
 import org.eclipse.microprofile.metrics.annotation.Timed;
-
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
 
 @ApplicationScoped
 public class MetricAppBean {
@@ -76,8 +77,18 @@ public class MetricAppBean {
         counter.inc();
     }
 
-    @HitCounted(name = "metricTest.test1.countMeA", absolute = true)
+    @Counted(name = "metricTest.test1.countMeA", monotonic = true, absolute = true)
     public void countMeA() {
+
+    }
+
+    @HitCounted(name = "metricTest.test1.countMeB", absolute = true)
+    public void countMeB() {
+
+    }
+
+    @ParallelCounted(name = "metricTest.test1.countMeC", absolute = true)
+    public void countMeC() {
 
     }
 

--- a/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MetricAppBean.java
+++ b/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MetricAppBean.java
@@ -32,7 +32,6 @@ import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.MetricType;
 import org.eclipse.microprofile.metrics.MetricUnits;
 import org.eclipse.microprofile.metrics.Timer;
-import org.eclipse.microprofile.metrics.annotation.Counted;
 import org.eclipse.microprofile.metrics.annotation.HitCounted;
 import org.eclipse.microprofile.metrics.annotation.Metered;
 import org.eclipse.microprofile.metrics.annotation.Metric;

--- a/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MetricAppBean.java
+++ b/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MetricAppBean.java
@@ -33,6 +33,7 @@ import org.eclipse.microprofile.metrics.MetricType;
 import org.eclipse.microprofile.metrics.MetricUnits;
 import org.eclipse.microprofile.metrics.Timer;
 import org.eclipse.microprofile.metrics.annotation.Counted;
+import org.eclipse.microprofile.metrics.annotation.HitCounted;
 import org.eclipse.microprofile.metrics.annotation.Metered;
 import org.eclipse.microprofile.metrics.annotation.Metric;
 import org.eclipse.microprofile.metrics.annotation.Timed;
@@ -76,7 +77,7 @@ public class MetricAppBean {
         counter.inc();
     }
 
-    @Counted(name = "metricTest.test1.countMeA", monotonic = true, absolute = true)
+    @HitCounted(name = "metricTest.test1.countMeA", absolute = true)
     public void countMeA() {
 
     }

--- a/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MetricAppBean2.java
+++ b/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MetricAppBean2.java
@@ -27,6 +27,7 @@ package org.eclipse.microprofile.metrics.test;
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
 import org.eclipse.microprofile.metrics.Histogram;
+import org.eclipse.microprofile.metrics.HitCounter;
 import org.eclipse.microprofile.metrics.Metadata;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.MetricType;
@@ -85,23 +86,64 @@ public class MetricAppBean2 {
     }
 
 
-    public void badRegisterReusableMixed() {
+    public void badRegisterReusable() {
 
         Metadata metadata = Metadata.builder()
-            .withName("badReusableMixed").withType(MetricType.HISTOGRAM)
-            .reusable().build();
+            .withName("badReusable").withType(MetricType.HISTOGRAM)
+            .build();
         Histogram histogram = registry.histogram(metadata);
 
         histogram.update(1);
+
+        // We register a different metric of the same type - that is forbidden
+        // so we expect an exception
+
+        Metadata metadata2 = Metadata.builder()
+            .withName("badReusable").withType(MetricType.HISTOGRAM)
+            .reusable().build();
+        registry.histogram(metadata2);
+
+    }
+
+    public void badRegisterReusable2() {
+
+        Metadata metadata = Metadata.builder()
+            .withName("badReusable2").withType(MetricType.HIT_COUNTER)
+            .build();
+        registry.register(metadata, new DummyHitCounter());
 
         // We register a different metric type - that is forbidden
         // so we expect an exception
 
         Metadata metadata2 = Metadata.builder()
-            .withName("badReusableMixed").withType(MetricType.COUNTER)
+            .withName("badReusable2").withType(MetricType.HIT_COUNTER)
             .reusable().build();
-        registry.counter(metadata2);
+        registry.register(metadata2, new DummyHitCounter());
 
     }
 
+
+    private static class DummyHitCounter implements HitCounter {
+
+        @Override
+        public void inc() {
+        }
+
+        @Override
+        public void inc(long n) {
+        }
+
+        @Override
+        public void dec() {
+        }
+
+        @Override
+        public void dec(long n) {
+        }
+
+        @Override
+        public long getCount() {
+            return 0;  // TODO: Customise this generated block
+        }
+    }
 }

--- a/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MetricAppBean2.java
+++ b/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MetricAppBean2.java
@@ -31,6 +31,7 @@ import org.eclipse.microprofile.metrics.Metadata;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.MetricType;
 import org.eclipse.microprofile.metrics.annotation.Counted;
+import org.eclipse.microprofile.metrics.annotation.HitCounted;
 import org.eclipse.microprofile.metrics.annotation.Metered;
 import org.eclipse.microprofile.metrics.annotation.Timed;
 
@@ -40,12 +41,12 @@ public class MetricAppBean2 {
     @Inject
     private MetricRegistry registry;
 
-    @Counted(name = "countMe2", monotonic = true, absolute = true, reusable = true)
+    @HitCounted(name = "countMe2", absolute = true, reusable = true)
     public void countMeA() {
 
     }
 
-    @Counted(name = "countMe2", monotonic = true, absolute = true, reusable = true)
+    @HitCounted(name = "countMe2", absolute = true, reusable = true)
     public void countMeB() {
 
     }

--- a/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MetricAppBean2.java
+++ b/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MetricAppBean2.java
@@ -30,7 +30,6 @@ import org.eclipse.microprofile.metrics.Histogram;
 import org.eclipse.microprofile.metrics.Metadata;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.MetricType;
-import org.eclipse.microprofile.metrics.annotation.Counted;
 import org.eclipse.microprofile.metrics.annotation.HitCounted;
 import org.eclipse.microprofile.metrics.annotation.Metered;
 import org.eclipse.microprofile.metrics.annotation.Timed;

--- a/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/ReusableMetricsTest.java
+++ b/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/ReusableMetricsTest.java
@@ -162,7 +162,7 @@ public class ReusableMetricsTest {
 
   }
 
-  @Test(expected=IllegalArgumentException.class)
+//  @Test(expected=IllegalArgumentException.class)
   @InSequence(7)
   public void testBadReusableMixed() {
       metricAppBean.badRegisterReusableMixed();

--- a/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/ReusableMetricsTest.java
+++ b/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/ReusableMetricsTest.java
@@ -162,10 +162,16 @@ public class ReusableMetricsTest {
 
   }
 
-//  @Test(expected=IllegalArgumentException.class)
+  @Test(expected=IllegalArgumentException.class)
   @InSequence(7)
-  public void testBadReusableMixed() {
-      metricAppBean.badRegisterReusableMixed();
+  public void testBadReusable() {
+      metricAppBean.badRegisterReusable();
+  }
+
+  @Test(expected=IllegalArgumentException.class)
+  @InSequence(8)
+  public void testBadReusable2() {
+      metricAppBean.badRegisterReusable2();
   }
 
 

--- a/tck/rest/src/main/resources/application_metrics.xml
+++ b/tck/rest/src/main/resources/application_metrics.xml
@@ -25,6 +25,8 @@
   <metric multi="false" name="purple" type="counter" unit="none"/>
   <metric multi="false" name="jellybeanHistogram" type="histogram" unit="jellybeans"/>
   <metric multi="false" name="metricTest.test1.countMeA" type="counter" unit="none"/>
+  <metric multi="false" name="metricTest.test1.countMeB" type="hit-counter" unit="none"/>
+  <metric multi="false" name="metricTest.test1.countMeC" type="parallel-counter" unit="none"/>
   <metric multi="false" name="org.eclipse.microprofile.metrics.test.MetricAppBean.gaugeMeA" type="gauge" unit="kibibits"/>
   <metric multi="false" name="meterMeA" type="meter" unit="per_second"/>
   <metric multi="false" name="org.eclipse.microprofile.metrics.test.MetricAppBean.timeMeA" type="timer" unit="nanoseconds"/>


### PR DESCRIPTION
This is for deprecation of `@Counted` and also introducing #259 to allow for `@HitCounted` and `@ParallelCounted` to be put on one method.
Also deals with reusability.

Implementation counterpart is at https://github.com/thorntail/thorntail/pull/998