### PR TITLE
Make enterprise dependencies optional, so that it can be used on SE as well

### DIFF
--- a/api/bnd.bnd
+++ b/api/bnd.bnd
@@ -1,5 +1,6 @@
 -exportcontents: \
     org.eclipse.microprofile.*
+Import-Package: javax.enterprise.util.*;resolution:=optional, javax.inject.*;resolution:=optional, javax.interceptor.*;resolution:=optional, *
 Bundle-SymbolicName: org.eclipse.microprofile.metrics
 Bundle-Name: MicroProfile Metrics Bundle
 Bundle-License: Apache License, Version 2.0


### PR DESCRIPTION
We would [like to use microprofile-metrics in Eclipse SmartHome](https://www.eclipse.org/forums/index.php?t=msg&th=1094339&goto=1793459&#msg_1793459) as well and trying to add it, I had to noticed that the manifest declares mandatory dependencies to `javax`packages, which are not part of JavaSE.
While these dependencies might be relevant at compile time of the project, I absolutely do not see any need for their presence at runtime; only the implementations might have those dependencies, but that should be left to them.

I'd therefore suggest to mark those dependencies as optional, which let's people easily use this API on a plain JavaSE as well.

Signed-off-by: Kai Kreuzer <kai@openhab.org>