### PR TITLE
Dimensional tags

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/metrics/DefaultMetadata.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/DefaultMetadata.java
@@ -23,11 +23,8 @@
  **********************************************************************/
 package org.eclipse.microprofile.metrics;
 
-import java.util.Collections;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * The default implementation of {@link Metadata}
@@ -89,25 +86,14 @@ public class DefaultMetadata implements Metadata {
      */
     private final boolean reusable;
 
-    /**
-     * Tags of the metric. Augmented by global tags.
-     * <p>
-     * An optional field which holds the tags of the metric object which can be
-     * augmented by global tags.
-     * </p>
-     */
-    private final Map<String, String> tags;
-
     protected DefaultMetadata(String name, String displayName, String description,
-                           MetricType type, String unit, boolean reusable,
-                           Map<String, String> tags) {
+                              MetricType type, String unit, boolean reusable) {
         this.name = name;
         this.displayName = displayName;
         this.description = description;
         this.type = type;
         this.unit = unit;
         this.reusable = reusable;
-        this.tags = tags;
     }
 
     @Override
@@ -146,18 +132,6 @@ public class DefaultMetadata implements Metadata {
     }
 
     @Override
-    public String getTagsAsString() {
-        return this.tags.entrySet()
-                .stream().map(e -> e.getKey() + "=\"" + e.getValue() + "\"")
-                .collect(Collectors.joining(","));
-    }
-
-    @Override
-    public Map<String, String> getTags() {
-        return Collections.unmodifiableMap(tags);
-    }
-
-    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;
@@ -166,13 +140,13 @@ public class DefaultMetadata implements Metadata {
             return false;
         }
         Metadata that = (Metadata) o;
-        return Objects.equals(name, that.getName()) && Objects.equals(tags, that.getTags());
+        return Objects.equals(name, that.getName());
 
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, tags);
+        return Objects.hashCode(name);
     }
 
     @Override
@@ -182,7 +156,6 @@ public class DefaultMetadata implements Metadata {
         sb.append(", type=").append(type);
         sb.append(", unit='").append(unit).append('\'');
         sb.append(", reusable=").append(reusable);
-        sb.append(", tags=").append(tags);
         sb.append('}');
         return sb.toString();
     }

--- a/api/src/main/java/org/eclipse/microprofile/metrics/DefaultMetadata.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/DefaultMetadata.java
@@ -1,6 +1,6 @@
 /*
  **********************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
  *               2018 Red Hat, Inc. and/or its affiliates
  *               and other contributors as indicated by the @author tags.
  *
@@ -140,13 +140,23 @@ public class DefaultMetadata implements Metadata {
             return false;
         }
         Metadata that = (Metadata) o;
-        return Objects.equals(name, that.getName());
 
+        //Retrieve the Optional value or set to the "defaults" if empty
+        String thatDescription = (that.getDescription().isPresent()) ? that.getDescription().get() : null;
+        String thatUnit = (that.getUnit().isPresent()) ? that.getUnit().get() : MetricUnits.NONE;
+        
+        //Need to use this.getDisplayname() and this.getTypeRaw() for the Optional.orElse() logic
+        return Objects.equals(name, that.getName()) &&
+                Objects.equals(this.getDisplayName(), that.getDisplayName()) &&
+                Objects.equals(description, thatDescription) &&
+                Objects.equals(unit, thatUnit) &&
+                Objects.equals(this.getTypeRaw(), that.getTypeRaw()) &&
+                Objects.equals(reusable, that.isReusable());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(name);
+        return Objects.hash(name, displayName, description, unit, type, reusable);
     }
 
     @Override

--- a/api/src/main/java/org/eclipse/microprofile/metrics/DefaultMetadata.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/DefaultMetadata.java
@@ -166,13 +166,13 @@ public class DefaultMetadata implements Metadata {
             return false;
         }
         Metadata that = (Metadata) o;
-        return Objects.equals(name, that.getName());
+        return Objects.equals(name, that.getName()) && Objects.equals(tags, that.getTags());
 
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(name);
+        return Objects.hash(name, tags);
     }
 
     @Override

--- a/api/src/main/java/org/eclipse/microprofile/metrics/Metadata.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/Metadata.java
@@ -23,7 +23,6 @@
  **********************************************************************/
 package org.eclipse.microprofile.metrics;
 
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -49,20 +48,11 @@ import java.util.Optional;
  * {@code Unit}: (Optional) The unit of the metric.
  * The unit may be any unit specified as a String or one specified in {@link MetricUnits}.
  * </li>
- * <li>
- * {@code Tags}: (Optional) The tags (represented by key/value pairs) of the metric which is augmented by global tags (if available).
- * Global tags can be set by passing the list of tags in an environment variable {@code MP_METRICS_TAGS}.
- * For example, the following can be used to set the global tags:
- * <pre><code>
- *      export MP_METRICS_TAGS=app=shop,tier=integration
- * </code></pre>
- * </li>
  * </ul>
  *
  * @author hrupp, Raymond Lam
  */
 public interface Metadata {
-
 
     /**
      * Returns the metric name.
@@ -78,14 +68,12 @@ public interface Metadata {
      */
     String getDisplayName();
 
-
     /**
      * Returns the description of the metric.
      *
      * @return the description
      */
     Optional<String> getDescription();
-
 
     /**
      * Returns the String representation of the {@link MetricType}.
@@ -102,27 +90,13 @@ public interface Metadata {
      */
     MetricType getTypeRaw();
 
-
     Optional<String> getUnit();
 
     boolean isReusable();
 
     /**
-     * Gets the list of tags as a single String in the format 'key="value",key2="value2",...'
-     *
-     * @return a String containing the tags
-     */
-    String getTagsAsString();
-
-    /**
-     * Returns the underlying HashMap containing the tags.
-     *
-     * @return a {@link Map} of tags
-     */
-    Map<String, String> getTags();
-
-    /**
      * Returns a new builder
+     *
      * @return a new {@link MetadataBuilder} instance
      */
     static MetadataBuilder builder() {
@@ -131,8 +105,9 @@ public interface Metadata {
 
     /**
      * Returns a new builder with the {@link Metadata} information
+     *
      * @param metadata the metadata
-     * @return  a new {@link MetadataBuilder} instance with the {@link Metadata} values
+     * @return a new {@link MetadataBuilder} instance with the {@link Metadata} values
      * @throws NullPointerException when metadata is null
      */
     static MetadataBuilder builder(Metadata metadata) {

--- a/api/src/main/java/org/eclipse/microprofile/metrics/MetadataBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/MetadataBuilder.java
@@ -23,10 +23,7 @@
  **********************************************************************/
 package org.eclipse.microprofile.metrics;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Stream;
 
 /**
  * The {@link Metadata} builder.
@@ -36,8 +33,6 @@ import java.util.stream.Stream;
  * {@link MetadataBuilder#reusable} as {@link Boolean#FALSE}
  */
 public class MetadataBuilder {
-
-    public static final String GLOBAL_TAGS_VARIABLE = "MP_METRICS_TAGS";
 
     private String name;
 
@@ -51,24 +46,18 @@ public class MetadataBuilder {
 
     private boolean reusable = false;
 
-    private Map<String, String> tags = new HashMap<>();
+    public MetadataBuilder() {
 
-    MetadataBuilder() {
-        String globalTagsFromEnv = System.getenv(GLOBAL_TAGS_VARIABLE);
-        addTags(globalTagsFromEnv);
     }
 
     MetadataBuilder(Metadata metadata) {
         this.name = metadata.getName();
         this.type = metadata.getTypeRaw();
         this.reusable = metadata.isReusable();
-        this.tags.putAll(metadata.getTags());
         this.displayName = metadata.getDisplayName();
         metadata.getDescription().ifPresent(this::withDescription);
         metadata.getUnit().ifPresent(this::withUnit);
-
     }
-
 
     /**
      * Sets the name
@@ -151,38 +140,6 @@ public class MetadataBuilder {
     }
 
     /**
-     * Add multiple tags delimited by commas.
-     * The format must be in the form 'key1=value1, key2=value2'.
-     * This method will call {@link #addTag(String)} on each tag.
-     *
-     * @param tagsString a string containing multiple tags
-     * @return this instance with new tags
-     */
-    public MetadataBuilder addTags(String tagsString) {
-        if (tagsString == null || tagsString.isEmpty()) {
-            return this;
-        }
-        String[] singleTags = tagsString.split(",");
-        Stream.of(singleTags).map(String::trim).forEach(this::addTag);
-        return this;
-    }
-
-    /**
-     * Add one single tag with the format: 'key=value'. If the input is empty or does
-     * not contain a '=' sign, the entry is ignored.
-     *
-     * @param kvString Input string
-     * @return this instance with new tag
-     */
-    public MetadataBuilder addTag(String kvString) {
-        if (kvString == null || kvString.isEmpty() || !kvString.contains("=")) {
-            return this;
-        }
-        tags.put(kvString.substring(0, kvString.indexOf("=")), kvString.substring(kvString.indexOf("=") + 1));
-        return this;
-    }
-
-    /**
      * @return
      * @throws IllegalStateException when either name is null
      */
@@ -191,6 +148,6 @@ public class MetadataBuilder {
             throw new IllegalStateException("Name is required");
         }
 
-        return new DefaultMetadata(name, displayName, description, type, unit, reusable, tags);
+        return new DefaultMetadata(name, displayName, description, type, unit, reusable);
     }
 }

--- a/api/src/main/java/org/eclipse/microprofile/metrics/MetadataBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/MetadataBuilder.java
@@ -46,10 +46,6 @@ public class MetadataBuilder {
 
     private boolean reusable = false;
 
-    public MetadataBuilder() {
-
-    }
-
     MetadataBuilder(Metadata metadata) {
         this.name = metadata.getName();
         this.type = metadata.getTypeRaw();
@@ -57,6 +53,11 @@ public class MetadataBuilder {
         this.displayName = metadata.getDisplayName();
         metadata.getDescription().ifPresent(this::withDescription);
         metadata.getUnit().ifPresent(this::withUnit);
+
+    }
+
+    public MetadataBuilder() {
+
     }
 
     /**

--- a/api/src/main/java/org/eclipse/microprofile/metrics/MetricFilter.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/MetricFilter.java
@@ -1,6 +1,6 @@
 /*
  **********************************************************************
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017, 2019 Contributors to the Eclipse Foundation
  *               2010-2013 Coda Hale, Yammer.com
  *
  * See the NOTICES file(s) distributed with this work for additional
@@ -27,16 +27,16 @@ package org.eclipse.microprofile.metrics;
  */
 public interface MetricFilter {
     /**
-     * Matches all metrics, regardless of type or name.
+     * Matches all metrics, regardless of type or {@link MetricID}.
      */
-    MetricFilter ALL = (name, metric) -> true;
+    MetricFilter ALL = (metricID, metric) -> true;
 
     /**
      * Returns {@code true} if the metric matches the filter; {@code false} otherwise.
      *
-     * @param name      the metric's name
-     * @param metric    the metric
+     * @param metricID the metric's {@link MetricID}
+     * @param metric the metric
      * @return {@code true} if the metric matches the filter
      */
-    boolean matches(String name, Metric metric);
+    boolean matches(MetricID metricID, Metric metric);
 }

--- a/api/src/main/java/org/eclipse/microprofile/metrics/MetricID.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/MetricID.java
@@ -71,7 +71,7 @@ public class MetricID implements Comparable<MetricID> {
                                                                 + "must match the following regex [a-zA-Z_][a-zA-Z0-9_]*."
                                                                 + " Global Tag values must not be empty."
                                                                 + " Global Tag values MUST escape equal signs `=` and commas `,`"
-                                                                + "with a backslash `\\` ";
+                                                                + " with a backslash `\\` ";
 
     /**
      * Name of the metric.
@@ -124,7 +124,7 @@ public class MetricID implements Comparable<MetricID> {
     }
 
     /**
-     * Returns the underlying HashMap containing the tags.
+     * Returns the underlying map containing the tags.
      *
      * @return a {@link Map} of tags
      */

--- a/api/src/main/java/org/eclipse/microprofile/metrics/MetricID.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/MetricID.java
@@ -1,7 +1,7 @@
 /*
  **********************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
- *               2018 IBM Corporation and others
+ * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
+ *               2018, 2019 IBM Corporation and others
  *               and other contributors as indicated by the @author tags.
  *
  * See the NOTICES file(s) distributed with this work for additional
@@ -67,7 +67,7 @@ public class MetricID implements Comparable<MetricID> {
 
     public static final String GLOBAL_TAGS_VARIABLE = "MP_METRICS_TAGS";
 
-    private static final String GLOBA_TAG_MALFORMED_EXCEPTION = "Malformed list of Global Tags. Tag names "
+    private static final String GLOBAL_TAG_MALFORMED_EXCEPTION = "Malformed list of Global Tags. Tag names "
                                                                 + "must match the following regex [a-zA-Z_][a-zA-Z0-9_]*."
                                                                 + " Global Tag values must not be empty."
                                                                 + " Global Tag values MUST escape equal signs `=` and commas `,`"
@@ -214,13 +214,13 @@ public class MetricID implements Comparable<MetricID> {
         for (String kvString : kvPairs) {
 
             if (kvString.length() == 0) {
-                throw new IllegalArgumentException(GLOBA_TAG_MALFORMED_EXCEPTION);
+                throw new IllegalArgumentException(GLOBAL_TAG_MALFORMED_EXCEPTION);
             }
 
             String[] keyValueSplit = kvString.split("(?<!\\\\)=");
 
             if (keyValueSplit.length != 2 || keyValueSplit[0].length() == 0 || keyValueSplit[1].length() == 0) {
-                throw new IllegalArgumentException(GLOBA_TAG_MALFORMED_EXCEPTION);
+                throw new IllegalArgumentException(GLOBAL_TAG_MALFORMED_EXCEPTION);
             }
 
             String key = keyValueSplit[0];

--- a/api/src/main/java/org/eclipse/microprofile/metrics/MetricID.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/MetricID.java
@@ -1,0 +1,176 @@
+/*
+ **********************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *               2018 IBM Corporation and others
+ *               and other contributors as indicated by the @author tags.
+ *
+ * See the NOTICES file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+package org.eclipse.microprofile.metrics;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ *
+ * A unique identifier for {@link Metric} and {@link Metadata} that are registered
+ * in the {@link MetricRegistry}
+ *
+ * The MetricID contains:
+ * <ul>
+ * <li>
+ * {@code Name}: (Required) The name of the metric.
+ * </li>
+ * <li>
+ * {@code Tags}: (Optional) The tags (represented by key/value pairs) of the metric which is augmented by global tags (if available).
+ * Global tags can be set by passing the list of tags in an environment variable {@code MP_METRICS_TAGS}.
+ * For example, the following can be used to set the global tags:
+ *
+ * <pre>
+ * <code>
+ *      export MP_METRICS_TAGS=app=shop,tier=integration
+ * </code>
+ * </pre>
+ *
+ * </li>
+ * </ul>
+ */
+public class MetricID {
+
+    public static final String GLOBAL_TAGS_VARIABLE = "MP_METRICS_TAGS";
+
+    /**
+     * Name of the metric.
+     * <p>
+     * A required field which holds the name of the metric object.
+     * </p>
+     */
+    public final String name;
+
+    /**
+     * Tags of the metric. Augmented by global tags.
+     * <p>
+     * An optional field which holds the tags of the metric object which can be
+     * augmented by global tags.
+     * </p>
+     */
+    private final Map<String, String> tags = new HashMap<String, String>();
+
+    /**
+     * Constructs a MetricID with the given metric name and no tags.
+     * If global tags are available then they will be appended to this MetricID.
+     *
+     * @param name the name of the metric
+     */
+    public MetricID(String name) {
+        this(name, null);
+    }
+
+    /**
+     * Constructs a MetricID with the given metric name and tags.
+     * If global tags are available then they will be appended to this MetricID
+     *
+     * @param name the name of the metric
+     * @param tags the tags associated with this metric
+     */
+    public MetricID(String name, String tags) {
+        this.name = name;
+        String globalTagsFromEnv = System.getenv(GLOBAL_TAGS_VARIABLE);
+        addTags(globalTagsFromEnv);
+        addTags(tags);
+    }
+
+    /**
+     * Returns the Metric name associated with this MetricID
+     *
+     * @return the Metric name associated with this MetricID
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * Gets the list of tags as a single String in the format 'key="value",key2="value2",...'
+     *
+     * @return a String containing the tags
+     */
+    public String getTagsAsString() {
+        return this.tags.entrySet().stream().map(e -> e.getKey() + "=\"" + e.getValue() + "\"").collect(Collectors.joining(","));
+    }
+
+    /**
+     * Returns the underlying HashMap containing the tags.
+     *
+     * @return a {@link Map} of tags
+     */
+    public Map<String, String> getTags() {
+        return Collections.unmodifiableMap(tags);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof MetricID)) {
+            return false;
+        }
+        MetricID that = (MetricID) o;
+        return Objects.equals(this.name, that.getName()) && Objects.equals(this.tags, that.getTags());
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, tags);
+    }
+
+    /**
+     * Add multiple tags delimited by commas.
+     * The format must be in the form 'key1=value1, key2=value2'.
+     * This method will call {@link #addTag(String)} on each tag.
+     *
+     * @param tagsString a string containing multiple tags
+     */
+    public void addTags(String tagsString) {
+        if (tagsString == null || tagsString.isEmpty()) {
+            return;
+        }
+        String[] singleTags = tagsString.split(",");
+        Stream.of(singleTags).map(String::trim).forEach(this::addTag);
+    }
+
+    /**
+     * Add one single tag with the format: 'key=value'. If the input is empty or does
+     * not contain a '=' sign, the entry is ignored.
+     *
+     * @param kvString Input string
+     */
+    public void addTag(String kvString) {
+        if (kvString == null || kvString.isEmpty() || !kvString.contains("=")) {
+            return;
+        }
+        tags.put(kvString.substring(0, kvString.indexOf("=")), kvString.substring(kvString.indexOf("=") + 1));
+    }
+
+}

--- a/api/src/main/java/org/eclipse/microprofile/metrics/MetricID.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/MetricID.java
@@ -238,7 +238,7 @@ public class MetricID implements Comparable<MetricID> {
 
     /**
      * Compares two MetricID objects through the following steps:
-     * <p>
+     * <br>
      * <ol>
      * <li>
      * Compares the names of the two MetricIDs lexicographically.
@@ -275,7 +275,8 @@ public class MetricID implements Comparable<MetricID> {
                     compareVal = thisEntry.getKey().compareTo(otherEntry.getKey());
                     if (compareVal != 0) {
                         return compareVal;
-                    } else {
+                    } 
+                    else {
                         compareVal = thisEntry.getValue().compareTo(otherEntry.getValue());
                         if (compareVal != 0) {
                             return compareVal;

--- a/api/src/main/java/org/eclipse/microprofile/metrics/MetricRegistry.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/MetricRegistry.java
@@ -114,25 +114,30 @@ public abstract class MetricRegistry {
 
     /**
      * Given a {@link Metric}, registers it under a {@link MetricID} with the given name and with no tags.
-     * A {@link Metadata} object will be registered with the name and type under the same {@link MetricID}.
+     * A {@link Metadata} object will be registered with the name and type.
+     * However, if a {@link Metadata} object is already registered with this metric name and is not equal to the created {@link Metadata} object then an exception will be thrown.
      *
      * @param name the name of the metric
      * @param metric the metric
      * @param <T> the type of the metric
      * @return {@code metric}
-     * @throws IllegalArgumentException if the name is already registered
+     * @throws IllegalArgumentException if the name is already registered or if Metadata with different values has already been registered with the name
      */
     public abstract <T extends Metric> T register(String name, T metric) throws IllegalArgumentException;
 
     /**
-     * Given a {@link Metric} and {@link Metadata}, registers both under a {@link MetricID} with the name provided by the {@link Metadata}
+     * Given a {@link Metric} and {@link Metadata}, registers the metric with a {@link MetricID} with the name provided by the {@link Metadata}
      * and with no tags.
+     * <p>
+     * Note: If a {@link Metadata} object is already registered under this metric name and is not equal to the provided {@link Metadata} object then
+     * an exception will be thrown.
+     * </p>
      *
      * @param metadata the metadata
      * @param metric the metric
      * @param <T> the type of the metric
      * @return {@code metric}
-     * @throws IllegalArgumentException if the name is already registered
+     * @throws IllegalArgumentException if the name is already registered or if Metadata with different values has already been registered with the name
      *
      * @since 1.1
      */
@@ -141,13 +146,17 @@ public abstract class MetricRegistry {
     /**
      * Given a {@link Metric} and {@link Metadata}, registers both under a {@link MetricID} with the name provided by the {@link Metadata}
      * and with the provided tags.
+     * <p>
+     * Note: If a {@link Metadata} object is already registered under this metric name and is not equal to the provided {@link Metadata} object then
+     * an exception will be thrown.
+     * </p>
      *
      * @param metadata the metadata
      * @param metric the metric
      * @param <T> the type of the metric
-     * @param tags the tags of the metric
+     * @param tags the tags of the metric in 'key1=value1, key2=value2' format
      * @return {@code metric}
-     * @throws IllegalArgumentException if the name is already registered
+     * @throws IllegalArgumentException if the name is already registered or if Metadata with different values has already been registered with the name
      *
      * @since 2.0
      */
@@ -157,6 +166,7 @@ public abstract class MetricRegistry {
      * Return the {@link Counter} registered under the {@link MetricID} with this name and with no tags; or create and register
      * a new {@link Counter} if none is registered.
      * If a {@link Counter} was created, a {@link Metadata} object will be registered with the name and type.
+     * However, if a {@link Metadata} object is already registered with this metric name and is not equal to the created {@link Metadata} object then an exception will be thrown.
      *
      * @param name the name of the metric
      * @return a new or pre-existing {@link Counter}
@@ -164,11 +174,26 @@ public abstract class MetricRegistry {
     public abstract Counter counter(String name);
 
     /**
+     * Return the {@link Counter} registered under the {@link MetricID} with this name and with the provided tags; or create and register
+     * a new {@link Counter} if none is registered.
+     * If a {@link Counter} was created, a {@link Metadata} object will be registered with the name and type.
+     * However, if a {@link Metadata} object is already registered with this metric name and is not equal to the created {@link Metadata} object then an exception will be thrown.
+     *
+     * @param name the name of the metric
+     * @param tags the tags of the metric in 'key1=value1, key2=value2' format
+     * @return a new or pre-existing {@link Counter}
+     *
+     * @since 2.0
+     */
+    public abstract Counter counter(String name, String tags);
+
+    /**
      * Return the {@link Counter} registered under the {@link MetricID} with the {@link Metadata}'s name and with no tags; or create and register
      * a new {@link Counter} if none is registered.
      * If a {@link Counter} was created, the provided {@link Metadata} object will be registered.
      * <p>
-     * Note: The {@link Metadata} will not be updated if the metric is already registered.
+     * Note: During retrieval or creation, if a {@link Metadata} object is already registered under this metric name and is not equal to the provided {@link Metadata} object then
+     * an exception will be thrown.
      * </p>
      *
      * @param metadata the name of the metric
@@ -181,12 +206,15 @@ public abstract class MetricRegistry {
      * a new {@link Counter} if none is registered.
      * If a {@link Counter} was created, the provided {@link Metadata} object will be registered.
      * <p>
-     * Note: The {@link Metadata} will not be updated if the metric is already registered.
+     * Note: During retrieval or creation, if a {@link Metadata} object is already registered under this metric name and is not equal to the provided {@link Metadata} object then
+     * an exception will be thrown.
      * </p>
      *
      * @param metadata the name of the metric
-     * @param tags the tags of the metric
+     * @param tags the tags of the metric in 'key1=value1, key2=value2' format
      * @return a new or pre-existing {@link Counter}
+     *
+     * @since 2.0
      */
     public abstract Counter counter(Metadata metadata, String tags);
 
@@ -194,6 +222,7 @@ public abstract class MetricRegistry {
      * Return the {@link Histogram} registered under the {@link MetricID} with this name and with no tags; or create and register
      * a new {@link Histogram} if none is registered.
      * If a {@link Histogram} was created, a {@link Metadata} object will be registered with the name and type.
+     * However, if a {@link Metadata} object is already registered with this metric name and is not equal to the created {@link Metadata} object then an exception will be thrown.
      *
      * @param name the name of the metric
      * @return a new or pre-existing {@link Histogram}
@@ -201,11 +230,26 @@ public abstract class MetricRegistry {
     public abstract Histogram histogram(String name);
 
     /**
+     * Return the {@link Histogram} registered under the {@link MetricID} with this name and with the provided tags; or create and register
+     * a new {@link Histogram} if none is registered.
+     * If a {@link Histogram} was created, a {@link Metadata} object will be registered with the name and type.
+     * However, if a {@link Metadata} object is already registered with this metric name and is not equal to the created {@link Metadata} object then an exception will be thrown.
+     *
+     * @param name the name of the metric
+     * @param tags the tags of the metric in 'key1=value1, key2=value2' format
+     * @return a new or pre-existing {@link Histogram}
+     *
+     * @since 2.0
+     */
+    public abstract Histogram histogram(String name, String tags);
+
+    /**
      * Return the {@link Histogram} registered under the {@link MetricID} with the {@link Metadata}'s name and with no tags; or create and register
      * a new {@link Histogram} if none is registered.
      * If a {@link Histogram} was created, the provided {@link Metadata} object will be registered.
      * <p>
-     * Note: The {@link Metadata} will not be updated if the metric is already registered.
+     * Note: During retrieval or creation, if a {@link Metadata} object is already registered under this metric name and is not equal to the provided {@link Metadata} object then
+     * an exception will be thrown.
      * </p>
      *
      * @param metadata the name of the metric
@@ -218,12 +262,15 @@ public abstract class MetricRegistry {
      * a new {@link Histogram} if none is registered.
      * If a {@link Histogram} was created, the provided {@link Metadata} object will be registered.
      * <p>
-     * Note: The {@link Metadata} will not be updated if the metric is already registered.
+     * Note: During retrieval or creation, if a {@link Metadata} object is already registered under this metric name and is not equal to the provided {@link Metadata} object then
+     * an exception will be thrown.
      * </p>
      *
      * @param metadata the name of the metric
-     * @param metadata the tags of the metric
+     * @param tags the tags of the metric in 'key1=value1, key2=value2' format
      * @return a new or pre-existing {@link Histogram}
+     *
+     * @since 2.0
      */
     public abstract Histogram histogram(Metadata metadata, String tags);
 
@@ -231,6 +278,7 @@ public abstract class MetricRegistry {
      * Return the {@link Meter} registered under the {@link MetricID} with this name and with no tags; or create and register
      * a new {@link Meter} if none is registered.
      * If a {@link Meter} was created, a {@link Metadata} object will be registered with the name and type.
+     * However, if a {@link Metadata} object is already registered with this metric name and is not equal to the created {@link Metadata} object then an exception will be thrown.
      *
      * @param name the name of the metric
      * @return a new or pre-existing {@link Meter}
@@ -238,11 +286,26 @@ public abstract class MetricRegistry {
     public abstract Meter meter(String name);
 
     /**
+     * Return the {@link Meter} registered under the {@link MetricID} with this name and with the provided tags; or create and register
+     * a new {@link Meter} if none is registered.
+     * If a {@link Meter} was created, a {@link Metadata} object will be registered with the name and type.
+     * However, if a {@link Metadata} object is already registered with this metric name and is not equal to the created {@link Metadata} object then an exception will be thrown.
+     *
+     * @param name the name of the metric
+     * @param tags the tags of the metric in 'key1=value1, key2=value2' format
+     * @return a new or pre-existing {@link Meter}
+     *
+     * @since 2.0
+     */
+    public abstract Meter meter(String name, String tags);
+
+    /**
      * Return the {@link Meter} registered under the {@link MetricID} with the {@link Metadata}'s name and with no tags; or create and register
      * a new {@link Meter} if none is registered.
      * If a {@link Meter} was created, the provided {@link Metadata} object will be registered.
      * <p>
-     * Note: The {@link Metadata} will not be updated if the metric is already registered.
+     * Note: During retrieval or creation, if a {@link Metadata} object is already registered under this metric name and is not equal to the provided {@link Metadata} object then
+     * an exception will be thrown.
      * </p>
      *
      * @param metadata the name of the metric
@@ -255,12 +318,15 @@ public abstract class MetricRegistry {
      * a new {@link Meter} if none is registered.
      * If a {@link Meter} was created, the provided {@link Metadata} object will be registered.
      * <p>
-     * Note: The {@link Metadata} will not be updated if the metric is already registered.
+     * Note: During retrieval or creation, if a {@link Metadata} object is already registered under this metric name and is not equal to the provided {@link Metadata} object then
+     * an exception will be thrown.
      * </p>
      *
      * @param metadata the name of the metric
-     * @param metadata the tags of the metric
+     * @param tags the tags of the metric in 'key1=value1, key2=value2' format
      * @return a new or pre-existing {@link Meter}
+     *
+     * @since 2.0
      */
     public abstract Meter meter(Metadata metadata, String tags);
 
@@ -268,6 +334,7 @@ public abstract class MetricRegistry {
      * Return the {@link Timer} registered under the {@link MetricID} with this name and with no tags; or create and register
      * a new {@link Timer} if none is registered.
      * If a {@link Timer} was created, a {@link Metadata} object will be registered with the name and type.
+     * However, if a {@link Metadata} object is already registered with this metric name and is not equal to the created {@link Metadata} object then an exception will be thrown.
      *
      * @param name the name of the metric
      * @return a new or pre-existing {@link Timer}
@@ -275,11 +342,26 @@ public abstract class MetricRegistry {
     public abstract Timer timer(String name);
 
     /**
+     * Return the {@link Timer} registered under the {@link MetricID} with this name and with the provided tags; or create and register
+     * a new {@link Timer} if none is registered.
+     * If a {@link Timer} was created, a {@link Metadata} object will be registered with the name and type.
+     * However, if a {@link Metadata} object is already registered with this metric name and is not equal to the created {@link Metadata} object then an exception will be thrown.
+     *
+     * @param name the name of the metric
+     * @param tags the tags of the metric in 'key1=value1, key2=value2' format
+     * @return a new or pre-existing {@link Timer}
+     *
+     * @since 2.0
+     */
+    public abstract Timer timer(String name, String tags);
+
+    /**
      * Return the {@link Timer} registered under the the {@link MetricID} with the {@link Metadata}'s name and with no tags; or create and register
      * a new {@link Timer} if none is registered.
      * If a {@link Timer} was created, the provided {@link Metadata} object will be registered.
      * <p>
-     * Note: The {@link Metadata} will not be updated if the metric is already registered.
+     * Note: During retrieval or creation, if a {@link Metadata} object is already registered under this metric name and is not equal to the provided {@link Metadata} object then
+     * an exception will be thrown.
      * </p>
      *
      * @param metadata the name of the metric
@@ -292,12 +374,15 @@ public abstract class MetricRegistry {
      * a new {@link Timer} if none is registered.
      * If a {@link Timer} was created, the provided {@link Metadata} object will be registered.
      * <p>
-     * Note: The {@link Metadata} will not be updated if the metric is already registered.
+     * Note: During retrieval or creation, if a {@link Metadata} object is already registered under this metric name and is not equal to the provided {@link Metadata} object then
+     * an exception will be thrown.
      * </p>
      *
      * @param metadata the name of the metric
-     * @param tags the tags of the metric
+     * @param tags the tags of the metric in 'key1=value1, key2=value2' format
      * @return a new or pre-existing {@link Timer}
+     *
+     * @since 2.0
      */
     public abstract Timer timer(Metadata metadata, String tags);
 
@@ -314,6 +399,8 @@ public abstract class MetricRegistry {
      *
      * @param MetricID the MetricID of the metric
      * @return whether or not the metric was removed
+     *
+     * @since 2.0
      */
     public abstract boolean remove(MetricID MetricID);
 
@@ -423,10 +510,10 @@ public abstract class MetricRegistry {
     public abstract Map<MetricID, Metric> getMetrics();
 
     /**
-     * Returns a map of all the metadata in the registry and their {@link MetricID}s.
+     * Returns a map of all the metadata in the registry and their names.
      *
      * @return all the metadata in the registry
      */
-    public abstract Map<MetricID, Metadata> getMetadata();
+    public abstract Map<String, Metadata> getMetadata();
 
 }

--- a/api/src/main/java/org/eclipse/microprofile/metrics/MetricRegistry.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/MetricRegistry.java
@@ -409,7 +409,7 @@ public abstract class MetricRegistry {
     /**
      * Removes the metric with the given MetricID
      *
-     * @param MetricID the MetricID of the metric
+     * @param metricID the MetricID of the metric
      * @return whether or not the metric was removed
      *
      * @since 2.0

--- a/api/src/main/java/org/eclipse/microprofile/metrics/MetricRegistry.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/MetricRegistry.java
@@ -115,58 +115,63 @@ public abstract class MetricRegistry {
     /**
      * Given a {@link Metric}, registers it under a {@link MetricID} with the given name and with no tags.
      * A {@link Metadata} object will be registered with the name and type.
-     * However, if a {@link Metadata} object is already registered with this metric name and is not equal to the created {@link Metadata} object then an exception will be thrown.
+     * However, if a {@link Metadata} object is already registered with this metric name and is not equal
+     * to the created {@link Metadata} object then an exception will be thrown.
      *
      * @param name the name of the metric
      * @param metric the metric
      * @param <T> the type of the metric
      * @return {@code metric}
-     * @throws IllegalArgumentException if the name is already registered or if Metadata with different values has already been registered with the name
+     * @throws IllegalArgumentException if the name is already registered or if Metadata with different
+     *             values has already been registered with the name
      */
     public abstract <T extends Metric> T register(String name, T metric) throws IllegalArgumentException;
 
     /**
-     * Given a {@link Metric} and {@link Metadata}, registers the metric with a {@link MetricID} with the name provided by the {@link Metadata}
-     * and with no tags.
+     * Given a {@link Metric} and {@link Metadata}, registers the metric with a {@link MetricID} with the
+     * name provided by the {@link Metadata} and with no tags.
      * <p>
-     * Note: If a {@link Metadata} object is already registered under this metric name and is not equal to the provided {@link Metadata} object then
-     * an exception will be thrown.
+     * Note: If a {@link Metadata} object is already registered under this metric name and is not equal
+     * to the provided {@link Metadata} object then an exception will be thrown.
      * </p>
      *
      * @param metadata the metadata
      * @param metric the metric
      * @param <T> the type of the metric
      * @return {@code metric}
-     * @throws IllegalArgumentException if the name is already registered or if Metadata with different values has already been registered with the name
+     * @throws IllegalArgumentException if the name is already registered or if Metadata with different
+     *             values has already been registered with the name
      *
      * @since 1.1
      */
     public abstract <T extends Metric> T register(Metadata metadata, T metric) throws IllegalArgumentException;
 
     /**
-     * Given a {@link Metric} and {@link Metadata}, registers both under a {@link MetricID} with the name provided by the {@link Metadata}
-     * and with the provided tags.
+     * Given a {@link Metric} and {@link Metadata}, registers both under a {@link MetricID} with the
+     * name provided by the {@link Metadata} and with the provided {@link Tag}s.
      * <p>
-     * Note: If a {@link Metadata} object is already registered under this metric name and is not equal to the provided {@link Metadata} object then
-     * an exception will be thrown.
+     * Note: If a {@link Metadata} object is already registered under this metric name and is not equal
+     * to the provided {@link Metadata} object then an exception will be thrown.
      * </p>
      *
      * @param metadata the metadata
      * @param metric the metric
      * @param <T> the type of the metric
-     * @param tags the tags of the metric in 'key1=value1, key2=value2' format
+     * @param tags the tags of the metric
      * @return {@code metric}
-     * @throws IllegalArgumentException if the name is already registered or if Metadata with different values has already been registered with the name
+     * @throws IllegalArgumentException if the name is already registered or if Metadata with different
+     *             values has already been registered with the name
      *
      * @since 2.0
      */
-    public abstract <T extends Metric> T register(Metadata metadata, T metric, String tags) throws IllegalArgumentException;
+    public abstract <T extends Metric> T register(Metadata metadata, T metric, Tag... tags) throws IllegalArgumentException;
 
     /**
-     * Return the {@link Counter} registered under the {@link MetricID} with this name and with no tags; or create and register
-     * a new {@link Counter} if none is registered.
-     * If a {@link Counter} was created, a {@link Metadata} object will be registered with the name and type.
-     * However, if a {@link Metadata} object is already registered with this metric name and is not equal to the created {@link Metadata} object then an exception will be thrown.
+     * Return the {@link Counter} registered under the {@link MetricID} with this name and with no tags;
+     * or create and register a new {@link Counter} if none is registered. If a {@link Counter} was created,
+     * a {@link Metadata} object will be registered with the name and type. However, if a {@link Metadata}
+     * object is already registered with this metric name and is not equal to the created {@link Metadata}
+     * object then an exception will be thrown.
      *
      * @param name the name of the metric
      * @return a new or pre-existing {@link Counter}
@@ -174,26 +179,27 @@ public abstract class MetricRegistry {
     public abstract Counter counter(String name);
 
     /**
-     * Return the {@link Counter} registered under the {@link MetricID} with this name and with the provided tags; or create and register
-     * a new {@link Counter} if none is registered.
-     * If a {@link Counter} was created, a {@link Metadata} object will be registered with the name and type.
-     * However, if a {@link Metadata} object is already registered with this metric name and is not equal to the created {@link Metadata} object then an exception will be thrown.
+     * Return the {@link Counter} registered under the {@link MetricID} with this name and with the provided
+     * {@link Tag}s; or create and register a new {@link Counter} if none is registered. If a {@link Counter} was
+     * created, a {@link Metadata} object will be registered with the name and type.
+     * However, if a {@link Metadata} object is already registered with this metric name and is not equal
+     * to the created {@link Metadata} object then an exception will be thrown.
      *
      * @param name the name of the metric
-     * @param tags the tags of the metric in 'key1=value1, key2=value2' format
+     * @param tags the tags of the metric
      * @return a new or pre-existing {@link Counter}
      *
      * @since 2.0
      */
-    public abstract Counter counter(String name, String tags);
+    public abstract Counter counter(String name, Tag... tags);
 
     /**
-     * Return the {@link Counter} registered under the {@link MetricID} with the {@link Metadata}'s name and with no tags; or create and register
-     * a new {@link Counter} if none is registered.
-     * If a {@link Counter} was created, the provided {@link Metadata} object will be registered.
+     * Return the {@link Counter} registered under the {@link MetricID} with the {@link Metadata}'s name and
+     * with no tags; or create and register a new {@link Counter} if none is registered. If a {@link Counter}
+     * was created, the provided {@link Metadata} object will be registered.
      * <p>
-     * Note: During retrieval or creation, if a {@link Metadata} object is already registered under this metric name and is not equal to the provided {@link Metadata} object then
-     * an exception will be thrown.
+     * Note: During retrieval or creation, if a {@link Metadata} object is already registered under this
+     * metric name and is not equal to the provided {@link Metadata} object then an exception will be thrown.
      * </p>
      *
      * @param metadata the name of the metric
@@ -202,27 +208,28 @@ public abstract class MetricRegistry {
     public abstract Counter counter(Metadata metadata);
 
     /**
-     * Return the {@link Counter} registered under the {@link MetricID} with the {@link Metadata}'s name and with the provided tags; or create and register
-     * a new {@link Counter} if none is registered.
+     * Return the {@link Counter} registered under the {@link MetricID} with the {@link Metadata}'s name and
+     * with the provided {@link Tag}s; or create and register a new {@link Counter} if none is registered.
      * If a {@link Counter} was created, the provided {@link Metadata} object will be registered.
      * <p>
-     * Note: During retrieval or creation, if a {@link Metadata} object is already registered under this metric name and is not equal to the provided {@link Metadata} object then
-     * an exception will be thrown.
+     * Note: During retrieval or creation, if a {@link Metadata} object is already registered under this
+     * metric name and is not equal to the provided {@link Metadata} object then an exception will be thrown.
      * </p>
      *
      * @param metadata the name of the metric
-     * @param tags the tags of the metric in 'key1=value1, key2=value2' format
+     * @param tags the tags of the metric
      * @return a new or pre-existing {@link Counter}
      *
      * @since 2.0
      */
-    public abstract Counter counter(Metadata metadata, String tags);
+    public abstract Counter counter(Metadata metadata, Tag... tags);
 
     /**
-     * Return the {@link Histogram} registered under the {@link MetricID} with this name and with no tags; or create and register
-     * a new {@link Histogram} if none is registered.
-     * If a {@link Histogram} was created, a {@link Metadata} object will be registered with the name and type.
-     * However, if a {@link Metadata} object is already registered with this metric name and is not equal to the created {@link Metadata} object then an exception will be thrown.
+     * Return the {@link Histogram} registered under the {@link MetricID} with this name and with no tags;
+     * or create and register a new {@link Histogram} if none is registered. If a {@link Histogram} was
+     * created, a {@link Metadata} object will be registered with the name and type.
+     * However, if a {@link Metadata} object is already registered with this metric name and is not equal
+     * to the created {@link Metadata} object then an exception will be thrown.
      *
      * @param name the name of the metric
      * @return a new or pre-existing {@link Histogram}
@@ -230,26 +237,28 @@ public abstract class MetricRegistry {
     public abstract Histogram histogram(String name);
 
     /**
-     * Return the {@link Histogram} registered under the {@link MetricID} with this name and with the provided tags; or create and register
-     * a new {@link Histogram} if none is registered.
-     * If a {@link Histogram} was created, a {@link Metadata} object will be registered with the name and type.
-     * However, if a {@link Metadata} object is already registered with this metric name and is not equal to the created {@link Metadata} object then an exception will be thrown.
+     * Return the {@link Histogram} registered under the {@link MetricID} with this name and with the
+     * provided {@link Tag}s; or create and register a new {@link Histogram} if none is registered.
+     * If a {@link Histogram} was created, a {@link Metadata} object will be registered with the name
+     * and type. However, if a {@link Metadata} object is already registered with this metric name and
+     * is not equal to the created {@link Metadata} object then an exception will be thrown.
      *
      * @param name the name of the metric
-     * @param tags the tags of the metric in 'key1=value1, key2=value2' format
+     * @param tags the tags of the metric
      * @return a new or pre-existing {@link Histogram}
      *
      * @since 2.0
      */
-    public abstract Histogram histogram(String name, String tags);
+    public abstract Histogram histogram(String name, Tag... tags);
 
     /**
-     * Return the {@link Histogram} registered under the {@link MetricID} with the {@link Metadata}'s name and with no tags; or create and register
-     * a new {@link Histogram} if none is registered.
+     * Return the {@link Histogram} registered under the {@link MetricID} with the {@link Metadata}'s
+     * name and with no tags; or create and register a new {@link Histogram} if none is registered.
      * If a {@link Histogram} was created, the provided {@link Metadata} object will be registered.
      * <p>
-     * Note: During retrieval or creation, if a {@link Metadata} object is already registered under this metric name and is not equal to the provided {@link Metadata} object then
-     * an exception will be thrown.
+     * Note: During retrieval or creation, if a {@link Metadata} object is already registered under
+     * this metric name and is not equal to the provided {@link Metadata} object then an exception
+     * will be thrown.
      * </p>
      *
      * @param metadata the name of the metric
@@ -258,27 +267,28 @@ public abstract class MetricRegistry {
     public abstract Histogram histogram(Metadata metadata);
 
     /**
-     * Return the {@link Histogram} registered under the {@link MetricID} with the {@link Metadata}'s name and with the provided tags; or create and register
-     * a new {@link Histogram} if none is registered.
+     * Return the {@link Histogram} registered under the {@link MetricID} with the {@link Metadata}'s
+     * name and with the provided {@link Tag}s; or create and register a new {@link Histogram} if none is registered.
      * If a {@link Histogram} was created, the provided {@link Metadata} object will be registered.
      * <p>
-     * Note: During retrieval or creation, if a {@link Metadata} object is already registered under this metric name and is not equal to the provided {@link Metadata} object then
-     * an exception will be thrown.
+     * Note: During retrieval or creation, if a {@link Metadata} object is already registered under
+     * this metric name and is not equal to the provided {@link Metadata} object then an exception will be thrown.
      * </p>
      *
      * @param metadata the name of the metric
-     * @param tags the tags of the metric in 'key1=value1, key2=value2' format
+     * @param tags the tags of the metric
      * @return a new or pre-existing {@link Histogram}
      *
      * @since 2.0
      */
-    public abstract Histogram histogram(Metadata metadata, String tags);
+    public abstract Histogram histogram(Metadata metadata, Tag... tags);
 
     /**
-     * Return the {@link Meter} registered under the {@link MetricID} with this name and with no tags; or create and register
-     * a new {@link Meter} if none is registered.
-     * If a {@link Meter} was created, a {@link Metadata} object will be registered with the name and type.
-     * However, if a {@link Metadata} object is already registered with this metric name and is not equal to the created {@link Metadata} object then an exception will be thrown.
+     * Return the {@link Meter} registered under the {@link MetricID} with this name and with no tags; or
+     * create and register a new {@link Meter} if none is registered. If a {@link Meter} was created, a
+     * {@link Metadata} object will be registered with the name and type.
+     * However, if a {@link Metadata} object is already registered with this metric name and is not equal
+     * to the created {@link Metadata} object then an exception will be thrown.
      *
      * @param name the name of the metric
      * @return a new or pre-existing {@link Meter}
@@ -286,26 +296,27 @@ public abstract class MetricRegistry {
     public abstract Meter meter(String name);
 
     /**
-     * Return the {@link Meter} registered under the {@link MetricID} with this name and with the provided tags; or create and register
-     * a new {@link Meter} if none is registered.
-     * If a {@link Meter} was created, a {@link Metadata} object will be registered with the name and type.
-     * However, if a {@link Metadata} object is already registered with this metric name and is not equal to the created {@link Metadata} object then an exception will be thrown.
+     * Return the {@link Meter} registered under the {@link MetricID} with this name and with the provided {@link Tag}s;
+     * or create and register a new {@link Meter} if none is registered. If a {@link Meter} was created,
+     * a {@link Metadata} object will be registered with the name and type. However, if a {@link Metadata} object
+     * is already registered with this metric name and is not equal to the created {@link Metadata} object
+     * then an exception will be thrown.
      *
      * @param name the name of the metric
-     * @param tags the tags of the metric in 'key1=value1, key2=value2' format
+     * @param tags the tags of the metric
      * @return a new or pre-existing {@link Meter}
      *
      * @since 2.0
      */
-    public abstract Meter meter(String name, String tags);
+    public abstract Meter meter(String name, Tag... tags);
 
     /**
-     * Return the {@link Meter} registered under the {@link MetricID} with the {@link Metadata}'s name and with no tags; or create and register
-     * a new {@link Meter} if none is registered.
-     * If a {@link Meter} was created, the provided {@link Metadata} object will be registered.
+     * Return the {@link Meter} registered under the {@link MetricID} with the {@link Metadata}'s name and with
+     * no tags; or create and register a new {@link Meter} if none is registered. If a {@link Meter} was created,
+     * the provided {@link Metadata} object will be registered.
      * <p>
-     * Note: During retrieval or creation, if a {@link Metadata} object is already registered under this metric name and is not equal to the provided {@link Metadata} object then
-     * an exception will be thrown.
+     * Note: During retrieval or creation, if a {@link Metadata} object is already registered under this metric
+     * name and is not equal to the provided {@link Metadata} object then an exception will be thrown.
      * </p>
      *
      * @param metadata the name of the metric
@@ -314,27 +325,27 @@ public abstract class MetricRegistry {
     public abstract Meter meter(Metadata metadata);
 
     /**
-     * Return the {@link Meter} registered under the {@link MetricID} with the {@link Metadata}'s name and with the provided tags; or create and register
-     * a new {@link Meter} if none is registered.
-     * If a {@link Meter} was created, the provided {@link Metadata} object will be registered.
+     * Return the {@link Meter} registered under the {@link MetricID} with the {@link Metadata}'s name and with
+     * the provided {@link Tag}s; or create and register a new {@link Meter} if none is registered. If a {@link Meter} was
+     * created, the provided {@link Metadata} object will be registered.
      * <p>
-     * Note: During retrieval or creation, if a {@link Metadata} object is already registered under this metric name and is not equal to the provided {@link Metadata} object then
-     * an exception will be thrown.
+     * Note: During retrieval or creation, if a {@link Metadata} object is already registered under this metric name
+     * and is not equal to the provided {@link Metadata} object then an exception will be thrown.
      * </p>
      *
      * @param metadata the name of the metric
-     * @param tags the tags of the metric in 'key1=value1, key2=value2' format
+     * @param tags the tags of the metric
      * @return a new or pre-existing {@link Meter}
      *
      * @since 2.0
      */
-    public abstract Meter meter(Metadata metadata, String tags);
+    public abstract Meter meter(Metadata metadata, Tag... tags);
 
     /**
-     * Return the {@link Timer} registered under the {@link MetricID} with this name and with no tags; or create and register
-     * a new {@link Timer} if none is registered.
-     * If a {@link Timer} was created, a {@link Metadata} object will be registered with the name and type.
-     * However, if a {@link Metadata} object is already registered with this metric name and is not equal to the created {@link Metadata} object then an exception will be thrown.
+     * Return the {@link Timer} registered under the {@link MetricID} with this name and with no tags; or create
+     * and register a new {@link Timer} if none is registered. If a {@link Timer} was created, a {@link Metadata}
+     * object will be registered with the name and type. However, if a {@link Metadata} object is already registered
+     * with this metric name and is not equal to the created {@link Metadata} object then an exception will be thrown.
      *
      * @param name the name of the metric
      * @return a new or pre-existing {@link Timer}
@@ -342,26 +353,27 @@ public abstract class MetricRegistry {
     public abstract Timer timer(String name);
 
     /**
-     * Return the {@link Timer} registered under the {@link MetricID} with this name and with the provided tags; or create and register
-     * a new {@link Timer} if none is registered.
-     * If a {@link Timer} was created, a {@link Metadata} object will be registered with the name and type.
-     * However, if a {@link Metadata} object is already registered with this metric name and is not equal to the created {@link Metadata} object then an exception will be thrown.
+     * Return the {@link Timer} registered under the {@link MetricID} with this name and with the provided {@link Tag}s;
+     * or create and register a new {@link Timer} if none is registered. If a {@link Timer} was created, a
+     * {@link Metadata} object will be registered with the name and type. However, if a {@link Metadata} object
+     * is already registered with this metric name and is not equal to the created {@link Metadata} object
+     * then an exception will be thrown.
      *
      * @param name the name of the metric
-     * @param tags the tags of the metric in 'key1=value1, key2=value2' format
+     * @param tags the tags of the metric
      * @return a new or pre-existing {@link Timer}
      *
      * @since 2.0
      */
-    public abstract Timer timer(String name, String tags);
+    public abstract Timer timer(String name, Tag... tags);
 
     /**
-     * Return the {@link Timer} registered under the the {@link MetricID} with the {@link Metadata}'s name and with no tags; or create and register
-     * a new {@link Timer} if none is registered.
-     * If a {@link Timer} was created, the provided {@link Metadata} object will be registered.
+     * Return the {@link Timer} registered under the the {@link MetricID} with the {@link Metadata}'s name and
+     * with no tags; or create and register a new {@link Timer} if none is registered. If a {@link Timer} was
+     * created, the provided {@link Metadata} object will be registered.
      * <p>
-     * Note: During retrieval or creation, if a {@link Metadata} object is already registered under this metric name and is not equal to the provided {@link Metadata} object then
-     * an exception will be thrown.
+     * Note: During retrieval or creation, if a {@link Metadata} object is already registered under this metric
+     * name and is not equal to the provided {@link Metadata} object then an exception will be thrown.
      * </p>
      *
      * @param metadata the name of the metric
@@ -370,21 +382,21 @@ public abstract class MetricRegistry {
     public abstract Timer timer(Metadata metadata);
 
     /**
-     * Return the {@link Timer} registered under the the {@link MetricID} with the {@link Metadata}'s name and with the provided tags; or create and register
-     * a new {@link Timer} if none is registered.
+     * Return the {@link Timer} registered under the the {@link MetricID} with the {@link Metadata}'s name and
+     * with the provided {@link Tag}s; or create and register a new {@link Timer} if none is registered.
      * If a {@link Timer} was created, the provided {@link Metadata} object will be registered.
      * <p>
-     * Note: During retrieval or creation, if a {@link Metadata} object is already registered under this metric name and is not equal to the provided {@link Metadata} object then
-     * an exception will be thrown.
+     * Note: During retrieval or creation, if a {@link Metadata} object is already registered under this metric
+     * name and is not equal to the provided {@link Metadata} object then an exception will be thrown.
      * </p>
      *
      * @param metadata the name of the metric
-     * @param tags the tags of the metric in 'key1=value1, key2=value2' format
+     * @param tags the tags of the metric
      * @return a new or pre-existing {@link Timer}
      *
      * @since 2.0
      */
-    public abstract Timer timer(Metadata metadata, String tags);
+    public abstract Timer timer(Metadata metadata, Tag... tags);
 
     /**
      * Removes all metrics with the given name.
@@ -402,7 +414,7 @@ public abstract class MetricRegistry {
      *
      * @since 2.0
      */
-    public abstract boolean remove(MetricID MetricID);
+    public abstract boolean remove(MetricID metricID);
 
     /**
      * Removes all metrics which match the given filter.

--- a/api/src/main/java/org/eclipse/microprofile/metrics/MetricRegistry.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/MetricRegistry.java
@@ -1,7 +1,7 @@
 /*
  **********************************************************************
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
- *               2010-2013 Coda Hale, Yammer.com
+ * Copyright (c) 2017, 2018 Contributors to the Eclipse Foundation
+ *               2010, 2013 Coda Hale, Yammer.com
  *
  * See the NOTICES file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -57,7 +57,7 @@ public abstract class MetricRegistry {
          */
         VENDOR("vendor");
 
-        private String name;
+        private final String name;
 
         Type(String name) {
             this.name = name;
@@ -65,6 +65,7 @@ public abstract class MetricRegistry {
 
         /**
          * Returns the name of the MetricRegistry scope.
+         *
          * @return the scope
          */
         public String getName() {
@@ -75,8 +76,8 @@ public abstract class MetricRegistry {
     /**
      * Concatenates elements to form a dotted name, eliding any null values or empty strings.
      *
-     * @param name     the first element of the name
-     * @param names    the remaining elements of the name
+     * @param name the first element of the name
+     * @param names the remaining elements of the name
      * @return {@code name} and {@code names} concatenated by periods
      */
     public static String name(String name, String... names) {
@@ -103,8 +104,8 @@ public abstract class MetricRegistry {
      * Concatenates a class name and elements to form a dotted name, eliding any null values or
      * empty strings.
      *
-     * @param klass    the first element of the name
-     * @param names    the remaining elements of the name
+     * @param klass the first element of the name
+     * @param names the remaining elements of the name
      * @return {@code klass} and {@code names} concatenated by periods
      */
     public static String name(Class<?> klass, String... names) {
@@ -112,24 +113,24 @@ public abstract class MetricRegistry {
     }
 
     /**
-     * Given a {@link Metric}, registers it under the given name.
-     * A {@link Metadata} object will be registered with the name and type.
+     * Given a {@link Metric}, registers it under a {@link MetricID} with the given name and with no tags.
+     * A {@link Metadata} object will be registered with the name and type under the same {@link MetricID}.
      *
-     * @param name   the name of the metric
+     * @param name the name of the metric
      * @param metric the metric
-     * @param <T>    the type of the metric
+     * @param <T> the type of the metric
      * @return {@code metric}
      * @throws IllegalArgumentException if the name is already registered
      */
     public abstract <T extends Metric> T register(String name, T metric) throws IllegalArgumentException;
 
-
     /**
-     * Given a {@link Metric}, registers it under the provided {@link Metadata}.
+     * Given a {@link Metric} and {@link Metadata}, registers both under a {@link MetricID} with the name provided by the {@link Metadata}
+     * and with no tags.
      *
-     * @param metadata  the metadata
-     * @param metric    the metric
-     * @param <T>       the type of the metric
+     * @param metadata the metadata
+     * @param metric the metric
+     * @param <T> the type of the metric
      * @return {@code metric}
      * @throws IllegalArgumentException if the name is already registered
      *
@@ -137,9 +138,23 @@ public abstract class MetricRegistry {
      */
     public abstract <T extends Metric> T register(Metadata metadata, T metric) throws IllegalArgumentException;
 
+    /**
+     * Given a {@link Metric} and {@link Metadata}, registers both under a {@link MetricID} with the name provided by the {@link Metadata}
+     * and with the provided tags.
+     *
+     * @param metadata the metadata
+     * @param metric the metric
+     * @param <T> the type of the metric
+     * @param tags the tags of the metric
+     * @return {@code metric}
+     * @throws IllegalArgumentException if the name is already registered
+     *
+     * @since 2.0
+     */
+    public abstract <T extends Metric> T register(Metadata metadata, T metric, String tags) throws IllegalArgumentException;
 
     /**
-     * Return the {@link Counter} registered under this name; or create and register
+     * Return the {@link Counter} registered under the {@link MetricID} with this name and with no tags; or create and register
      * a new {@link Counter} if none is registered.
      * If a {@link Counter} was created, a {@link Metadata} object will be registered with the name and type.
      *
@@ -149,7 +164,7 @@ public abstract class MetricRegistry {
     public abstract Counter counter(String name);
 
     /**
-     * Return the {@link Counter} registered under the {@link Metadata}'s name; or create and register
+     * Return the {@link Counter} registered under the {@link MetricID} with the {@link Metadata}'s name and with no tags; or create and register
      * a new {@link Counter} if none is registered.
      * If a {@link Counter} was created, the provided {@link Metadata} object will be registered.
      * <p>
@@ -161,12 +176,24 @@ public abstract class MetricRegistry {
      */
     public abstract Counter counter(Metadata metadata);
 
-
+    /**
+     * Return the {@link Counter} registered under the {@link MetricID} with the {@link Metadata}'s name and with the provided tags; or create and register
+     * a new {@link Counter} if none is registered.
+     * If a {@link Counter} was created, the provided {@link Metadata} object will be registered.
+     * <p>
+     * Note: The {@link Metadata} will not be updated if the metric is already registered.
+     * </p>
+     *
+     * @param metadata the name of the metric
+     * @param tags the tags of the metric
+     * @return a new or pre-existing {@link Counter}
+     */
+    public abstract Counter counter(Metadata metadata, String tags);
 
     /**
-     * Return the {@link Histogram} registered under this name; or create and register
+     * Return the {@link Histogram} registered under the {@link MetricID} with this name and with no tags; or create and register
      * a new {@link Histogram} if none is registered.
-     * If a {@link Histogram} was created, a {@link Metadata}  object will be registered with the name and type.
+     * If a {@link Histogram} was created, a {@link Metadata} object will be registered with the name and type.
      *
      * @param name the name of the metric
      * @return a new or pre-existing {@link Histogram}
@@ -174,7 +201,7 @@ public abstract class MetricRegistry {
     public abstract Histogram histogram(String name);
 
     /**
-     * Return the {@link Histogram} registered under the {@link Metadata}'s name; or create and register
+     * Return the {@link Histogram} registered under the {@link MetricID} with the {@link Metadata}'s name and with no tags; or create and register
      * a new {@link Histogram} if none is registered.
      * If a {@link Histogram} was created, the provided {@link Metadata} object will be registered.
      * <p>
@@ -186,11 +213,24 @@ public abstract class MetricRegistry {
      */
     public abstract Histogram histogram(Metadata metadata);
 
+    /**
+     * Return the {@link Histogram} registered under the {@link MetricID} with the {@link Metadata}'s name and with the provided tags; or create and register
+     * a new {@link Histogram} if none is registered.
+     * If a {@link Histogram} was created, the provided {@link Metadata} object will be registered.
+     * <p>
+     * Note: The {@link Metadata} will not be updated if the metric is already registered.
+     * </p>
+     *
+     * @param metadata the name of the metric
+     * @param metadata the tags of the metric
+     * @return a new or pre-existing {@link Histogram}
+     */
+    public abstract Histogram histogram(Metadata metadata, String tags);
 
     /**
-     * Return the {@link Meter} registered under this name; or create and register
+     * Return the {@link Meter} registered under the {@link MetricID} with this name and with no tags; or create and register
      * a new {@link Meter} if none is registered.
-     * If a {@link Meter} was created, a {@link Metadata}  object will be registered with the name and type.
+     * If a {@link Meter} was created, a {@link Metadata} object will be registered with the name and type.
      *
      * @param name the name of the metric
      * @return a new or pre-existing {@link Meter}
@@ -198,7 +238,7 @@ public abstract class MetricRegistry {
     public abstract Meter meter(String name);
 
     /**
-     * Return the {@link Meter} registered under the {@link Metadata}'s name; or create and register
+     * Return the {@link Meter} registered under the {@link MetricID} with the {@link Metadata}'s name and with no tags; or create and register
      * a new {@link Meter} if none is registered.
      * If a {@link Meter} was created, the provided {@link Metadata} object will be registered.
      * <p>
@@ -210,11 +250,24 @@ public abstract class MetricRegistry {
      */
     public abstract Meter meter(Metadata metadata);
 
+    /**
+     * Return the {@link Meter} registered under the {@link MetricID} with the {@link Metadata}'s name and with the provided tags; or create and register
+     * a new {@link Meter} if none is registered.
+     * If a {@link Meter} was created, the provided {@link Metadata} object will be registered.
+     * <p>
+     * Note: The {@link Metadata} will not be updated if the metric is already registered.
+     * </p>
+     *
+     * @param metadata the name of the metric
+     * @param metadata the tags of the metric
+     * @return a new or pre-existing {@link Meter}
+     */
+    public abstract Meter meter(Metadata metadata, String tags);
 
     /**
-     * Return the {@link Timer} registered under this name; or create and register
+     * Return the {@link Timer} registered under the {@link MetricID} with this name and with no tags; or create and register
      * a new {@link Timer} if none is registered.
-     * If a {@link Timer} was created, a {@link Metadata}  object will be registered with the name and type.
+     * If a {@link Timer} was created, a {@link Metadata} object will be registered with the name and type.
      *
      * @param name the name of the metric
      * @return a new or pre-existing {@link Timer}
@@ -222,7 +275,7 @@ public abstract class MetricRegistry {
     public abstract Timer timer(String name);
 
     /**
-     * Return the {@link Timer} registered under the {@link Metadata}'s name; or create and register
+     * Return the {@link Timer} registered under the the {@link MetricID} with the {@link Metadata}'s name and with no tags; or create and register
      * a new {@link Timer} if none is registered.
      * If a {@link Timer} was created, the provided {@link Metadata} object will be registered.
      * <p>
@@ -234,10 +287,22 @@ public abstract class MetricRegistry {
      */
     public abstract Timer timer(Metadata metadata);
 
-
+    /**
+     * Return the {@link Timer} registered under the the {@link MetricID} with the {@link Metadata}'s name and with the provided tags; or create and register
+     * a new {@link Timer} if none is registered.
+     * If a {@link Timer} was created, the provided {@link Metadata} object will be registered.
+     * <p>
+     * Note: The {@link Metadata} will not be updated if the metric is already registered.
+     * </p>
+     *
+     * @param metadata the name of the metric
+     * @param tags the tags of the metric
+     * @return a new or pre-existing {@link Timer}
+     */
+    public abstract Timer timer(Metadata metadata, String tags);
 
     /**
-     * Removes the metric with the given name.
+     * Removes all metrics with the given name.
      *
      * @param name the name of the metric
      * @return whether or not the metric was removed
@@ -245,12 +310,19 @@ public abstract class MetricRegistry {
     public abstract boolean remove(String name);
 
     /**
+     * Removes the metric with the given MetricID
+     *
+     * @param MetricID the MetricID of the metric
+     * @return whether or not the metric was removed
+     */
+    public abstract boolean remove(MetricID MetricID);
+
+    /**
      * Removes all metrics which match the given filter.
      *
      * @param filter a filter
      */
     public abstract void removeMatching(MetricFilter filter);
-
 
     /**
      * Returns a set of the names of all the metrics in the registry.
@@ -260,94 +332,101 @@ public abstract class MetricRegistry {
     public abstract SortedSet<String> getNames();
 
     /**
-     * Returns a map of all the gauges in the registry and their names.
+     * Returns a set of the {@link MetricID}s of all the metrics in the registry.
+     *
+     * @return the MetricIDs of all the metrics
+     */
+    public abstract SortedSet<MetricID> getMetricIDs();
+
+    /**
+     * Returns a map of all the gauges in the registry and their {@link MetricID}s.
      *
      * @return all the gauges in the registry
      */
-    public abstract SortedMap<String, Gauge> getGauges();
+    public abstract SortedMap<MetricID, Gauge> getGauges();
 
     /**
-     * Returns a map of all the gauges in the registry and their names which match the given filter.
+     * Returns a map of all the gauges in the registry and their {@link MetricID}s which match the given filter.
      *
-     * @param filter    the metric filter to match
+     * @param filter the metric filter to match
      * @return all the gauges in the registry
      */
-    public abstract SortedMap<String, Gauge> getGauges(MetricFilter filter);
+    public abstract SortedMap<MetricID, Gauge> getGauges(MetricFilter filter);
 
     /**
-     * Returns a map of all the counters in the registry and their names.
+     * Returns a map of all the counters in the registry and their {@link MetricID}s.
      *
      * @return all the counters in the registry
      */
-    public abstract SortedMap<String, Counter> getCounters();
+    public abstract SortedMap<MetricID, Counter> getCounters();
 
     /**
-     * Returns a map of all the counters in the registry and their names which match the given
+     * Returns a map of all the counters in the registry and their {@link MetricID}s which match the given
      * filter.
      *
-     * @param filter    the metric filter to match
+     * @param filter the metric filter to match
      * @return all the counters in the registry
      */
-    public abstract SortedMap<String, Counter> getCounters(MetricFilter filter);
+    public abstract SortedMap<MetricID, Counter> getCounters(MetricFilter filter);
 
     /**
-     * Returns a map of all the histograms in the registry and their names.
+     * Returns a map of all the histograms in the registry and their {@link MetricID}s.
      *
      * @return all the histograms in the registry
      */
-    public abstract SortedMap<String, Histogram> getHistograms();
+    public abstract SortedMap<MetricID, Histogram> getHistograms();
 
     /**
-     * Returns a map of all the histograms in the registry and their names which match the given
+     * Returns a map of all the histograms in the registry and their {@link MetricID}s which match the given
      * filter.
      *
-     * @param filter    the metric filter to match
+     * @param filter the metric filter to match
      * @return all the histograms in the registry
      */
-    public abstract SortedMap<String, Histogram> getHistograms(MetricFilter filter);
+    public abstract SortedMap<MetricID, Histogram> getHistograms(MetricFilter filter);
 
     /**
-     * Returns a map of all the meters in the registry and their names.
+     * Returns a map of all the meters in the registry and their {@link MetricID}s.
      *
      * @return all the meters in the registry
      */
-    public abstract SortedMap<String, Meter> getMeters();
+    public abstract SortedMap<MetricID, Meter> getMeters();
 
     /**
-     * Returns a map of all the meters in the registry and their names which match the given filter.
+     * Returns a map of all the meters in the registry and their {@link MetricID}s which match the given filter.
      *
-     * @param filter    the metric filter to match
+     * @param filter the metric filter to match
      * @return all the meters in the registry
      */
-    public abstract SortedMap<String, Meter> getMeters(MetricFilter filter);
+    public abstract SortedMap<MetricID, Meter> getMeters(MetricFilter filter);
 
     /**
-     * Returns a map of all the timers in the registry and their names.
+     * Returns a map of all the timers in the registry and their {@link MetricID}s.
      *
      * @return all the timers in the registry
      */
-    public abstract SortedMap<String, Timer> getTimers();
+    public abstract SortedMap<MetricID, Timer> getTimers();
 
     /**
-     * Returns a map of all the timers in the registry and their names which match the given filter.
+     * Returns a map of all the timers in the registry and their {@link MetricID}s which match the given filter.
      *
-     * @param filter    the metric filter to match
+     * @param filter the metric filter to match
      * @return all the timers in the registry
      */
-    public abstract SortedMap<String, Timer> getTimers(MetricFilter filter);
+    public abstract SortedMap<MetricID, Timer> getTimers(MetricFilter filter);
 
     /**
-     * Returns a map of all the metrics in the registry and their names.
+     * Returns a map of all the metrics in the registry and their {@link MetricID}s.
      *
      * @return all the metrics in the registry
      */
-    public abstract Map<String, Metric> getMetrics();
+    public abstract Map<MetricID, Metric> getMetrics();
 
     /**
-     * Returns a map of all the metadata in the registry and their names.
+     * Returns a map of all the metadata in the registry and their {@link MetricID}s.
      *
      * @return all the metadata in the registry
      */
-    public abstract Map<String, Metadata> getMetadata();
+    public abstract Map<MetricID, Metadata> getMetadata();
 
 }

--- a/api/src/main/java/org/eclipse/microprofile/metrics/MetricRegistry.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/MetricRegistry.java
@@ -168,10 +168,11 @@ public abstract class MetricRegistry {
 
     /**
      * Return the {@link Counter} registered under the {@link MetricID} with this name and with no tags;
-     * or create and register a new {@link Counter} if none is registered. If a {@link Counter} was created,
-     * a {@link Metadata} object will be registered with the name and type. However, if a {@link Metadata}
-     * object is already registered with this metric name and is not equal to the created {@link Metadata}
-     * object then an exception will be thrown.
+     * or create and register a new {@link Counter} if none is registered. 
+     * 
+     * If a {@link Counter} was created, a {@link Metadata} object will be registered with the name
+     * and type. If a {@link Metadata} object is already registered with this metric name then that
+     * {@link Metadata} will be used.
      *
      * @param name the name of the metric
      * @return a new or pre-existing {@link Counter}
@@ -180,10 +181,11 @@ public abstract class MetricRegistry {
 
     /**
      * Return the {@link Counter} registered under the {@link MetricID} with this name and with the provided
-     * {@link Tag}s; or create and register a new {@link Counter} if none is registered. If a {@link Counter} was
-     * created, a {@link Metadata} object will be registered with the name and type.
-     * However, if a {@link Metadata} object is already registered with this metric name and is not equal
-     * to the created {@link Metadata} object then an exception will be thrown.
+     * {@link Tag}s; or create and register a new {@link Counter} if none is registered. 
+     * 
+     * If a {@link Counter} was created, a {@link Metadata} object will be registered with the name
+     * and type. If a {@link Metadata} object is already registered with this metric name then that
+     * {@link Metadata} will be used.
      *
      * @param name the name of the metric
      * @param tags the tags of the metric
@@ -226,10 +228,11 @@ public abstract class MetricRegistry {
 
     /**
      * Return the {@link Histogram} registered under the {@link MetricID} with this name and with no tags;
-     * or create and register a new {@link Histogram} if none is registered. If a {@link Histogram} was
-     * created, a {@link Metadata} object will be registered with the name and type.
-     * However, if a {@link Metadata} object is already registered with this metric name and is not equal
-     * to the created {@link Metadata} object then an exception will be thrown.
+     * or create and register a new {@link Histogram} if none is registered. 
+     * 
+     * If a {@link Histogram} was created, a {@link Metadata} object will be registered with the name 
+     * and type. If a {@link Metadata} object is already registered with this metric name then that
+     * {@link Metadata} will be used.
      *
      * @param name the name of the metric
      * @return a new or pre-existing {@link Histogram}
@@ -239,9 +242,10 @@ public abstract class MetricRegistry {
     /**
      * Return the {@link Histogram} registered under the {@link MetricID} with this name and with the
      * provided {@link Tag}s; or create and register a new {@link Histogram} if none is registered.
+     * 
      * If a {@link Histogram} was created, a {@link Metadata} object will be registered with the name
-     * and type. However, if a {@link Metadata} object is already registered with this metric name and
-     * is not equal to the created {@link Metadata} object then an exception will be thrown.
+     * and type. If a {@link Metadata} object is already registered with this metric name then that
+     * {@link Metadata} will be used.
      *
      * @param name the name of the metric
      * @param tags the tags of the metric
@@ -285,10 +289,11 @@ public abstract class MetricRegistry {
 
     /**
      * Return the {@link Meter} registered under the {@link MetricID} with this name and with no tags; or
-     * create and register a new {@link Meter} if none is registered. If a {@link Meter} was created, a
-     * {@link Metadata} object will be registered with the name and type.
-     * However, if a {@link Metadata} object is already registered with this metric name and is not equal
-     * to the created {@link Metadata} object then an exception will be thrown.
+     * create and register a new {@link Meter} if none is registered. 
+     * 
+     * If a {@link Meter} was created, a {@link Metadata} object will be registered with the name
+     * and type. If a {@link Metadata} object is already registered with this metric name then that
+     * {@link Metadata} will be used.
      *
      * @param name the name of the metric
      * @return a new or pre-existing {@link Meter}
@@ -297,10 +302,11 @@ public abstract class MetricRegistry {
 
     /**
      * Return the {@link Meter} registered under the {@link MetricID} with this name and with the provided {@link Tag}s;
-     * or create and register a new {@link Meter} if none is registered. If a {@link Meter} was created,
-     * a {@link Metadata} object will be registered with the name and type. However, if a {@link Metadata} object
-     * is already registered with this metric name and is not equal to the created {@link Metadata} object
-     * then an exception will be thrown.
+     * or create and register a new {@link Meter} if none is registered. 
+     * 
+     * If a {@link Meter} was created, a {@link Metadata} object will be registered with the name
+     * and type. If a {@link Metadata} object is already registered with this metric name then that
+     * {@link Metadata} will be used.
      *
      * @param name the name of the metric
      * @param tags the tags of the metric
@@ -343,10 +349,12 @@ public abstract class MetricRegistry {
 
     /**
      * Return the {@link Timer} registered under the {@link MetricID} with this name and with no tags; or create
-     * and register a new {@link Timer} if none is registered. If a {@link Timer} was created, a {@link Metadata}
-     * object will be registered with the name and type. However, if a {@link Metadata} object is already registered
-     * with this metric name and is not equal to the created {@link Metadata} object then an exception will be thrown.
-     *
+     * and register a new {@link Timer} if none is registered.
+     * 
+     * If a {@link Timer} was created, a {@link Metadata} object will be registered with the name
+     * and type. If a {@link Metadata} object is already registered with this metric name then that
+     * {@link Metadata} will be used.
+     * 
      * @param name the name of the metric
      * @return a new or pre-existing {@link Timer}
      */
@@ -354,10 +362,12 @@ public abstract class MetricRegistry {
 
     /**
      * Return the {@link Timer} registered under the {@link MetricID} with this name and with the provided {@link Tag}s;
-     * or create and register a new {@link Timer} if none is registered. If a {@link Timer} was created, a
-     * {@link Metadata} object will be registered with the name and type. However, if a {@link Metadata} object
-     * is already registered with this metric name and is not equal to the created {@link Metadata} object
-     * then an exception will be thrown.
+     * or create and register a new {@link Timer} if none is registered.
+     * 
+     * If a {@link Timer} was created, a {@link Metadata} object will be registered with the name
+     * and type. If a {@link Metadata} object is already registered with this metric name then that
+     * {@link Metadata} will be used.
+     * 
      *
      * @param name the name of the metric
      * @param tags the tags of the metric

--- a/api/src/main/java/org/eclipse/microprofile/metrics/Tag.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/Tag.java
@@ -1,0 +1,107 @@
+/*
+ **********************************************************************
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *               2018 IBM Corporation and others
+ *               and other contributors as indicated by the @author tags.
+ *
+ * See the NOTICES file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+package org.eclipse.microprofile.metrics;
+
+import java.util.Objects;
+
+/**
+ * Tag represents a singular metric tag key and value pair.
+ *
+ * The Tag contains:
+ * <ul>
+ * <li>
+ * {@code TagName}: (Required) The name of the tag. Must match the regex [a-zA-Z_][a-zA-Z0-9_]*.
+ * </li>
+ * <li>
+ * {@code TagValue}: (Required) The value of the tag.
+ * </li>
+ * <li>
+ *
+ */
+public class Tag {
+
+    /**
+     * Name of the Tag. Must match the regex [a-zA-Z_][a-zA-Z0-9_]*.
+     * <p>
+     * A required field which holds the name of the tag.
+     * </p>
+     */
+    final String tagName;
+
+    /**
+     * Value of the Tag.
+     * <p>
+     * A required field which holds the value of the tag.
+     * </p>
+     */
+    final String tagValue;
+
+    /**
+     * Constructs the Tag object with the given tag name and tag value
+     *
+     * @param tagName The tag name, must match the regex [a-zA-Z_][a-zA-Z0-9_]*.
+     * @param tagValue The tag value
+     * @throws IllegalArgumentException If the tagName does not match [a-zA-Z_][a-zA-Z0-9_]*
+     */
+    public Tag(String tagName, String tagValue) throws IllegalArgumentException {
+        if (!tagName.matches("[a-zA-Z_][a-zA-Z0-9_]*")) {
+            throw new IllegalArgumentException("Invalid Tag name. Tag names must match the following regex [a-zA-Z_][a-zA-Z0-9_]*");
+        }
+        this.tagName = tagName;
+        this.tagValue = tagValue;
+    }
+
+    /**
+     * @return the tagName
+     */
+    public String getTagName() {
+        return tagName;
+    }
+
+    /**
+     * @return the tagValue
+     */
+    public String getTagValue() {
+        return tagValue;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int hashCode() {
+        return Objects.hash(tagName, tagValue);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Tag)) {
+            return false;
+        }
+        Tag that = (Tag) o;
+        return Objects.equals(this.tagName, that.getTagName()) && Objects.equals(this.tagValue, that.getTagValue());
+    }
+}

--- a/api/src/main/java/org/eclipse/microprofile/metrics/Tag.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/Tag.java
@@ -65,7 +65,9 @@ public class Tag {
      * @throws IllegalArgumentException If the tagName does not match [a-zA-Z_][a-zA-Z0-9_]*
      */
     public Tag(String tagName, String tagValue) throws IllegalArgumentException {
-        if (!tagName.matches("[a-zA-Z_][a-zA-Z0-9_]*")) {
+        if (tagName == null ||
+            tagValue == null ||
+            !tagName.matches("[a-zA-Z_][a-zA-Z0-9_]*")) {
             throw new IllegalArgumentException("Invalid Tag name. Tag names must match the following regex [a-zA-Z_][a-zA-Z0-9_]*");
         }
         this.tagName = tagName;

--- a/api/src/main/java/org/eclipse/microprofile/metrics/Tag.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/Tag.java
@@ -36,7 +36,7 @@ import java.util.Objects;
  * <li>
  * {@code TagValue}: (Required) The value of the tag.
  * </li>
- * <li>
+ * </ul>
  *
  */
 public class Tag {
@@ -47,7 +47,7 @@ public class Tag {
      * A required field which holds the name of the tag.
      * </p>
      */
-    final String tagName;
+    private final String tagName;
 
     /**
      * Value of the Tag.
@@ -55,7 +55,7 @@ public class Tag {
      * A required field which holds the value of the tag.
      * </p>
      */
-    final String tagValue;
+    private final String tagValue;
 
     /**
      * Constructs the Tag object with the given tag name and tag value

--- a/spec/src/main/asciidoc/app-programming-model.adoc
+++ b/spec/src/main/asciidoc/app-programming-model.adoc
@@ -57,7 +57,7 @@ in <<rest-api>>.
 * Metrics registered via non-annotations API need their values be set via updates from the application code.
 * The implementation must flag duplicate metrics upon registration and reject the duplicate unless the metric
 is explicitly marked as reusable upon first registration and in all subsequent registrations.
-** A duplicate metric is a metric that has the same scope and name as an existing one.
+** A duplicate metric is a metric that has the same scope, name and tags as an existing one.
 ** The implementation must throw an `IllegalArgumentException` when the metric is rejected.
 ** It is not allowed to reuse a metric (name) for metrics of different types.
 The implementation must throw an `IllegalArgumentException` if such a mismatch is detected.

--- a/spec/src/main/asciidoc/app-programming-model.adoc
+++ b/spec/src/main/asciidoc/app-programming-model.adoc
@@ -57,7 +57,7 @@ in <<rest-api>>.
 * Metrics registered via non-annotations API need their values be set via updates from the application code.
 * The implementation must flag duplicate metrics upon registration and reject the duplicate unless the metric
 is explicitly marked as reusable upon first registration and in all subsequent registrations.
-** A duplicate metric is a metric that has the same scope, name and tags as an existing one.
+** A duplicate metric is a metric that has the same scope and MetricID (name and tags) as an existing one.
 ** The implementation must throw an `IllegalArgumentException` when the metric is rejected.
 ** It is not allowed to reuse a metric (name) for metrics of different types.
 The implementation must throw an `IllegalArgumentException` if such a mismatch is detected.

--- a/spec/src/main/asciidoc/app-programming-model.adoc
+++ b/spec/src/main/asciidoc/app-programming-model.adoc
@@ -62,8 +62,7 @@ is explicitly marked as reusable upon first registration and in all subsequent r
 ** It is not allowed to reuse a metric (name) for metrics of different types.
 The implementation must throw an `IllegalArgumentException` if such a mismatch is detected.
 ** See <<reusing_of_metrics>> for more details.
-* The implementation must flag and reject metrics upon registration if the metadata information being registered is
-not equivalent to the metadata information that has already been registered under the given metric name.
+* The implementation must flag and reject metrics upon registration if the metadata information being registered is not equivalent to the metadata information that has already been registered under the given metric name (if it already exists).
 ** All metrics of a given metric name must be associated with the same metadata information
 ** The implementation must throw an `IllegalArgumentException` when the metric is rejected.
 

--- a/spec/src/main/asciidoc/app-programming-model.adoc
+++ b/spec/src/main/asciidoc/app-programming-model.adoc
@@ -62,6 +62,10 @@ is explicitly marked as reusable upon first registration and in all subsequent r
 ** It is not allowed to reuse a metric (name) for metrics of different types.
 The implementation must throw an `IllegalArgumentException` if such a mismatch is detected.
 ** See <<reusing_of_metrics>> for more details.
+* The implementation must flag and reject metrics upon registration if the metadata information being registered is
+not equivalent to the metadata information that has already been registered under the given metric name.
+** All metrics of a given metric name must be associated with the same metadata information
+** The implementation must throw an `IllegalArgumentException` when the metric is rejected.
 
 
 === Base Package

--- a/spec/src/main/asciidoc/architecture.adoc
+++ b/spec/src/main/asciidoc/architecture.adoc
@@ -102,17 +102,21 @@ In MicroProfile Metrics, tags add an additional dimension to metrics that share 
 and etc). Rather than incorporating this in the metric name, tags can be used to capture these information in separate metrics.
 
 [source]
-```
+----
 carCount{type=sedan,colour=red}
 carCount{type=sedan,colour=blue}
 carCount{type=suv,colour=red}
 carCount{type=coupe,colour=blue}
-```
+----
 
-The key name for the tag must match the regex `[a-zA-Z_][a-zA-Z0-9_]*` (Ascii alphabet, numbers and underscore). If an illegal character is
-used, the implementation must throw an IllegalArgumentException.
+For portability reasons, the key name for the tag must match the regex `[a-zA-Z_][a-zA-Z0-9_]*` (Ascii alphabet, numbers and underscore).
+If an illegal character is used, the implementation must throw an IllegalArgumentException.
 
-The tag value may contain any Unicode character.
+The tag value may contain any UTF-8 encoded character.
+
+NOTE: The REST endpoints provided by MicroProfile Metrics have different reserved characters based on the format.
+The characters are only escaped as needed when exposed through the REST endpoints.
+See <<rest_endpoints>> for more information on the reserved characters.
 
 Tags can be supplied in two ways:
 

--- a/spec/src/main/asciidoc/architecture.adoc
+++ b/spec/src/main/asciidoc/architecture.adoc
@@ -183,14 +183,14 @@ There is one `MetricRegistry` instance for each of the scopes listed in <<scopes
 Metrics can be added to or retrieved from the registry either using the `@Metric` annotation
 (see <<api-annotations, Metrics Annotations>>) or using the `MetricRegistry` object directly.
 
-A metric is uniquely identified by the `MetricRegistry` if the `MetricID` associated with the metric is unique. That is to say, there are no other metrics with the same combination of metric name and tags. However, all metrics of the same name must be of the same type otherwise an `IllegalArgumentException` will be thrown.
+A metric is uniquely identified by the `MetricRegistry` if the `MetricID` associated with the metric is unique. That is to say, there are no other metrics with the same combination of metric name and tags. However, all metrics of the same name must be of the same type otherwise an `IllegalArgumentException` will be thrown. This exception will be thrown during registration.
 
-The metadata information is registered under a unique metric name and is immutable. All metrics of the same name must be registered with the same metadata information otherwise an "IllegalArgumentException" will be thrown.
+The metadata information is registered under a unique metric name and is immutable. All metrics of the same name must be registered with the same metadata information otherwise an "IllegalArgumentException" will be thrown. This exception will be thrown during registration.
 
 [[metricid-data-def]]
 ==== MetricID
 
-The MetricID consists of the metric's name and tags (if supplied). This is used by the MetricRegistry to uniquely identify a metric and its' corresponding metadata.
+The MetricID consists of the metric's name and tags (if supplied). This is used by the MetricRegistry to uniquely identify a metric and its corresponding metadata.
 
 The MetricID:
 
@@ -200,7 +200,7 @@ The MetricID:
 [[reusing_of_metrics]]
 ==== Reusing of Metrics
 
-By default it is not allowed to re-register more than one metric under a certain name and tags combination in a scope. This is done
+By default it is not allowed to register more than one metric under a certain name and tags combination in a scope. This is done
 to prevent hard to spot copy & paste errors, where for example all methods of a Jax-Rs class are marked with
 `@Timed(name="myApp", absolute=true)`.
 

--- a/spec/src/main/asciidoc/architecture.adoc
+++ b/spec/src/main/asciidoc/architecture.adoc
@@ -97,6 +97,23 @@ Tags have taken over the role to, for example, identify an application (`app=myS
 (`tier=database` or `tier=app_server`) and also the node/container id. Aggregation of metrics can then work over label
 queries (Give me the API hit count for `app=myShop && tier=app_server`).
 
+In MicroProfile Metrics, tags add an additional dimension to metrics that share a common basis. For example, a metric named
+`carCount` can be further differentiated by the car type (sedan, SUV, coupe, and etc) and the colour (red, blue, white, black,
+and etc). Rather than incorporating this in the metric name, tags can be used to capture these information in separate metrics.
+
+[source]
+```
+carCount{type=sedan,colour=red}
+carCount{type=sedan,colour=blue}
+carCount{type=suv,colour=red}
+carCount{type=coupe,colour=blue}
+```
+
+The key name for the tag must match the regex `[a-zA-Z_][a-zA-Z0-9_]*` (Ascii alphabet, numbers and underscore). If an illegal character is
+used, the implementation must throw an IllegalArgumentException.
+
+The tag value may contain any Unicode character.
+
 Tags can be supplied in two ways:
 
 * At the level of a metric as described in <<app-metrics-api>>.
@@ -125,6 +142,7 @@ operators when correct metadata is provided, as this helps getting a context and
 
 The Metadata:
 
+* name: The name of the metric.
 * unit: a fixed set of string units
 * type:
 ** counter: an incrementally increasing or decreasing numeric value (e.g. total number of requests received or total number of concurrently active HTTP sessions).
@@ -159,10 +177,13 @@ There is one `MetricRegistry` instance for each of the scopes listed in <<scopes
 Metrics can be added to or retrieved from the registry either using the `@Metric` annotation
 (see <<api-annotations, Metrics Annotations>>) or using the `MetricRegistry` object directly.
 
+A metric is uniquely identified by the `MetricRegistry` if the combination of the name and tags (order independent) in the Metadata are unique.
+However, all metrics of the same name must be of the same type otherwise an `IllegalArgumentException` will be thrown.
+
 [[reusing_of_metrics]]
 ==== Reusing of Metrics
 
-By default it is not allowed to register more than one metric under a certain name in a scope. This is done
+By default it is not allowed to re-register more than one metric under a certain name and tags combination in a scope. This is done
 to prevent hard to spot copy & paste errors, where for example all methods of a Jax-Rs class are marked with
 `@Timed(name="myApp", absolute=true)`.
 

--- a/spec/src/main/asciidoc/architecture.adoc
+++ b/spec/src/main/asciidoc/architecture.adoc
@@ -99,7 +99,7 @@ queries (Give me the API hit count for `app=myShop && tier=app_server`).
 
 In MicroProfile Metrics, tags add an additional dimension to metrics that share a common basis. For example, a metric named
 `carCount` can be further differentiated by the car type (sedan, SUV, coupe, and etc) and the colour (red, blue, white, black,
-and etc). Rather than incorporating this in the metric name, tags can be used to capture these information in separate metrics.
+and etc). Rather than incorporating this in the metric name, tags can be used to capture this information in separate metrics.
 
 [source]
 ----
@@ -111,6 +111,7 @@ carCount{type=coupe,colour=blue}
 
 For portability reasons, the key name for the tag must match the regex `[a-zA-Z_][a-zA-Z0-9_]*` (Ascii alphabet, numbers and underscore).
 If an illegal character is used, the implementation must throw an IllegalArgumentException.
+If a duplicate tag is used, the last occurrence of the tag is used.
 
 The tag value may contain any UTF-8 encoded character.
 
@@ -134,7 +135,7 @@ the global tags that existed already in Metrics 1.0. Future version of the spec 
 export MP_METRICS_TAGS=app=shop,tier=integration
 ----
 
-Global tags and tags set in metric metadata are included in the output returned from the REST API.
+Global tags and tags registered with the metric are included in the output returned from the REST API.
 
 [[meta-data-def]]
 ==== Metadata
@@ -175,14 +176,23 @@ will be "the same" and form part of an app, where it would be confusing in
 an overall view if the same metric has different metadata.
 
 === Metric Registry
-The `MetricRegistry` stores the metrics and metadata information.
+The `MetricRegistry` stores the metrics and metadata information with a unique `MetricID`
 There is one `MetricRegistry` instance for each of the scopes listed in <<scopes>>.
 
 Metrics can be added to or retrieved from the registry either using the `@Metric` annotation
 (see <<api-annotations, Metrics Annotations>>) or using the `MetricRegistry` object directly.
 
-A metric is uniquely identified by the `MetricRegistry` if the combination of the name and tags (order independent) in the Metadata are unique.
-However, all metrics of the same name must be of the same type otherwise an `IllegalArgumentException` will be thrown.
+A metric is uniquely identified by the `MetricRegistry` if the `MetricID` associated with the metric is unique. That is to say, there are no other metrics with the same combination of metric name and tags. However, all metrics of the same name must be of the same type otherwise an `IllegalArgumentException` will be thrown.
+
+[[metricid-data-def]]
+==== MetricID
+
+The MetricID consists of the metric's name and tags (if supplied). This is used by the MetricRegistry to uniquely identify a metric and its' corresponding metadata.
+
+The MetricID:
+
+* name: The name of the metric.
+* tags (optional): A list of `key=value` pairs, which are separated by comma. See also <<supplying_of_tags>>.
 
 [[reusing_of_metrics]]
 ==== Reusing of Metrics

--- a/spec/src/main/asciidoc/architecture.adoc
+++ b/spec/src/main/asciidoc/architecture.adoc
@@ -176,13 +176,15 @@ will be "the same" and form part of an app, where it would be confusing in
 an overall view if the same metric has different metadata.
 
 === Metric Registry
-The `MetricRegistry` stores the metrics and metadata information with a unique `MetricID`
+The `MetricRegistry` stores the metrics and metadata information.
 There is one `MetricRegistry` instance for each of the scopes listed in <<scopes>>.
 
 Metrics can be added to or retrieved from the registry either using the `@Metric` annotation
 (see <<api-annotations, Metrics Annotations>>) or using the `MetricRegistry` object directly.
 
 A metric is uniquely identified by the `MetricRegistry` if the `MetricID` associated with the metric is unique. That is to say, there are no other metrics with the same combination of metric name and tags. However, all metrics of the same name must be of the same type otherwise an `IllegalArgumentException` will be thrown.
+
+The metadata information is registered under a unique metric name and is immutable. All metrics of the same name must be registered with the same metadata information otherwise an "IllegalArgumentException" will be thrown.
 
 [[metricid-data-def]]
 ==== MetricID

--- a/spec/src/main/asciidoc/architecture.adoc
+++ b/spec/src/main/asciidoc/architecture.adoc
@@ -125,6 +125,7 @@ Tags can be supplied in two ways:
 * At the application server level by using https://github.com/eclipse/microprofile-config[MicroProfile Config] and
 setting a property of the name `MP_METRICS_TAGS`.
 This property translates to the environment variable `MP_METRICS_TAGS`.
+** Tag values set through `MP_METRICS_TAGS` MUST escape equal symbols `=` and commas `,` with a backslash `\`
 
 NOTE: The use of MicroProfile-Config is mandatory in MicroProfile-Metrics 1.1 even if it only serves to provide
 the global tags that existed already in Metrics 1.0. Future version of the spec will introduce more config options.
@@ -132,7 +133,7 @@ the global tags that existed already in Metrics 1.0. Future version of the spec 
 .Set up global tags via environment
 [source,bash]
 ----
-export MP_METRICS_TAGS=app=shop,tier=integration
+export MP_METRICS_TAGS=app=shop,tier=integration,special=deli\=ver\,y
 ----
 
 Global tags and tags registered with the metric are included in the output returned from the REST API.
@@ -194,7 +195,7 @@ The MetricID consists of the metric's name and tags (if supplied). This is used 
 The MetricID:
 
 * name: The name of the metric.
-* tags (optional): A list of `key=value` pairs, which are separated by comma. See also <<supplying_of_tags>>.
+* tags (optional): A list of Tag objects. See also <<supplying_of_tags>>.
 
 [[reusing_of_metrics]]
 ==== Reusing of Metrics

--- a/spec/src/main/asciidoc/changelog.adoc
+++ b/spec/src/main/asciidoc/changelog.adoc
@@ -23,7 +23,7 @@
 ** Removed unnecessary `@InterceptorBinding` annotation from `org.eclipse.microprofile.metrics.annotation.Metric`.
 ** Removed deprecated `org.eclipse.microprofile.metrics.MetricRegistry.register(String name, Metric, Metadata)`
 ** `Metadata` is now immutable and built via a `MetadataBuilder`.
-** Metrics are now uniquely identified by the combination of name and tags (order independent).
+** Metrics are now uniquely identified by a MetricID (combination of the metric's name and tags).
 ** Tag key names are restricted to match the regex `[a-zA-Z_][a-zA-Z0-9_]*`.
 ** JSON format now includes tags along with the metric name for the JSON key. As the tags are provided with the metric name,
 the OPTIONS requests do not list the tags as a nested JSON field.

--- a/spec/src/main/asciidoc/changelog.adoc
+++ b/spec/src/main/asciidoc/changelog.adoc
@@ -23,12 +23,14 @@
 ** Removed unnecessary `@InterceptorBinding` annotation from `org.eclipse.microprofile.metrics.annotation.Metric`.
 ** Removed deprecated `org.eclipse.microprofile.metrics.MetricRegistry.register(String name, Metric, Metadata)`
 ** `Metadata` is now immutable and built via a `MetadataBuilder`.
+** Introduced a Tag object which represents a singular tag key/value pair.
 ** Metrics are now uniquely identified by a MetricID (combination of the metric's name and tags).
 ** The 'Metadata' is mapped to a unique metric name in the `MetricRegistry` and this relationship is immutable.
 ** Tag key names are restricted to match the regex `[a-zA-Z_][a-zA-Z0-9_]*`.
 ** Tag values defined through MP_METRICS_TAGS must escape equal signs `=` and commas `,` with a backslash `\`.
-** JSON format now includes tags along with the metric name for the JSON key. As the tags are provided with the metric name,
-the OPTIONS requests do not list the tags as a nested JSON field.
+** JSON format for GET requests now includes tags along with the metric name. JSON format for OPTIONS requests
+have been modified such that the 'tags' attribute is a list of nested lists which holds tags from different metrics that
+ are associated with the metadata.
 ** Reserved characters in Prometheus format must be escaped.
 
 

--- a/spec/src/main/asciidoc/changelog.adoc
+++ b/spec/src/main/asciidoc/changelog.adoc
@@ -24,6 +24,7 @@
 ** Removed deprecated `org.eclipse.microprofile.metrics.MetricRegistry.register(String name, Metric, Metadata)`
 ** `Metadata` is now immutable and built via a `MetadataBuilder`.
 ** Metrics are now uniquely identified by a MetricID (combination of the metric's name and tags).
+** The 'Metadata' is mapped to a unique metric name in the `MetricRegistry` and this relationship is immutable.
 ** Tag key names are restricted to match the regex `[a-zA-Z_][a-zA-Z0-9_]*`.
 ** JSON format now includes tags along with the metric name for the JSON key. As the tags are provided with the metric name,
 the OPTIONS requests do not list the tags as a nested JSON field.

--- a/spec/src/main/asciidoc/changelog.adoc
+++ b/spec/src/main/asciidoc/changelog.adoc
@@ -23,6 +23,12 @@
 ** Removed unnecessary `@InterceptorBinding` annotation from `org.eclipse.microprofile.metrics.annotation.Metric`.
 ** Removed deprecated `org.eclipse.microprofile.metrics.MetricRegistry.register(String name, Metric, Metadata)`
 ** `Metadata` is now immutable and built via a `MetadataBuilder`.
+** Metrics are now uniquely identified by the combination of name and tags (order independent).
+** Tag key names are restricted to match the regex `[a-zA-Z_][a-zA-Z0-9_]*`.
+** JSON format now includes tags along with the metric name for the JSON key. As the tags are provided with the metric name,
+the OPTIONS requests do not list the tags as a nested JSON field.
+** Reserved characters in Prometheus format must be escaped.
+
 
 * Since 1.0
 ** Improved TCK

--- a/spec/src/main/asciidoc/changelog.adoc
+++ b/spec/src/main/asciidoc/changelog.adoc
@@ -26,6 +26,7 @@
 ** Metrics are now uniquely identified by a MetricID (combination of the metric's name and tags).
 ** The 'Metadata' is mapped to a unique metric name in the `MetricRegistry` and this relationship is immutable.
 ** Tag key names are restricted to match the regex `[a-zA-Z_][a-zA-Z0-9_]*`.
+** Tag values defined through MP_METRICS_TAGS must escape equal signs `=` and commas `,` with a backslash `\`.
 ** JSON format now includes tags along with the metric name for the JSON key. As the tags are provided with the metric name,
 the OPTIONS requests do not list the tags as a nested JSON field.
 ** Reserved characters in Prometheus format must be escaped.

--- a/spec/src/main/asciidoc/changelog.adoc
+++ b/spec/src/main/asciidoc/changelog.adoc
@@ -25,6 +25,7 @@
 ** `Metadata` is now immutable and built via a `MetadataBuilder`.
 ** Introduced a Tag object which represents a singular tag key/value pair.
 ** Metrics are now uniquely identified by a MetricID (combination of the metric's name and tags).
+** MetricFilter modified to filter with MetricID instead of name
 ** The 'Metadata' is mapped to a unique metric name in the `MetricRegistry` and this relationship is immutable.
 ** Tag key names are restricted to match the regex `[a-zA-Z_][a-zA-Z0-9_]*`.
 ** Tag values defined through MP_METRICS_TAGS must escape equal signs `=` and commas `,` with a backslash `\`.

--- a/spec/src/main/asciidoc/rest-endpoints.adoc
+++ b/spec/src/main/asciidoc/rest-endpoints.adoc
@@ -27,15 +27,17 @@ This section describes the REST-api, that monitoring agents would use to retriev
 
 * When using JSON format, the REST API will respond to GET requests with data formatted in a tree like fashion with sub-trees for the sub-resources.
 A sub-tree that does not contain data must be omitted.
-* A 'shadow tree' that responds to OPTIONS will provide the metadata.
+* A 'shadow tree' that responds to OPTIONS will provide the metadata and tags associated to a metric name.
 
 ==== Translation rules for metric names
 
-The metric name in JSON is comprised of the metric name appended with the metric tags (if they exist).
-The metric tags is represented by a comma separated list of key/value tag pairs surrounded by braces `{` and `}`
-Each tag is a key-value-pair in the format of `<key>=<value>`. The list of tags must be sorted alphabetically.
+The following rules apply only to GET requests:
+* The metric name in JSON is comprised of the metric name appended with the metric tags (if they exist).
+* The metric tags is represented by a comma separated list of key/value tag pairs surrounded by braces `{` and `}`
 
-If the metric name or tag value contains a special reserved JSON character, these characters must be escaped in the JSON response.
+The following apply to both GET and OPTION requests:
+* Each tag is a key-value-pair in the format of `<key>=<value>`. The list of tags must be sorted alphabetically.
+* If the metric name or tag value contains a special reserved JSON character, these characters must be escaped in the JSON response.
 
 
 [source]
@@ -250,7 +252,7 @@ The value of the counter must be equivalent to a call to the instance Counter's 
 
 
 Metadata is exposed in a tree-like fashion with sub-trees for the sub-resources mentioned previously.
-
+Tags from metrics associated with the metric name are also included.
 
 Example:
 
@@ -258,7 +260,7 @@ If `GET /metrics/base/fooVal` exposes:
 
 [source]
 ----
-{"fooVal": 12345}
+{"fooVal{app=webshop}": 12345}
 ----
 
 then `OPTIONS /metrics/base/fooVal` will expose:
@@ -267,11 +269,16 @@ then `OPTIONS /metrics/base/fooVal` will expose:
 ----
 
 {
-  "fooVal{app=webshop}": {
+  "fooVal": {
     "unit": "milliseconds",
     "type": "gauge",
     "description": "The size of foo after each request",
-    "displayName": "Size of foo"
+    "displayName": "Size of foo",
+    "tags": [
+      [
+        "app=webshop"
+      ]
+    ]
   }
 }
 
@@ -283,8 +290,8 @@ If `GET /metrics/base` exposes multiple values like this:
 [source]
 ----
 {
-  "fooVal": 12345,
-  "barVal": 42
+  "fooVal{app=webshop}": 12345,
+  "barVal{app=webshop,component=backend}": 42
 }
 ----
 
@@ -294,15 +301,26 @@ then `OPTIONS /metrics/base` exposes:
 [source]
 ----
 {
-  "fooVal{app=webshop}": {
+  "fooVal": {
     "unit": "milliseconds",
     "type": "gauge",
     "description": "The average duration of foo requests during last 5 minutes",
-    "displayName": "Duration of foo"
+    "displayName": "Duration of foo",
+    "tags": [
+      [
+        "app=webshop"
+      ]
+    ]
   },
-  "barVal{app=webshop,component=backend}": {
+  "barVal": {
     "unit": "megabytes",
     "type": "gauge",
+    "tags": [
+      [
+        "app=webshop",
+        "component=backend"
+      ]
+    ]
   }
 }
 ----

--- a/spec/src/main/asciidoc/rest-endpoints.adoc
+++ b/spec/src/main/asciidoc/rest-endpoints.adoc
@@ -17,6 +17,7 @@
 // limitations under the License.
 //
 
+[[rest_endpoints]]
 == REST endpoints
 
 This section describes the REST-api, that monitoring agents would use to retrieve the collected metrics.
@@ -32,11 +33,10 @@ A sub-tree that does not contain data must be omitted.
 
 The metric name in JSON is comprised of the metric name appended with the metric tags (if they exist).
 The metric tags is represented by a comma separated list of key/value tag pairs surrounded by braces `{` and `}`
-Each tag is a key-value-pair in the format of `<key>=<value>`.
+Each tag is a key-value-pair in the format of `<key>=<value>`. The list of tags must be sorted alphabetically.
 
 If the metric name or tag value contains a special reserved JSON character, these characters must be escaped in the JSON response.
 
-For every unique metric, the implementation must always return the same metric name for that metric (the order of the tags cannot change between requests).
 
 [source]
 ----
@@ -267,12 +267,11 @@ then `OPTIONS /metrics/base/fooVal` will expose:
 ----
 
 {
-  "fooVal": {
+  "fooVal{app=webshop}": {
     "unit": "milliseconds",
     "type": "gauge",
     "description": "The size of foo after each request",
-    "displayName": "Size of foo",
-    "tags": "app=webshop"
+    "displayName": "Size of foo"
   }
 }
 
@@ -295,17 +294,15 @@ then `OPTIONS /metrics/base` exposes:
 [source]
 ----
 {
-  "fooVal": {
+  "fooVal{app=webshop}": {
     "unit": "milliseconds",
     "type": "gauge",
     "description": "The average duration of foo requests during last 5 minutes",
-    "displayName": "Duration of foo",
-    "tags": "app=webshop"
+    "displayName": "Duration of foo"
   },
-  "barVal": {
+  "barVal{app=webshop,component=backend}": {
     "unit": "megabytes",
     "type": "gauge",
-    "tags": "component=backend,app=webshop"
   }
 }
 ----
@@ -360,9 +357,9 @@ The `quantile` tag must be included alongside the metrics tags within the curly 
 
 The tag value can be any Unicode character but the following characters must be escaped:
 
-* Backslash (`\`) must be escaped as `\\`
-* Double-quotes (`"`) must be escaped as `\"`
-* Line feed (`\n`) must be escaped as `\n`
+* Backslash (`\`) must be escaped as `\\` (as two characters: `\` and `\`)
+* Double-quotes (`"`) must be escaped as `\"` (as two characters: `\` and `"`)
+* Line feed (`\n`) must be escaped as `\n` (as two characters: `\` and `n`)
 
 [[OpenMetrics_units]]
 ==== Handling of units

--- a/spec/src/main/asciidoc/rest-endpoints.adoc
+++ b/spec/src/main/asciidoc/rest-endpoints.adoc
@@ -291,7 +291,8 @@ If `GET /metrics/base` exposes multiple values like this:
 ----
 {
   "fooVal{app=webshop}": 12345,
-  "barVal{app=webshop,component=backend}": 42
+  "barVal{app=webshop,component=backend}": 42,
+  "barVal{app=webshop,component=frontend}": 63
 }
 ----
 
@@ -319,6 +320,10 @@ then `OPTIONS /metrics/base` exposes:
       [
         "app=webshop",
         "component=backend"
+      ],
+      [
+        "app=webshop",
+        "component=frontend"
       ]
     ]
   }
@@ -346,6 +351,8 @@ The above json example would look like this in OpenMetrics format
 base_foo_val_seconds{app="webshop"} 12.345  <3>
 # TYPE base_bar_val_bytes gauge <1>
 base_bar_val_bytes{component="backend", app="webshop"} 42000 <3>
+# TYPE base_bar_val_bytes gauge <1>
+base_bar_val_bytes{component="frontend", app="webshop"} 63000 <3>
 ----
 <1> Metric names are turned from camel case into snake_case.
 <2> The description goes into the HELP line
@@ -441,7 +448,7 @@ Counters do not have a suffix for the unit.
 ----
 # TYPE application_visitors_total counter
 # HELP application_visitors_total The number of unique visitors
-application_visitors 80
+application_visitors_total 80
 ----
 
 ==== Meter OpenMetrics Text Format

--- a/spec/src/main/asciidoc/rest-endpoints.adoc
+++ b/spec/src/main/asciidoc/rest-endpoints.adoc
@@ -28,6 +28,36 @@ This section describes the REST-api, that monitoring agents would use to retriev
 A sub-tree that does not contain data must be omitted.
 * A 'shadow tree' that responds to OPTIONS will provide the metadata.
 
+==== Translation rules for metric names
+
+The metric name in JSON is comprised of the metric name appended with the metric tags (if they exist).
+The metric tags is represented by a comma separated list of key/value tag pairs surrounded by braces `{` and `}`
+Each tag is a key-value-pair in the format of `<key>=<value>`.
+
+If the metric name or tag value contains a special reserved JSON character, these characters must be escaped in the JSON response.
+
+For every unique metric, the implementation must always return the same metric name for that metric (the order of the tags cannot change between requests).
+
+[source]
+----
+{
+  "cars{colour=red,type=sedan}" : 12,
+  "cars{colour=blue,type=sedan}" : 9,
+  "cars{colour=yellow,type=sedan}" : 16,
+}
+----
+
+If the metric has no tags, the braces `{}` must be omitted.
+
+For example,
+[source]
+----
+{
+  "metricWithoutTags": 192
+}
+----
+
+
 *REST-API Objects*
 
 API-objects MAY include one or more metrics as in
@@ -48,7 +78,7 @@ or
 [source]
 ----
 {
-  "hitCount": 45
+  "hitCount{type=yes}": 45,
 }
 ----
 
@@ -325,6 +355,15 @@ follow the pattern `[a-zA-Z_][a-zA-Z0-9_]*`.
 Metric tags are appended to the metric name in curly braces `{` and `}` and are separated by comma.
 Each tag is a key-value-pair in the format of `<key>="<value>"` (the quotes around the value are required).
 
+MicroProfile Metrics timers and histograms expose a Prometheus `summary` type which requires an additional `quantile` tag for certain metrics.
+The `quantile` tag must be included alongside the metrics tags within the curly braces `{` and `}`.
+
+The tag value can be any Unicode character but the following characters must be escaped:
+
+* Backslash (`\`) must be escaped as `\\`
+* Double-quotes (`"`) must be escaped as `\"`
+* Line feed (`\n`) must be escaped as `\n`
+
 [[OpenMetrics_units]]
 ==== Handling of units
 
@@ -548,4 +587,3 @@ In case of a secured endpoint, accessing `/metrics` without valid credentials mu
 A server SHOULD implement TLS encryption by default.
 
 It is allowed to ignore security for trusted origins (e.g. localhost)
-

--- a/spec/src/main/asciidoc/rest-endpoints.adoc
+++ b/spec/src/main/asciidoc/rest-endpoints.adoc
@@ -33,7 +33,7 @@ A sub-tree that does not contain data must be omitted.
 
 The following rules apply only to GET requests:
 * The metric name in JSON is comprised of the metric name appended with the metric tags (if they exist).
-* The metric tags is represented by a comma separated list of key/value tag pairs surrounded by braces `{` and `}`
+* The metric tags are represented by a comma separated list of key/value tag pairs surrounded by braces `{` and `}`
 
 The following apply to both GET and OPTION requests:
 * Each tag is a key-value-pair in the format of `<key>=<value>`. The list of tags must be sorted alphabetically.
@@ -45,7 +45,7 @@ The following apply to both GET and OPTION requests:
 {
   "cars{colour=red,type=sedan}" : 12,
   "cars{colour=blue,type=sedan}" : 9,
-  "cars{colour=yellow,type=sedan}" : 16,
+  "cars{colour=yellow,type=sedan}" : 16
 }
 ----
 
@@ -80,7 +80,7 @@ or
 [source]
 ----
 {
-  "hitCount{type=yes}": 45,
+  "hitCount{type=yes}": 45
 }
 ----
 
@@ -149,7 +149,7 @@ The value of the counter must be equivalent to a call to the instance Counter's 
     "meanRate": 12.223,
     "oneMinRate": 12.563,
     "fiveMinRate": 12.364,
-    "fifteenMinRate": 12.126,
+    "fifteenMinRate": 12.126
   }
 }
 ----

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/ApplicationScopedTimedMethodBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/ApplicationScopedTimedMethodBeanTest.java
@@ -24,6 +24,7 @@ import javax.inject.Inject;
 
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.Timer;
+import org.eclipse.microprofile.metrics.MetricID;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
@@ -39,6 +40,7 @@ import org.junit.runner.RunWith;
 public class ApplicationScopedTimedMethodBeanTest {
 
     private final static String TIMER_NAME = MetricRegistry.name(ApplicationScopedTimedMethodBean.class, "applicationScopedTimedMethod");
+    private final static MetricID TIMER_METRICID = new MetricID(TIMER_NAME);
 
     @Deployment
     static Archive<?> createTestArchive() {
@@ -65,8 +67,8 @@ public class ApplicationScopedTimedMethodBeanTest {
     @Test
     @InSequence(1)
     public void timedMethodNotCalledYet() {
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(TIMER_NAME));
-        Timer timer = registry.getTimers().get(TIMER_NAME);
+        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(TIMER_METRICID));
+        Timer timer = registry.getTimers().get(TIMER_METRICID);
 
         // Make sure that the timer hasn't been called yet
         assertThat("Timer count is incorrect", timer.getCount(), is(equalTo(0L)));
@@ -75,8 +77,8 @@ public class ApplicationScopedTimedMethodBeanTest {
     @Test
     @InSequence(2)
     public void callTimedMethodOnce() {
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(TIMER_NAME));
-        Timer timer = registry.getTimers().get(TIMER_NAME);
+        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(TIMER_METRICID));
+        Timer timer = registry.getTimers().get(TIMER_METRICID);
 
         // Call the timed method and assert it's been timed
         bean.applicationScopedTimedMethod();

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/ConcreteExtendedTimedBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/ConcreteExtendedTimedBeanTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertThat;
 
 import javax.inject.Inject;
 
+import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.Timer;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -40,6 +41,9 @@ public class ConcreteExtendedTimedBeanTest {
     private final static String TIMED_NAME = MetricRegistry.name(ConcreteExtendedTimedBean.class, "timedMethod");
     private final static String EXTENDED_TIMED_NAME = MetricRegistry.name(ConcreteExtendedTimedBean.class, "anotherTimedMethod");
 
+    private final static MetricID TIMED_METRICID = new MetricID(TIMED_NAME);
+    private final static MetricID EXTENDED_TIMED_METRICID = new MetricID(EXTENDED_TIMED_NAME);
+    
     @Deployment
     static Archive<?> createTestArchive() {
         return ShrinkWrap.create(JavaArchive.class)
@@ -55,8 +59,8 @@ public class ConcreteExtendedTimedBeanTest {
     @Test
     @InSequence(1)
     public void timedMethodNotCalledYet(MetricRegistry registry) {
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(TIMED_NAME));
-        Timer timer = registry.getTimers().get(TIMED_NAME);
+        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(TIMED_METRICID));
+        Timer timer = registry.getTimers().get(TIMED_METRICID);
 
         // Make sure that the timer hasn't been called yet
         assertThat("Timer count is incorrect", timer.getCount(), is(equalTo(0L)));
@@ -65,8 +69,8 @@ public class ConcreteExtendedTimedBeanTest {
     @Test
     @InSequence(2)
     public void extendedTimedMethodNotCalledYet(MetricRegistry registry) {
-        assertThat("Timer is not registered correctly on the methods on the abstract class", registry.getTimers(), hasKey(EXTENDED_TIMED_NAME));
-        Timer timer = registry.getTimers().get(EXTENDED_TIMED_NAME);
+        assertThat("Timer is not registered correctly on the methods on the abstract class", registry.getTimers(), hasKey(EXTENDED_TIMED_METRICID));
+        Timer timer = registry.getTimers().get(EXTENDED_TIMED_METRICID);
 
         // Make sure that the timer hasn't been called yet
         assertThat("Timer count is incorrect", timer.getCount(), is(equalTo(0L)));
@@ -75,8 +79,8 @@ public class ConcreteExtendedTimedBeanTest {
     @Test
     @InSequence(3)
     public void callTimedMethodOnce(MetricRegistry registry) {
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(TIMED_NAME));
-        Timer timer = registry.getTimers().get(TIMED_NAME);
+        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(TIMED_METRICID));
+        Timer timer = registry.getTimers().get(TIMED_METRICID);
 
         // Call the timed method and assert it's been timed
         bean.timedMethod();
@@ -88,8 +92,8 @@ public class ConcreteExtendedTimedBeanTest {
     @Test
     @InSequence(4)
     public void callExtendedTimedMethodOnce(MetricRegistry registry) {
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(EXTENDED_TIMED_NAME));
-        Timer timer = registry.getTimers().get(EXTENDED_TIMED_NAME);
+        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(EXTENDED_TIMED_METRICID));
+        Timer timer = registry.getTimers().get(EXTENDED_TIMED_METRICID);
 
         // Call the timed method and assert it's been timed
         bean.anotherTimedMethod();

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/ConcreteTimedBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/ConcreteTimedBeanTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertThat;
 
 import javax.inject.Inject;
 
+import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.Timer;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -40,6 +41,9 @@ public class ConcreteTimedBeanTest {
     private final static String TIMED_NAME = MetricRegistry.name(ConcreteTimedBean.class, "timedMethod");
     private final static String EXTENDED_TIMED_NAME = MetricRegistry.name(ConcreteTimedBean.class, "normallyNotTimedMethod");
 
+    private final static MetricID TIMED_METRICID = new MetricID(TIMED_NAME);
+    private final static MetricID EXTENDED_TIMED_METRICID = new MetricID(EXTENDED_TIMED_NAME);
+    
     @Deployment
     static Archive<?> createTestArchive() {
         return ShrinkWrap.create(JavaArchive.class)
@@ -55,8 +59,8 @@ public class ConcreteTimedBeanTest {
     @Test
     @InSequence(1)
     public void timedMethodNotCalledYet(MetricRegistry registry) {
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(TIMED_NAME));
-        Timer timer = registry.getTimers().get(TIMED_NAME);
+        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(TIMED_METRICID));
+        Timer timer = registry.getTimers().get(TIMED_METRICID);
 
         // Make sure that the timer hasn't been called yet
         assertThat("Timer count is incorrect", timer.getCount(), is(equalTo(0L)));
@@ -65,8 +69,8 @@ public class ConcreteTimedBeanTest {
     @Test
     @InSequence(2)
     public void extendedTimedMethodNotCalledYet(MetricRegistry registry) {
-        assertThat("Timer is not registered correctly on the methods on the abstract class", registry.getTimers(), hasKey(EXTENDED_TIMED_NAME));
-        Timer timer = registry.getTimers().get(EXTENDED_TIMED_NAME);
+        assertThat("Timer is not registered correctly on the methods on the abstract class", registry.getTimers(), hasKey(EXTENDED_TIMED_METRICID));
+        Timer timer = registry.getTimers().get(EXTENDED_TIMED_METRICID);
 
         // Make sure that the timer hasn't been called yet
         assertThat("Timer count is incorrect", timer.getCount(), is(equalTo(0L)));
@@ -75,8 +79,8 @@ public class ConcreteTimedBeanTest {
     @Test
     @InSequence(3)
     public void callTimedMethodOnce(MetricRegistry registry) {
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(TIMED_NAME));
-        Timer timer = registry.getTimers().get(TIMED_NAME);
+        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(TIMED_METRICID));
+        Timer timer = registry.getTimers().get(TIMED_METRICID);
 
         // Call the timed method and assert it's been timed
         bean.timedMethod();
@@ -88,8 +92,8 @@ public class ConcreteTimedBeanTest {
     @Test
     @InSequence(4)
     public void callExtendedTimedMethodOnce(MetricRegistry registry) {
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(EXTENDED_TIMED_NAME));
-        Timer timer = registry.getTimers().get(EXTENDED_TIMED_NAME);
+        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(EXTENDED_TIMED_METRICID));
+        Timer timer = registry.getTimers().get(EXTENDED_TIMED_METRICID);
 
         // Call the timed method and assert it's been timed
         bean.normallyNotTimedMethod();

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CountedClassBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CountedClassBeanTest.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.metrics.Counter;
+import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.hamcrest.Matchers;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -48,6 +49,8 @@ public class CountedClassBeanTest {
     private static final Set<String> COUNTER_NAMES = MetricsUtil.absoluteMetricNames(CountedClassBean.class, "countedClass", METHOD_NAMES,
             CONSTRUCTOR_NAME);
 
+    private static final Set<MetricID> COUNTER_METRICIDS = MetricsUtil.createMetricIDs(COUNTER_NAMES);
+            
     @Deployment
     static Archive<?> createTestArchive() {
         return ShrinkWrap.create(JavaArchive.class)
@@ -66,7 +69,7 @@ public class CountedClassBeanTest {
     @Test
     @InSequence(1)
     public void countedMethodsNotCalledYet() {
-        assertThat("Counters are not registered correctly", registry.getCounters().keySet(), is(equalTo(COUNTER_NAMES)));
+        assertThat("Counters are not registered correctly", registry.getCounters().keySet(), is(equalTo(COUNTER_METRICIDS)));
         // Make sure that the counters haven't been incremented
         assertThat("Counter counts are incorrect", registry.getCounters().values(), everyItem(Matchers.<Counter>hasProperty("count", equalTo(0L))));
     }
@@ -74,7 +77,7 @@ public class CountedClassBeanTest {
     @Test
     @InSequence(2)
     public void callCountedMethodsOnce() {
-        assertThat("Counters are not registered correctly", registry.getCounters().keySet(), is(equalTo(COUNTER_NAMES)));
+        assertThat("Counters are not registered correctly", registry.getCounters().keySet(), is(equalTo(COUNTER_METRICIDS)));
         
         // Call the counted methods and assert they're back to zero
         bean.countedMethodOne();

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CountedConstructorBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CountedConstructorBeanTest.java
@@ -24,6 +24,7 @@ import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.metrics.Counter;
+import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -39,6 +40,7 @@ import org.junit.runner.RunWith;
 public class CountedConstructorBeanTest {
 
     private final static String COUNTER_NAME = MetricRegistry.name(CountedConstructorBean.class, "countedConstructor");
+    private final static MetricID COUNTER_METRICID = new MetricID(COUNTER_NAME);
 
     @Deployment
     static Archive<?> createTestArchive() {
@@ -72,8 +74,8 @@ public class CountedConstructorBeanTest {
             instance.get();
         }
 
-        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(COUNTER_NAME));
-        Counter counter = registry.getCounters().get(COUNTER_NAME);
+        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(COUNTER_METRICID));
+        Counter counter = registry.getCounters().get(COUNTER_METRICID);
 
         // Make sure that the counter has been called
         assertThat("Counter count is incorrect", counter.getCount(), is(equalTo(count)));

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CountedMethodBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CountedMethodBeanTest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.metrics.Counter;
+import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.annotation.Metric;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -48,6 +49,7 @@ import org.junit.runner.RunWith;
 public class CountedMethodBeanTest {
 
     private final static String COUNTER_NAME = "countedMethod";
+    private final static MetricID COUNTER_METRICID = new MetricID(COUNTER_NAME);
 
     private final static AtomicLong COUNTER_COUNT = new AtomicLong();
 
@@ -69,8 +71,8 @@ public class CountedMethodBeanTest {
     @Test
     @InSequence(1)
     public void countedMethodNotCalledYet() {
-        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(COUNTER_NAME));
-        Counter counter = registry.getCounters().get(COUNTER_NAME);
+        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(COUNTER_METRICID));
+        Counter counter = registry.getCounters().get(COUNTER_METRICID);
 
         // Make sure that the counter hasn't been called yet
         assertThat("Counter count is incorrect", counter.getCount(), is(equalTo(COUNTER_COUNT.get())));
@@ -79,8 +81,8 @@ public class CountedMethodBeanTest {
     @Test
     @InSequence(2)
     public void countedMethodNotCalledYet(@Metric(name = "countedMethod", absolute = true) Counter instance) {
-        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(COUNTER_NAME));
-        Counter counter = registry.getCounters().get(COUNTER_NAME);
+        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(COUNTER_METRICID));
+        Counter counter = registry.getCounters().get(COUNTER_METRICID);
 
         // Make sure that the counter registered and the bean instance are the same
         assertThat("Counter and bean instance are not equal", instance, is(equalTo(counter)));
@@ -89,8 +91,8 @@ public class CountedMethodBeanTest {
     @Test
     @InSequence(3)
     public void callCountedMethodOnce() throws InterruptedException, TimeoutException {
-        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(COUNTER_NAME));
-        Counter counter = registry.getCounters().get(COUNTER_NAME);
+        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(COUNTER_METRICID));
+        Counter counter = registry.getCounters().get(COUNTER_METRICID);
 
         // Call the counted method, block and assert it's been counted
         final Exchanger<Long> exchanger = new Exchanger<>();
@@ -142,11 +144,11 @@ public class CountedMethodBeanTest {
     @Test
     @InSequence(4)
     public void removeCounterFromRegistry() {
-        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(COUNTER_NAME));
-        Counter counter = registry.getCounters().get(COUNTER_NAME);
+        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(COUNTER_METRICID));
+        Counter counter = registry.getCounters().get(COUNTER_METRICID);
 
         // Remove the counter from metrics registry
-        registry.remove(COUNTER_NAME);
+        registry.remove(COUNTER_METRICID);
 
         try {
             // Call the counted method and assert an exception is thrown

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CountedMethodTagBean.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CountedMethodTagBean.java
@@ -1,0 +1,38 @@
+/*
+ **********************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICES file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+package io.astefanutti.metrics.cdi.se;
+
+import org.eclipse.microprofile.metrics.annotation.Counted;
+
+public class CountedMethodTagBean {
+
+    @Counted(name = "countedMethod", absolute = true, tags = {"number=one"})
+    public void countedMethodOne() {
+
+    }
+    
+    @Counted(name = "countedMethod", absolute = true, tags = {"number=two"})
+    public void countedMethodTwo() {
+
+    }
+    
+}

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CountedMethodTagBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CountedMethodTagBeanTest.java
@@ -1,0 +1,95 @@
+/*
+ **********************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICES file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+package io.astefanutti.metrics.cdi.se;
+
+
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.hasKey;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.metrics.Counter;
+import org.eclipse.microprofile.metrics.MetricID;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.annotation.Metric;
+import org.eclipse.microprofile.metrics.Tag;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class CountedMethodTagBeanTest {
+
+    private final static String COUNTER_NAME = "countedMethod";
+    
+    private final static Tag NUMBER_ONE_TAG = new Tag("number", "one");
+    private final static Tag NUMBER_TWO_TAG = new Tag("number", "two");
+
+    private final static MetricID COUNTER_ONE_MID = new MetricID(COUNTER_NAME, NUMBER_ONE_TAG);    
+    private final static MetricID COUNTER_TWO_MID = new MetricID(COUNTER_NAME, NUMBER_TWO_TAG);
+
+    
+    @Deployment
+    static Archive<?> createTestArchive() {
+        return ShrinkWrap.create(JavaArchive.class)
+            // Test bean
+            .addClass(CountedMethodTagBean.class)
+            // Bean archive deployment descriptor
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Inject
+    private MetricRegistry registry;
+
+    @Inject
+    private CountedMethodTagBean bean;
+
+    @Test
+    @InSequence(1)
+    public void counterTagMethodsRegistered() {
+        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(COUNTER_ONE_MID));
+        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(COUNTER_TWO_MID));
+    }
+    
+    @Test
+    @InSequence(2)
+    public void countedTagMethodNotCalledYet(@Metric(name = "countedMethod", absolute = true, tags = {"number=one"}) Counter instanceOne,
+                                             @Metric(name = "countedMethod", absolute = true, tags = {"number=two"}) Counter instanceTwo) {
+        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(COUNTER_ONE_MID));
+        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(COUNTER_TWO_MID));
+        
+        Counter counterOne = registry.getCounters().get(COUNTER_ONE_MID);
+        Counter counterTwo = registry.getCounters().get(COUNTER_TWO_MID);
+        
+        // Make sure that the counter registered and the bean instance are the same
+        assertThat("Counter and bean instance are not equal", instanceOne, is(equalTo(counterOne)));
+        assertThat("Counter and bean instance are not equal", instanceTwo, is(equalTo(counterTwo)));
+    }
+}

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CountedMethodTagBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CountedMethodTagBeanTest.java
@@ -40,7 +40,7 @@ import org.jboss.arquillian.junit.InSequence;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -58,11 +58,11 @@ public class CountedMethodTagBeanTest {
     
     @Deployment
     static Archive<?> createTestArchive() {
-        return ShrinkWrap.create(JavaArchive.class)
+        return ShrinkWrap.create(WebArchive.class)
             // Test bean
             .addClass(CountedMethodTagBean.class)
             // Bean archive deployment descriptor
-            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
     @Inject

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CounterFieldBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CounterFieldBeanTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertThat;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.metrics.Counter;
+import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -39,6 +40,8 @@ public class CounterFieldBeanTest {
 
     private final static String COUNTER_NAME = MetricRegistry.name(CounterFieldBean.class, "counterName");
 
+    private final static MetricID COUNTER_METRICID = new MetricID(COUNTER_NAME);
+    
     @Deployment
     public static Archive<?> createTestArchive() {
         return ShrinkWrap.create(JavaArchive.class)
@@ -57,14 +60,14 @@ public class CounterFieldBeanTest {
     @Test
     @InSequence(1)
     public void counterFieldRegistered() {
-        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(COUNTER_NAME));
+        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(COUNTER_METRICID));
     }
 
     @Test
     @InSequence(2)
     public void incrementCounterField() {
-        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(COUNTER_NAME));
-        Counter counter = registry.getCounters().get(COUNTER_NAME);
+        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(COUNTER_METRICID));
+        Counter counter = registry.getCounters().get(COUNTER_METRICID);
 
         // Call the increment method and assert the counter is up-to-date
         long value = Math.round(Math.random() * Long.MAX_VALUE);

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CounterFieldTagBean.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CounterFieldTagBean.java
@@ -1,0 +1,54 @@
+/*
+ **********************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICES file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+package io.astefanutti.metrics.cdi.se;
+
+import org.eclipse.microprofile.metrics.Counter;
+import org.eclipse.microprofile.metrics.annotation.Metric;
+
+import javax.inject.Inject;
+
+public class CounterFieldTagBean {
+
+    @Inject
+    @Metric(name = "counterName")
+    private Counter counterOne;
+
+    @Inject
+    @Metric(name = "counterName", tags= {"number=two", "colour=red"})
+    private Counter counterTwo;
+    
+    @Inject
+    @Metric(name = "counterName", tags= {"number=three", "colour=blue"})
+    private Counter counterThree;
+
+    public void incrementOne(long n) {
+        counterOne.inc(n);
+    }
+    
+    public void incrementTwo(long n) {
+        counterTwo.inc(n);
+    }
+    
+    public void incrementThree(long n) {
+        counterThree.inc(n);
+    }
+}

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CounterFieldTagBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CounterFieldTagBeanTest.java
@@ -1,0 +1,110 @@
+/*
+ **********************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICES file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+package io.astefanutti.metrics.cdi.se;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.metrics.Counter;
+import org.eclipse.microprofile.metrics.MetricID;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.Tag;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class CounterFieldTagBeanTest {
+
+    private final static String COUNTER_NAME = MetricRegistry.name(CounterFieldTagBean.class, "counterName");
+    
+    private final static Tag NUMBER_TWO_TAG = new Tag("number", "two");
+    private final static Tag NUMBER_THREE_TAG = new Tag("number", "three");
+        
+    private final static Tag COLOUR_RED_TAG = new Tag("colour", "red"); 
+    private final static Tag COLOUR_BLUE_TAG = new Tag("colour", "blue"); 
+        
+    private final static MetricID COUNTER_MID = new MetricID(COUNTER_NAME);
+    private final static MetricID COUNTER_TWO_MID = new MetricID(COUNTER_NAME, NUMBER_TWO_TAG, COLOUR_RED_TAG);
+    private final static MetricID COUNTER_THREE_MID = new MetricID(COUNTER_NAME, NUMBER_THREE_TAG, COLOUR_BLUE_TAG);
+
+    @Deployment
+    public static Archive<?> createTestArchive() {
+        return ShrinkWrap.create(JavaArchive.class)
+            // Test bean
+            .addClass(CounterFieldTagBean.class)
+            // Bean archive deployment descriptor
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Inject
+    private MetricRegistry registry;
+
+    @Inject
+    private CounterFieldTagBean bean;
+
+    @Test
+    @InSequence(1)
+    public void counterTagFieldsRegistered() {      
+        
+        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(COUNTER_MID));
+        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(COUNTER_TWO_MID));
+        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(COUNTER_THREE_MID));
+    }
+
+    @Test
+    @InSequence(2)
+    public void incrementCounterTagFields() {
+        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(COUNTER_MID));
+        Counter counterOne = registry.getCounters().get(COUNTER_MID);
+        
+        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(COUNTER_TWO_MID));
+        Counter counterTwo = registry.getCounters().get(COUNTER_TWO_MID);
+        
+        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(COUNTER_THREE_MID));
+        Counter counterThree = registry.getCounters().get(COUNTER_THREE_MID);
+
+        // Call the increment method and assert the counter is up-to-date
+        long value = Math.round(Math.random() * Long.MAX_VALUE);
+        bean.incrementOne(value);
+        
+        long valueTwo = Math.round(Math.random() * Long.MAX_VALUE);
+        bean.incrementTwo(valueTwo);
+        
+        long valueThree = Math.round(Math.random() * Long.MAX_VALUE);
+        bean.incrementThree(valueThree);
+        
+        assertThat("Counter value is incorrect", counterOne.getCount(), is(equalTo(value)));
+        assertThat("Counter value is incorrect", counterTwo.getCount(), is(equalTo(valueTwo)));
+        assertThat("Counter value is incorrect", counterThree.getCount(), is(equalTo(valueThree)));
+    }
+}

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CounterFieldTagBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CounterFieldTagBeanTest.java
@@ -38,7 +38,7 @@ import org.jboss.arquillian.junit.InSequence;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -59,11 +59,11 @@ public class CounterFieldTagBeanTest {
 
     @Deployment
     public static Archive<?> createTestArchive() {
-        return ShrinkWrap.create(JavaArchive.class)
+        return ShrinkWrap.create(WebArchive.class)
             // Test bean
             .addClass(CounterFieldTagBean.class)
             // Bean archive deployment descriptor
-            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
     @Inject

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/DefaultNameMetricMethodBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/DefaultNameMetricMethodBeanTest.java
@@ -65,6 +65,6 @@ public class DefaultNameMetricMethodBeanTest {
 
     @Test
     public void metricMethodsWithDefaultNamingConvention() {
-        assertThat("Metrics are not registered correctly", registry.getMetrics().keySet(), is(equalTo(metricNames())));
+        assertThat("Metrics are not registered correctly", registry.getMetrics().keySet(), is(equalTo(MetricsUtil.createMetricIDs(metricNames()))));
     }
 }

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/GaugeMethodBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/GaugeMethodBeanTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertThat;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.metrics.Gauge;
+import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -40,6 +41,8 @@ public class GaugeMethodBeanTest {
 
     private final static String GAUGE_NAME = MetricRegistry.name(GaugeMethodBean.class, "gaugeMethod");
 
+    private final static MetricID GAUGE_METRICID = new MetricID(GAUGE_NAME);
+    
     @Deployment
     public static Archive<?> createTestArchive() {
         return ShrinkWrap.create(JavaArchive.class)
@@ -65,9 +68,9 @@ public class GaugeMethodBeanTest {
     @Test
     @InSequence(1)
     public void gaugeCalledWithDefaultValue() {
-        assertThat("Gauge is not registered correctly", registry.getGauges(), hasKey(GAUGE_NAME));
+        assertThat("Gauge is not registered correctly", registry.getGauges(), hasKey(GAUGE_METRICID));
         @SuppressWarnings("unchecked")
-        Gauge<Long> gauge = registry.getGauges().get(GAUGE_NAME);
+        Gauge<Long> gauge = registry.getGauges().get(GAUGE_METRICID);
 
         // Make sure that the gauge has the expected value
         assertThat("Gauge value is incorrect", gauge.getValue(), is(equalTo(0L)));
@@ -76,9 +79,9 @@ public class GaugeMethodBeanTest {
     @Test
     @InSequence(2)
     public void callGaugeAfterSetterCall() {
-        assertThat("Gauge is not registered correctly", registry.getGauges(), hasKey(GAUGE_NAME));
+        assertThat("Gauge is not registered correctly", registry.getGauges(), hasKey(GAUGE_METRICID));
         @SuppressWarnings("unchecked")
-        Gauge<Long> gauge = registry.getGauges().get(GAUGE_NAME);
+        Gauge<Long> gauge = registry.getGauges().get(GAUGE_METRICID);
 
         // Call the setter method and assert the gauge is up-to-date
         long value = Math.round(Math.random() * Long.MAX_VALUE);

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/GaugeTagMethodBean.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/GaugeTagMethodBean.java
@@ -1,0 +1,52 @@
+/*
+ **********************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICES file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+package io.astefanutti.metrics.cdi.se;
+
+import org.eclipse.microprofile.metrics.MetricUnits;
+import org.eclipse.microprofile.metrics.annotation.Gauge;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class GaugeTagMethodBean {
+
+    private long gaugeOne;
+    private long gaugeTwo;
+
+    @Gauge(name = "gaugeMethod", unit=MetricUnits.NONE, tags = {"number=one"})
+    public long getGaugeOne() {
+        return gaugeOne;
+    }
+    
+    @Gauge(name = "gaugeMethod", unit=MetricUnits.NONE, tags = {"number=two"})
+    public long getGaugeTwo() {
+        return gaugeTwo;
+    }
+
+    public void setGaugeOne(long gauge) {
+        this.gaugeOne = gauge;
+    }
+    
+    public void setGaugeTwo(long gauge) {
+        this.gaugeTwo = gauge;
+    }
+}

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/GaugeTagMethodBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/GaugeTagMethodBeanTest.java
@@ -1,0 +1,119 @@
+/*
+ **********************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICES file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+package io.astefanutti.metrics.cdi.se;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.metrics.Gauge;
+import org.eclipse.microprofile.metrics.MetricID;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.Tag;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class GaugeTagMethodBeanTest {
+
+    private final static String GAUGE_NAME = MetricRegistry.name(GaugeTagMethodBean.class, "gaugeMethod");
+
+    private final static Tag NUMBER_ONE_TAG = new Tag("number", "one");
+    private final static Tag NUMBER_TWO_TAG = new Tag("number", "two");
+    
+    private final static MetricID GAUGE_ONE_METRICID = new MetricID(GAUGE_NAME, NUMBER_ONE_TAG);
+    private final static MetricID GAUGE_TWO_METRICID = new MetricID(GAUGE_NAME, NUMBER_TWO_TAG);
+    
+    @Deployment
+    public static Archive<?> createTestArchive() {
+        return ShrinkWrap.create(JavaArchive.class)
+            // Test bean
+            .addClass(GaugeTagMethodBean.class)
+            // Bean archive deployment descriptor
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Inject
+    private MetricRegistry registry;
+
+    @Inject
+    private GaugeTagMethodBean bean;
+
+    @Before
+    public void instantiateApplicationScopedBean() {
+        // Let's trigger the instantiation of the application scoped bean explicitly
+        // as only a proxy gets injected otherwise
+        bean.getGaugeOne();
+        bean.getGaugeTwo();
+    }
+
+    @Test
+    @InSequence(1)
+    public void gaugeTagCalledWithDefaultValue() {
+        assertThat("Gauge is not registered correctly", registry.getGauges(), hasKey(GAUGE_ONE_METRICID));
+        assertThat("Gauge is not registered correctly", registry.getGauges(), hasKey(GAUGE_TWO_METRICID));
+        
+        @SuppressWarnings("unchecked")
+        Gauge<Long> gaugeOne = registry.getGauges().get(GAUGE_ONE_METRICID);
+
+        @SuppressWarnings("unchecked")
+        Gauge<Long> gaugeTwo = registry.getGauges().get(GAUGE_TWO_METRICID);
+        
+        // Make sure that the gauge has the expected value
+        assertThat("Gauge value is incorrect", gaugeOne.getValue(), is(equalTo(0L)));
+        assertThat("Gauge value is incorrect", gaugeTwo.getValue(), is(equalTo(0L)));
+    }
+
+    @Test
+    @InSequence(2)
+    public void callGaugeTagAfterSetterCall() {
+        assertThat("Gauge is not registered correctly", registry.getGauges(), hasKey(GAUGE_ONE_METRICID));
+        assertThat("Gauge is not registered correctly", registry.getGauges(), hasKey(GAUGE_TWO_METRICID));
+        
+        @SuppressWarnings("unchecked")
+        Gauge<Long> gaugeOne = registry.getGauges().get(GAUGE_ONE_METRICID);
+
+        @SuppressWarnings("unchecked")
+        Gauge<Long> gaugeTwo = registry.getGauges().get(GAUGE_TWO_METRICID);
+
+        // Call the setter method and assert the gauge is up-to-date
+        long value = Math.round(Math.random() * Long.MAX_VALUE);
+        bean.setGaugeOne(value);
+        
+        long secondValue = Math.round(Math.random() * Long.MAX_VALUE);
+        bean.setGaugeTwo(secondValue);
+        
+        assertThat("Gauge value is incorrect", gaugeOne.getValue(), is(equalTo(value)));
+        assertThat("Gauge value is incorrect", gaugeTwo.getValue(), is(equalTo(secondValue)));
+    }
+}

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/GaugeTagMethodBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/GaugeTagMethodBeanTest.java
@@ -38,7 +38,7 @@ import org.jboss.arquillian.junit.InSequence;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -56,11 +56,11 @@ public class GaugeTagMethodBeanTest {
     
     @Deployment
     public static Archive<?> createTestArchive() {
-        return ShrinkWrap.create(JavaArchive.class)
+        return ShrinkWrap.create(WebArchive.class)
             // Test bean
             .addClass(GaugeTagMethodBean.class)
             // Bean archive deployment descriptor
-            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
     @Inject

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/HistogramFieldBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/HistogramFieldBeanTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertThat;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.metrics.Histogram;
+import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -38,6 +39,7 @@ import org.junit.runner.RunWith;
 public class HistogramFieldBeanTest {
 
     private final static String HISTOGRAM_NAME = MetricRegistry.name(HistogramFieldBean.class, "histogramName");
+    private final static MetricID HISTOGRAM_METRICID = new MetricID(HISTOGRAM_NAME);
 
     @Deployment
     static Archive<?> createTestArchive() {
@@ -57,14 +59,14 @@ public class HistogramFieldBeanTest {
     @Test
     @InSequence(1)
     public void histogramFieldRegistered() {
-        assertThat("Histogram is not registered correctly", registry.getHistograms(), hasKey(HISTOGRAM_NAME));
+        assertThat("Histogram is not registered correctly", registry.getHistograms(), hasKey(HISTOGRAM_METRICID));
     }
 
     @Test
     @InSequence(2)
     public void updateHistogramField() {
-        assertThat("Histogram is not registered correctly", registry.getHistograms(), hasKey(HISTOGRAM_NAME));
-        Histogram histogram = registry.getHistograms().get(HISTOGRAM_NAME);
+        assertThat("Histogram is not registered correctly", registry.getHistograms(), hasKey(HISTOGRAM_METRICID));
+        Histogram histogram = registry.getHistograms().get(HISTOGRAM_METRICID);
 
         // Call the update method and assert the histogram is up-to-date
         long value = Math.round(Math.random() * Long.MAX_VALUE);

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/HistogramTagFieldBean.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/HistogramTagFieldBean.java
@@ -1,0 +1,47 @@
+/*
+ **********************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICES file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+package io.astefanutti.metrics.cdi.se;
+
+import org.eclipse.microprofile.metrics.Histogram;
+import org.eclipse.microprofile.metrics.annotation.Metric;
+
+import javax.inject.Inject;
+
+public class HistogramTagFieldBean {
+
+    @Inject
+    @Metric(name = "histogramName", tags= {"number=one"})
+    private Histogram histogramOne;
+
+    
+    @Inject
+    @Metric(name = "histogramName", tags= {"number=two"})
+    private Histogram histogramTwo;
+    
+    public void updateOne(long n) {
+        histogramOne.update(n);
+    }
+    
+    public void updateTwo(long n) {
+        histogramTwo.update(n);
+    }
+}

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/HistogramTagFieldBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/HistogramTagFieldBeanTest.java
@@ -38,7 +38,7 @@ import org.jboss.arquillian.junit.InSequence;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -55,11 +55,11 @@ public class HistogramTagFieldBeanTest {
     
     @Deployment
     static Archive<?> createTestArchive() {
-        return ShrinkWrap.create(JavaArchive.class)
+        return ShrinkWrap.create(WebArchive.class)
             // Test bean
             .addClass(HistogramTagFieldBean.class)
             // Bean archive deployment descriptor
-            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
     @Inject

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/HistogramTagFieldBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/HistogramTagFieldBeanTest.java
@@ -1,0 +1,104 @@
+/*
+ **********************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICES file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+package io.astefanutti.metrics.cdi.se;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.metrics.Histogram;
+import org.eclipse.microprofile.metrics.MetricID;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.Tag;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class HistogramTagFieldBeanTest {
+
+    private final static String HISTOGRAM_NAME = MetricRegistry.name(HistogramTagFieldBean.class, "histogramName");
+
+    private final static Tag NUMBER_ONE_TAG = new Tag("number", "one");
+    private final static Tag NUMBER_TWO_TAG = new Tag("number", "two");
+    
+    private final static MetricID HISTOGRAM_ONE_METRICID = new MetricID(HISTOGRAM_NAME, NUMBER_ONE_TAG);
+    private final static MetricID HISTOGRAM_TWO_METRICID = new MetricID(HISTOGRAM_NAME, NUMBER_TWO_TAG);
+    
+    @Deployment
+    static Archive<?> createTestArchive() {
+        return ShrinkWrap.create(JavaArchive.class)
+            // Test bean
+            .addClass(HistogramTagFieldBean.class)
+            // Bean archive deployment descriptor
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Inject
+    private MetricRegistry registry;
+
+    @Inject
+    private HistogramTagFieldBean bean;
+
+    @Test
+    @InSequence(1)
+    public void histogramTagFieldRegistered() {
+        assertThat("Histogram is not registered correctly", registry.getHistograms(), hasKey(HISTOGRAM_ONE_METRICID));
+        assertThat("Histogram is not registered correctly", registry.getHistograms(), hasKey(HISTOGRAM_TWO_METRICID));
+    }
+    
+    @Test
+    @InSequence(2)
+    public void updateHistogramTagField() {
+        assertThat("Histogram is not registered correctly", registry.getHistograms(), hasKey(HISTOGRAM_ONE_METRICID));
+        assertThat("Histogram is not registered correctly", registry.getHistograms(), hasKey(HISTOGRAM_TWO_METRICID));
+        
+        Histogram histogramOne = registry.getHistograms().get(HISTOGRAM_ONE_METRICID);
+        Histogram histogramTwo = registry.getHistograms().get(HISTOGRAM_TWO_METRICID);
+        
+        // Call the update method and assert the histogram is up-to-date
+        long value = Math.round(Math.random() * Long.MAX_VALUE);
+        bean.updateOne(value);
+        long valueTwo = Math.round(Math.random() * Long.MAX_VALUE);
+        bean.updateTwo(valueTwo);
+        
+        assertThat("Histogram count is incorrect", histogramOne.getCount(), is(equalTo(1L)));
+        assertThat("Histogram size is incorrect", histogramOne.getSnapshot().size(), is(equalTo(1)));
+        assertThat("Histogram min value is incorrect", histogramOne.getSnapshot().getMin(), is(equalTo(value)));
+        assertThat("Histogram max value is incorrect", histogramOne.getSnapshot().getMax(), is(equalTo(value)));
+        
+
+        assertThat("Histogram count is incorrect", histogramTwo.getCount(), is(equalTo(1L)));
+        assertThat("Histogram size is incorrect", histogramTwo.getSnapshot().size(), is(equalTo(1)));
+        assertThat("Histogram min value is incorrect", histogramTwo.getSnapshot().getMin(), is(equalTo(valueTwo)));
+        assertThat("Histogram max value is incorrect", histogramTwo.getSnapshot().getMax(), is(equalTo(valueTwo)));
+    }
+}

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/InheritedGaugeMethodBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/InheritedGaugeMethodBeanTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasKey;
 import static org.junit.Assert.assertThat;
+import org.eclipse.microprofile.metrics.MetricID;
 
 import java.util.Arrays;
 
@@ -42,7 +43,10 @@ public class InheritedGaugeMethodBeanTest {
 
     private final static String PARENT_GAUGE_NAME = MetricRegistry.name(InheritedParentGaugeMethodBean.class, "inheritedParentGaugeMethod");
     private final static String CHILD_GAUGE_NAME = MetricRegistry.name(InheritedChildGaugeMethodBean.class, "inheritedChildGaugeMethod");
-
+    
+    private final static MetricID PARENT_METRICID = new MetricID(PARENT_GAUGE_NAME);
+    private final static MetricID CHILD_METRICID = new MetricID(CHILD_GAUGE_NAME);
+    
     @Deployment
     public static Archive<?> createTestArchive() {
         return ShrinkWrap.create(JavaArchive.class)
@@ -73,12 +77,12 @@ public class InheritedGaugeMethodBeanTest {
     @Test
     @InSequence(1)
     public void gaugesCalledWithDefaultValues() {
-        assertThat("Gauges are not registered correctly", registry.getGauges(), allOf(hasKey(PARENT_GAUGE_NAME), hasKey(CHILD_GAUGE_NAME)));
+        assertThat("Gauges are not registered correctly", registry.getGauges(), allOf(hasKey(PARENT_METRICID), hasKey(CHILD_METRICID)));
 
         @SuppressWarnings("unchecked")
-        Gauge<Long> parentGauge = registry.getGauges().get(PARENT_GAUGE_NAME);
+        Gauge<Long> parentGauge = registry.getGauges().get(PARENT_METRICID);
         @SuppressWarnings("unchecked")
-        Gauge<Long> childGauge = registry.getGauges().get(CHILD_GAUGE_NAME);
+        Gauge<Long> childGauge = registry.getGauges().get(CHILD_METRICID);
 
         // Make sure that the gauge has the expected value
         assertThat("Gauge values are incorrect", Arrays.asList(parentGauge.getValue(), childGauge.getValue()), contains(0L, 0L));
@@ -87,11 +91,11 @@ public class InheritedGaugeMethodBeanTest {
     @Test
     @InSequence(2)
     public void callGaugesAfterSetterCalls() {
-        assertThat("Gauges are not registered correctly", registry.getGauges(), allOf(hasKey(PARENT_GAUGE_NAME), hasKey(CHILD_GAUGE_NAME)));
+        assertThat("Gauges are not registered correctly", registry.getGauges(), allOf(hasKey(PARENT_METRICID), hasKey(CHILD_METRICID)));
         @SuppressWarnings("unchecked")
-        Gauge<Long> parentGauge = registry.getGauges().get(PARENT_GAUGE_NAME);
+        Gauge<Long> parentGauge = registry.getGauges().get(PARENT_METRICID);
         @SuppressWarnings("unchecked")
-        Gauge<Long> childGauge = registry.getGauges().get(CHILD_GAUGE_NAME);
+        Gauge<Long> childGauge = registry.getGauges().get(CHILD_METRICID);
 
         // Call the setter methods and assert the gauges are up-to-date
         long parentValue = Math.round(Math.random() * Long.MAX_VALUE);

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/InheritedTimedMethodBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/InheritedTimedMethodBeanTest.java
@@ -70,7 +70,8 @@ public class InheritedTimedMethodBeanTest {
     @Test
     @InSequence(1)
     public void timedMethodsNotCalledYet() {
-        assertThat("Timers are not registered correctly", registry.getTimers().keySet(), is(equalTo(absoluteMetricNames())));
+        assertThat("Timers are not registered correctly", registry.getTimers().keySet(),
+            is(equalTo(MetricsUtil.createMetricIDs(absoluteMetricNames()))));
 
         // Make sure that all the timers haven't been called yet
         assertThat("Timer counts are incorrect", registry.getTimers().values(), everyItem(Matchers.<Timer>hasProperty("count", equalTo(0L))));
@@ -78,8 +79,9 @@ public class InheritedTimedMethodBeanTest {
 
     @Test
     @InSequence(2)
-    public void callTimedMethodsOnce() {
-        assertThat("Timers are not registered correctly", registry.getTimers().keySet(), is(equalTo(absoluteMetricNames())));
+    public void callTimedMethodsOnce() { 
+        assertThat("Timers are not registered correctly", registry.getTimers().keySet(),
+            is(equalTo(MetricsUtil.createMetricIDs(absoluteMetricNames()))));
 
         // Call the timed methods and assert they've all been timed once
         bean.publicTimedMethod();

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MeteredClassBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MeteredClassBeanTest.java
@@ -27,6 +27,7 @@ import javax.inject.Inject;
 
 import org.eclipse.microprofile.metrics.Meter;
 import org.eclipse.microprofile.metrics.Metric;
+import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricFilter;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.hamcrest.Matchers;
@@ -48,6 +49,8 @@ public class MeteredClassBeanTest {
     private static final String CONSTRUCTOR_NAME = "MeteredClassBean";
 
     private static final String CONSTRUCTOR_METER_NAME = MetricsUtil.absoluteMetricName(MeteredClassBean.class, "meteredClass", CONSTRUCTOR_NAME);
+    
+    private static final MetricID CONSTRUCTOR_METRICID = new MetricID(CONSTRUCTOR_METER_NAME);
 
     private static final String[] METHOD_NAMES = { "meteredMethodOne", "meteredMethodTwo", "meteredMethodProtected", "meteredMethodPackagedPrivate" };
 
@@ -63,6 +66,8 @@ public class MeteredClassBeanTest {
     private static final Set<String> METER_NAMES = MetricsUtil.absoluteMetricNames(MeteredClassBean.class, "meteredClass", METHOD_NAMES,
             CONSTRUCTOR_NAME);
 
+    private static final Set<MetricID> METER_METRICIDS = MetricsUtil.createMetricIDs(METER_NAMES);
+            
     private final static AtomicLong CONSTRUCTOR_COUNT = new AtomicLong();
 
     private final static AtomicLong METHOD_COUNT = new AtomicLong();
@@ -85,9 +90,10 @@ public class MeteredClassBeanTest {
     @Test
     @InSequence(1)
     public void meteredMethodsNotCalledYet() {
-        assertThat("Meters are not registered correctly", registry.getMeters().keySet(), is(equalTo(METER_NAMES)));
+        assertThat("Meters are not registered correctly", registry.getMeters().keySet(), is(equalTo(METER_METRICIDS)));
 
-        assertThat("Constructor meter count is incorrect", registry.getMeters().get(CONSTRUCTOR_METER_NAME).getCount(), 
+        
+        assertThat("Constructor meter count is incorrect", registry.getMeters().get(CONSTRUCTOR_METRICID).getCount(), 
                 is(equalTo(CONSTRUCTOR_COUNT.incrementAndGet())));
 
         // Make sure that the method meters haven't been marked yet
@@ -98,10 +104,10 @@ public class MeteredClassBeanTest {
 
     @Test
     @InSequence(2)
-    public void callMeteredMethodsOnce() {
-        assertThat("Meters are not registered correctly", registry.getMeters().keySet(), is(equalTo(METER_NAMES)));
+    public void callMeteredMethodsOnce() {        
+        assertThat("Meters are not registered correctly", registry.getMeters().keySet(), is(equalTo(METER_METRICIDS)));
         
-        assertThat("Constructor meter count is incorrect", registry.getMeters().get(CONSTRUCTOR_METER_NAME).getCount(),
+        assertThat("Constructor meter count is incorrect", registry.getMeters().get(CONSTRUCTOR_METRICID).getCount(),
                 is(equalTo(CONSTRUCTOR_COUNT.incrementAndGet())));
 
         // Call the metered methods and assert they've been marked

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MeteredClassBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MeteredClassBeanTest.java
@@ -58,8 +58,8 @@ public class MeteredClassBeanTest {
 
     private static final MetricFilter METHOD_METERS = new MetricFilter() {
         @Override
-        public boolean matches(String name, Metric metric) {
-            return METHOD_METER_NAMES.contains(name);
+        public boolean matches(MetricID metricID, Metric metric) {
+            return METHOD_METER_NAMES.contains(metricID.getName());
         }
     };
 

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MeteredConstructorBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MeteredConstructorBeanTest.java
@@ -24,6 +24,7 @@ import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.metrics.Meter;
+import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -39,6 +40,8 @@ import org.junit.runner.RunWith;
 public class MeteredConstructorBeanTest {
 
     private final static String METER_NAME = "meteredConstructor";
+    
+    private final static MetricID METER_METRICID = new MetricID(METER_NAME);
 
     @Deployment
     static Archive<?> createTestArchive() {
@@ -69,8 +72,8 @@ public class MeteredConstructorBeanTest {
             instance.get();
         }
 
-        assertThat("Meter is not registered correctly", registry.getMeters(), hasKey(METER_NAME));
-        Meter meter = registry.getMeters().get(METER_NAME);
+        assertThat("Meter is not registered correctly", registry.getMeters(), hasKey(METER_METRICID));
+        Meter meter = registry.getMeters().get(METER_METRICID);
 
         // Make sure that the meter has been called
         assertThat("Meter count is incorrect", meter.getCount(), is(equalTo(count)));

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MeteredMethodBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MeteredMethodBeanTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.metrics.Meter;
+import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -42,6 +43,7 @@ import org.junit.runner.RunWith;
 public class MeteredMethodBeanTest {
 
     private final static String METER_NAME = MetricRegistry.name(MeteredMethodBean1.class, "meteredMethod");
+    private final static MetricID METER_METRICID = new MetricID(METER_NAME);
 
     private final static AtomicLong METER_COUNT = new AtomicLong();
 
@@ -63,8 +65,8 @@ public class MeteredMethodBeanTest {
     @Test
     @InSequence(1)
     public void meteredMethodNotCalledYet() {
-        assertThat("Meter is not registered correctly", registry.getMeters(), hasKey(METER_NAME));
-        Meter meter = registry.getMeters().get(METER_NAME);
+        assertThat("Meter is not registered correctly", registry.getMeters(), hasKey(METER_METRICID));
+        Meter meter = registry.getMeters().get(METER_METRICID);
 
         // Make sure that the meter hasn't been marked yet
         assertThat("Meter count is incorrect", meter.getCount(), is(equalTo(METER_COUNT.get())));
@@ -73,8 +75,8 @@ public class MeteredMethodBeanTest {
     @Test
     @InSequence(2)
     public void callMeteredMethodOnce() {
-        assertThat("Meter is not registered correctly", registry.getMeters(), hasKey(METER_NAME));
-        Meter meter = registry.getMeters().get(METER_NAME);
+        assertThat("Meter is not registered correctly", registry.getMeters(), hasKey(METER_METRICID));
+        Meter meter = registry.getMeters().get(METER_METRICID);
 
         // Call the metered method and assert it's been marked
         bean.meteredMethod();
@@ -86,11 +88,11 @@ public class MeteredMethodBeanTest {
     @Test
     @InSequence(3)
     public void removeMeterFromRegistry() {
-        assertThat("Meter is not registered correctly", registry.getMeters(), hasKey(METER_NAME));
-        Meter meter = registry.getMeters().get(METER_NAME);
+        assertThat("Meter is not registered correctly", registry.getMeters(), hasKey(METER_METRICID));
+        Meter meter = registry.getMeters().get(METER_METRICID);
 
         // Remove the meter from metrics registry
-        registry.remove(METER_NAME);
+        registry.remove(METER_METRICID);
 
         try {
             // Call the metered method and assert an exception is thrown

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MeteredTagMethodBean.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MeteredTagMethodBean.java
@@ -1,0 +1,35 @@
+/*
+ **********************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICES file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+package io.astefanutti.metrics.cdi.se;
+
+import org.eclipse.microprofile.metrics.annotation.Metered;
+
+public class MeteredTagMethodBean {
+
+    @Metered(name = "meteredMethod", tags= {"number=one"})
+    public void meteredMethodOne() {
+    }
+    
+    @Metered(name = "meteredMethod", tags= {"number=two"})
+    public void meteredMethodTwo() {
+    }
+}

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MeteredTagMethodBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MeteredTagMethodBeanTest.java
@@ -1,0 +1,75 @@
+/*
+ **********************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICES file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+package io.astefanutti.metrics.cdi.se;
+
+import static org.hamcrest.Matchers.hasKey;
+import static org.junit.Assert.assertThat;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.metrics.MetricID;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.Tag;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class MeteredTagMethodBeanTest {
+
+    private final static String METER_NAME = MetricRegistry.name(MeteredTagMethodBean.class, "meteredMethod");
+    
+    private final static Tag NUMBER_ONE_TAG = new Tag("number", "one");
+    private final static Tag NUMBER_TWO_TAG = new Tag("number", "two");
+    
+    private final static MetricID METER_ONE_METRICID = new MetricID(METER_NAME, NUMBER_ONE_TAG);
+    private final static MetricID METER_TWO_METRICID = new MetricID(METER_NAME, NUMBER_TWO_TAG);
+
+
+    @Deployment
+    static Archive<?> createTestArchive() {
+        return ShrinkWrap.create(JavaArchive.class)
+            // Test bean
+            .addClass(MeteredTagMethodBean.class)
+            // Bean archive deployment descriptor
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Inject
+    private MetricRegistry registry;
+
+    @Inject
+    private MeteredTagMethodBean bean;
+
+    @Test
+    @InSequence(1)
+    public void meteredTagMethodRegistered() {
+        assertThat("Meter is not registered correctly", registry.getMeters(), hasKey(METER_ONE_METRICID));
+        assertThat("Meter is not registered correctly", registry.getMeters(), hasKey(METER_TWO_METRICID));
+    }
+}

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MeteredTagMethodBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MeteredTagMethodBeanTest.java
@@ -35,7 +35,7 @@ import org.jboss.arquillian.junit.InSequence;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -53,11 +53,11 @@ public class MeteredTagMethodBeanTest {
 
     @Deployment
     static Archive<?> createTestArchive() {
-        return ShrinkWrap.create(JavaArchive.class)
+        return ShrinkWrap.create(WebArchive.class)
             // Test bean
             .addClass(MeteredTagMethodBean.class)
             // Bean archive deployment descriptor
-            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
     @Inject

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MetricProducerFieldBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MetricProducerFieldBeanTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertThat;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.metrics.Counter;
+import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.Gauge;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.annotation.Metric;
@@ -42,6 +43,11 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class MetricProducerFieldBeanTest {
 
+    private final static MetricID COUNTER1_METRICID = new MetricID("counter1");
+    private final static MetricID COUNTER2_METRICID = new MetricID("counter2");
+    private final static MetricID RATIO_GAUGE_METRICID = new MetricID("ratioGauge");
+    private final static MetricID NOTREG_METRICID = new MetricID("not_registered_counter");
+    
     @Deployment
     static Archive<?> createTestArchive() {
         return ShrinkWrap.create(JavaArchive.class)
@@ -69,17 +75,17 @@ public class MetricProducerFieldBeanTest {
     public void countersNotIncrementedYet() {
         assertThat("Counters are not registered correctly", registry.getCounters(),
             allOf(
-                hasKey("counter1"),
-                hasKey("counter2"),
-                not(hasKey("not_registered_counter"))
+                hasKey(COUNTER1_METRICID),
+                hasKey(COUNTER2_METRICID),
+                not(hasKey(NOTREG_METRICID))
             )
         );
-        Counter counter1 = registry.getCounters().get("counter1");
-        Counter counter2 = registry.getCounters().get("counter2");
+        Counter counter1 = registry.getCounters().get(COUNTER1_METRICID);
+        Counter counter2 = registry.getCounters().get(COUNTER2_METRICID);
 
-        assertThat("Gauge is not registered correctly", registry.getGauges(), hasKey("ratioGauge"));
+        assertThat("Gauge is not registered correctly", registry.getGauges(), hasKey(RATIO_GAUGE_METRICID));
         @SuppressWarnings("unchecked")
-        Gauge<Double> gauge = (Gauge<Double>) registry.getGauges().get("ratioGauge");
+        Gauge<Double> gauge = (Gauge<Double>) registry.getGauges().get(RATIO_GAUGE_METRICID);
 
         assertThat("Gauge value is incorrect", gauge.getValue(), is(equalTo(((double) counter1.getCount()) / ((double) counter2.getCount()))));
     }
@@ -89,17 +95,17 @@ public class MetricProducerFieldBeanTest {
     public void incrementCountersFromRegistry() {
         assertThat("Counters are not registered correctly", registry.getCounters(),
             allOf(
-                hasKey("counter1"),
-                hasKey("counter2"),
-                not(hasKey("not_registered_counter"))
+                hasKey(COUNTER1_METRICID),
+                hasKey(COUNTER2_METRICID),
+                not(hasKey(NOTREG_METRICID))
             )
         );
-        Counter counter1 = registry.getCounters().get("counter1");
-        Counter counter2 = registry.getCounters().get("counter2");
+        Counter counter1 = registry.getCounters().get(COUNTER1_METRICID);
+        Counter counter2 = registry.getCounters().get(COUNTER2_METRICID);
 
-        assertThat("Gauge is not registered correctly", registry.getGauges(), hasKey("ratioGauge"));
+        assertThat("Gauge is not registered correctly", registry.getGauges(), hasKey(RATIO_GAUGE_METRICID));
         @SuppressWarnings("unchecked")
-        Gauge<Double> gauge = (Gauge<Double>) registry.getGauges().get("ratioGauge");
+        Gauge<Double> gauge = (Gauge<Double>) registry.getGauges().get(RATIO_GAUGE_METRICID);
 
         counter1.inc(Math.round(Math.random() * Integer.MAX_VALUE));
         counter2.inc(Math.round(Math.random() * Integer.MAX_VALUE));

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MetricProducerMethodBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MetricProducerMethodBeanTest.java
@@ -25,6 +25,7 @@ import javax.inject.Inject;
 
 import org.eclipse.microprofile.metrics.Gauge;
 import org.eclipse.microprofile.metrics.Meter;
+import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.Timer;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -43,9 +44,15 @@ public class MetricProducerMethodBeanTest {
 
     private final static String CALLS_METRIC = MetricRegistry.name(MetricProducerMethodBean.class, "calls");
 
+    private final static MetricID CALLS_METRICID = new MetricID(CALLS_METRIC); 
+    
     private final static String HITS_METRIC = MetricRegistry.name(MetricProducerMethodBean.class, "hits");
 
+    private final static MetricID HITS_METRICID = new MetricID(HITS_METRIC); 
+    
     private final static String CACHE_HITS_METRIC = MetricRegistry.name(MetricProducerMethodBean.class, "cache-hits");
+    
+    private final static MetricID CACHE_HITS_METRICID = new MetricID(CACHE_HITS_METRIC); 
 
     @Deployment
     static Archive<?> createTestArchive() {
@@ -74,15 +81,15 @@ public class MetricProducerMethodBeanTest {
     public void cachedMethodNotCalledYet() {
         assertThat("Metrics are not registered correctly", registry.getMetrics(),
             allOf(
-                hasKey(CALLS_METRIC),
-                hasKey(HITS_METRIC),
-                hasKey(CACHE_HITS_METRIC)
+                hasKey(CALLS_METRICID),
+                hasKey(HITS_METRICID),
+                hasKey(CACHE_HITS_METRICID)
             )
         );
-        Timer calls = registry.getTimers().get(CALLS_METRIC);
-        Meter hits = registry.getMeters().get(HITS_METRIC);
+        Timer calls = registry.getTimers().get(CALLS_METRICID);
+        Meter hits = registry.getMeters().get(HITS_METRICID);
         @SuppressWarnings("unchecked")
-        Gauge<Double> gauge = (Gauge<Double>) registry.getGauges().get(CACHE_HITS_METRIC);
+        Gauge<Double> gauge = (Gauge<Double>) registry.getGauges().get(CACHE_HITS_METRICID);
 
         assertThat("Gauge value is incorrect", gauge.getValue(), is(equalTo(((double) hits.getCount() / (double) calls.getCount()))));
     }
@@ -92,15 +99,15 @@ public class MetricProducerMethodBeanTest {
     public void callCachedMethodMultipleTimes() {
         assertThat("Metrics are not registered correctly", registry.getMetrics(),
             allOf(
-                hasKey(CALLS_METRIC),
-                hasKey(HITS_METRIC),
-                hasKey(CACHE_HITS_METRIC)
+                hasKey(CALLS_METRICID),
+                hasKey(HITS_METRICID),
+                hasKey(CACHE_HITS_METRICID)
             )
         );
-        Timer calls = registry.getTimers().get(CALLS_METRIC);
-        Meter hits = registry.getMeters().get(HITS_METRIC);
+        Timer calls = registry.getTimers().get(CALLS_METRICID);
+        Meter hits = registry.getMeters().get(HITS_METRICID);
         @SuppressWarnings("unchecked")
-        Gauge<Double> gauge = (Gauge<Double>) registry.getGauges().get(CACHE_HITS_METRIC);
+        Gauge<Double> gauge = (Gauge<Double>) registry.getGauges().get(CACHE_HITS_METRICID);
 
         long count = 10 + Math.round(Math.random() * 10);
         for (int i = 0; i < count; i++) {

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MonotonicCountedClassBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MonotonicCountedClassBeanTest.java
@@ -65,8 +65,8 @@ public class MonotonicCountedClassBeanTest {
             
     private static final MetricFilter METHOD_COUNTERS = new MetricFilter() {
         @Override
-        public boolean matches(String name, Metric metric) {
-            return METHOD_COUNTER_NAMES.contains(name);
+        public boolean matches(MetricID metricID, Metric metric) {
+            return METHOD_COUNTER_NAMES.contains(metricID.getName());
         }
     };
 

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MonotonicCountedClassBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MonotonicCountedClassBeanTest.java
@@ -27,6 +27,7 @@ import javax.inject.Inject;
 
 import org.eclipse.microprofile.metrics.Counter;
 import org.eclipse.microprofile.metrics.Metric;
+import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricFilter;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.hamcrest.Matchers;
@@ -50,6 +51,8 @@ public class MonotonicCountedClassBeanTest {
     private static final String CONSTRUCTOR_COUNTER_NAME = MetricsUtil.absoluteMetricName(MonotonicCountedClassBean.class, "monotonicCountedClass",
             CONSTRUCTOR_NAME);
 
+    private static final MetricID CONSTRUCTOR_METRICID = new MetricID(CONSTRUCTOR_COUNTER_NAME);
+            
     private static final String[] METHOD_NAMES = { "countedMethodOne", "countedMethodTwo", "countedMethodProtected", "countedMethodPackagedPrivate" };
 
     private static final Set<String> METHOD_COUNTER_NAMES = MetricsUtil.absoluteMetricNames(MonotonicCountedClassBean.class, "monotonicCountedClass",
@@ -58,6 +61,8 @@ public class MonotonicCountedClassBeanTest {
     private static final Set<String> COUNTER_NAMES = MetricsUtil.absoluteMetricNames(MonotonicCountedClassBean.class, "monotonicCountedClass",
             METHOD_NAMES, CONSTRUCTOR_NAME);
 
+    private static final Set<MetricID> COUNTER_METRICIDS = MetricsUtil.createMetricIDs(COUNTER_NAMES);
+            
     private static final MetricFilter METHOD_COUNTERS = new MetricFilter() {
         @Override
         public boolean matches(String name, Metric metric) {
@@ -85,9 +90,9 @@ public class MonotonicCountedClassBeanTest {
     @Test
     @InSequence(1)
     public void countedMethodsNotCalledYet() {
-        assertThat("Counters are not registered correctly", registry.getCounters().keySet(), is(equalTo(COUNTER_NAMES)));
+        assertThat("Counters are not registered correctly", registry.getCounters().keySet(), is(equalTo(COUNTER_METRICIDS)));
 
-        assertThat("Constructor timer count is incorrect", registry.getCounters().get(CONSTRUCTOR_COUNTER_NAME).getCount(),
+        assertThat("Constructor timer count is incorrect", registry.getCounters().get(CONSTRUCTOR_METRICID).getCount(),
                 is(equalTo(CONSTRUCTOR_COUNT.incrementAndGet())));
 
         // Make sure that the counters haven't been incremented
@@ -97,10 +102,10 @@ public class MonotonicCountedClassBeanTest {
 
     @Test
     @InSequence(2)
-    public void callCountedMethodsOnce() {
-        assertThat("Counters are not registered correctly", registry.getCounters().keySet(), is(equalTo(COUNTER_NAMES)));
+    public void callCountedMethodsOnce() { 
+        assertThat("Counters are not registered correctly", registry.getCounters().keySet(), is(equalTo(COUNTER_METRICIDS)));
         
-        assertThat("Constructor timer count is incorrect", registry.getCounters().get(CONSTRUCTOR_COUNTER_NAME).getCount(),
+        assertThat("Constructor timer count is incorrect", registry.getCounters().get(CONSTRUCTOR_METRICID).getCount(),
                 is(equalTo(CONSTRUCTOR_COUNT.incrementAndGet())));
 
         // Call the counted methods and assert they've been incremented

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MonotonicCountedMethodBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MonotonicCountedMethodBeanTest.java
@@ -33,6 +33,7 @@ import javax.inject.Inject;
 import org.eclipse.microprofile.metrics.Counter;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.annotation.Metric;
+import org.eclipse.microprofile.metrics.MetricID;
 import org.hamcrest.Matchers;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -48,6 +49,7 @@ import org.junit.runner.RunWith;
 public class MonotonicCountedMethodBeanTest {
 
     private final static String COUNTER_NAME = "monotonicCountedMethod";
+    private final static MetricID COUNTER_METRICID = new MetricID(COUNTER_NAME);
 
     private final static AtomicLong COUNTER_COUNT = new AtomicLong();
 
@@ -69,8 +71,8 @@ public class MonotonicCountedMethodBeanTest {
     @Test
     @InSequence(1)
     public void countedMethodNotCalledYet() {
-        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(COUNTER_NAME));
-        Counter counter = registry.getCounters().get(COUNTER_NAME);
+        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(COUNTER_METRICID));
+        Counter counter = registry.getCounters().get(COUNTER_METRICID);
 
         // Make sure that the counter hasn't been called yet
         assertThat("Counter count is incorrect", counter.getCount(), is(equalTo(COUNTER_COUNT.get())));
@@ -79,8 +81,8 @@ public class MonotonicCountedMethodBeanTest {
     @Test
     @InSequence(2)
     public void countedMethodNotCalledYet(@Metric(name = "monotonicCountedMethod", absolute = true) Counter instance) {
-        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(COUNTER_NAME));
-        Counter counter = registry.getCounters().get(COUNTER_NAME);
+        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(COUNTER_METRICID));
+        Counter counter = registry.getCounters().get(COUNTER_METRICID);
 
         // Make sure that the counter registered and the bean instance are the same
         assertThat("Counter and bean instance are not equal", instance, is(equalTo(counter)));
@@ -89,8 +91,8 @@ public class MonotonicCountedMethodBeanTest {
     @Test
     @InSequence(3)
     public void callCountedMethodOnce() throws InterruptedException, TimeoutException {
-        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(COUNTER_NAME));
-        Counter counter = registry.getCounters().get(COUNTER_NAME);
+        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(COUNTER_METRICID));
+        Counter counter = registry.getCounters().get(COUNTER_METRICID);
 
         // Call the counted method, block and assert it's been counted
         final Exchanger<Long> exchanger = new Exchanger<>();
@@ -142,11 +144,11 @@ public class MonotonicCountedMethodBeanTest {
     @Test
     @InSequence(4)
     public void removeMonotonicCounterFromRegistry() {
-        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(COUNTER_NAME));
-        Counter counter = registry.getCounters().get(COUNTER_NAME);
+        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(COUNTER_METRICID));
+        Counter counter = registry.getCounters().get(COUNTER_METRICID);
 
         // Remove the counter from metrics registry
-        registry.remove(COUNTER_NAME);
+        registry.remove(COUNTER_METRICID);
 
         try {
             // Call the counted method and assert an exception is thrown

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MultipleMetricsConstructorBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MultipleMetricsConstructorBeanTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertThat;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 
+import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -73,8 +74,11 @@ public class MultipleMetricsConstructorBeanTest {
         }
 
         // Make sure that the metrics have been called
-        assertThat("Counter count is incorrect", registry.getCounters().get(absoluteMetricName("counter")).getCount(), is(equalTo(count)));
-        assertThat("Meter count is incorrect", registry.getMeters().get(absoluteMetricName("meter")).getCount(), is(equalTo(count)));
-        assertThat("Timer count is incorrect", registry.getTimers().get(absoluteMetricName("timer")).getCount(), is(equalTo(count)));
+        assertThat("Counter count is incorrect", registry.getCounters()
+                .get(new MetricID(absoluteMetricName("counter"))).getCount(), is(equalTo(count)));
+        assertThat("Meter count is incorrect", registry.getMeters()
+                .get(new MetricID(absoluteMetricName("meter"))).getCount(), is(equalTo(count)));
+        assertThat("Timer count is incorrect", registry.getTimers()
+                .get(new MetricID(absoluteMetricName("timer"))).getCount(), is(equalTo(count)));
     }
 }

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MultipleMetricsMethodBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MultipleMetricsMethodBeanTest.java
@@ -24,6 +24,7 @@ import java.util.Set;
 
 import javax.inject.Inject;
 
+import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -77,23 +78,29 @@ public class MultipleMetricsMethodBeanTest {
     @Test
     @InSequence(1)
     public void metricsMethodNotCalledYet() {
-        assertThat("Metrics are not registered correctly", registry.getMetrics().keySet(), is(equalTo(absoluteMetricNames())));
+        assertThat("Metrics are not registered correctly", registry.getMetrics().keySet(), 
+            is(equalTo(MetricsUtil.createMetricIDs(absoluteMetricNames()))));
     }
 
     @Test
     @InSequence(2)
     public void callMetricsMethodOnce() {
-        assertThat("Metrics are not registered correctly", registry.getMetrics().keySet(), is(equalTo(absoluteMetricNames())));
+        assertThat("Metrics are not registered correctly", registry.getMetrics().keySet(),
+            is(equalTo(MetricsUtil.createMetricIDs(absoluteMetricNames()))));
 
         // Call the monitored method and assert it's been instrumented
         bean.metricsMethod();
 
         // Make sure that the metrics have been called
-        assertThat("Counter count is incorrect", registry.getCounters().get(absoluteMetricName("counter")).getCount(), is(equalTo(1L)));
-        assertThat("Meter count is incorrect", registry.getMeters().get(absoluteMetricName("meter")).getCount(), is(equalTo(1L)));
-        assertThat("Timer count is incorrect", registry.getTimers().get(absoluteMetricName("timer")).getCount(), is(equalTo(1L)));
+        assertThat("Counter count is incorrect", registry.getCounters()
+                .get(new MetricID(absoluteMetricName("counter"))).getCount(), is(equalTo(1L)));
+        assertThat("Meter count is incorrect", registry.getMeters()
+                .get(new MetricID(absoluteMetricName("meter"))).getCount(), is(equalTo(1L)));
+        assertThat("Timer count is incorrect", registry.getTimers()
+                .get(new MetricID(absoluteMetricName("timer"))).getCount(), is(equalTo(1L)));
         // Let's call the gauge at the end as Weld is intercepting the gauge
         // invocation while OWB not
-        assertThat("Gauge value is incorrect", registry.getGauges().get(absoluteMetricName("gauge")).getValue(), hasToString((equalTo("value"))));
+        assertThat("Gauge value is incorrect", registry.getGauges()
+                .get(new MetricID(absoluteMetricName("gauge"))).getValue(), hasToString((equalTo("value"))));
     }
 }

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/OverloadedTimedMethodBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/OverloadedTimedMethodBeanTest.java
@@ -68,7 +68,8 @@ public class OverloadedTimedMethodBeanTest {
     @Test
     @InSequence(1)
     public void overloadedTimedMethodNotCalledYet() {
-        Assert.assertTrue("Metrics are not registered correctly", registry.getMetrics().keySet().containsAll(absoluteMetricNames()));
+        Assert.assertTrue("Metrics are not registered correctly", 
+            registry.getMetrics().keySet().containsAll(MetricsUtil.createMetricIDs(absoluteMetricNames())));
 
         // Make sure that all the timers haven't been called yet
         assertThat("Timer counts are incorrect", registry.getTimers().values(), hasItem(Matchers.<Timer> hasProperty("count", equalTo(0L))));
@@ -77,7 +78,8 @@ public class OverloadedTimedMethodBeanTest {
     @Test
     @InSequence(2)
     public void callOverloadedTimedMethodOnce() {
-        Assert.assertTrue("Metrics are not registered correctly", registry.getMetrics().keySet().containsAll(absoluteMetricNames()));
+        Assert.assertTrue("Metrics are not registered correctly", 
+            registry.getMetrics().keySet().containsAll(MetricsUtil.createMetricIDs(absoluteMetricNames())));
 
         // Call the timed methods and assert they've all been timed once
         bean.overloadedTimedMethod();

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/TimedClassBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/TimedClassBeanTest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.metrics.Metric;
+import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricFilter;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.Timer;
@@ -50,6 +51,8 @@ public class TimedClassBeanTest {
 
     private static final String CONSTRUCTOR_TIMER_NAME = MetricsUtil.absoluteMetricName(TimedClassBean.class, "timedClass", CONSTRUCTOR_NAME);
 
+    private static final MetricID CONSTRUCTOR_METRICID = new MetricID(CONSTRUCTOR_TIMER_NAME);
+    
     private static final String[] METHOD_NAMES = { "timedMethodOne", "timedMethodTwo", "timedMethodProtected", "timedMethodPackagedPrivate" };
 
     private static final Set<String> METHOD_TIMER_NAMES = MetricsUtil.absoluteMetricNames(TimedClassBean.class, "timedClass", METHOD_NAMES);
@@ -63,6 +66,8 @@ public class TimedClassBeanTest {
 
     private static final Set<String> TIMER_NAMES = MetricsUtil.absoluteMetricNames(TimedClassBean.class, "timedClass", METHOD_NAMES,
             CONSTRUCTOR_NAME);
+            
+    private static final Set<MetricID> TIMER_METRICIDS = MetricsUtil.createMetricIDs(TIMER_NAMES);
 
     private static final AtomicLong METHOD_COUNT = new AtomicLong();
 
@@ -92,9 +97,9 @@ public class TimedClassBeanTest {
     @Test
     @InSequence(1)
     public void timedMethodsNotCalledYet() {
-        assertThat("Timers are not registered correctly", registry.getTimers().keySet(), is(equalTo(TIMER_NAMES)));
+        assertThat("Timers are not registered correctly", registry.getTimers().keySet(), is(equalTo(TIMER_METRICIDS)));
         
-        assertThat("Constructor timer count is incorrect", registry.getTimers().get(CONSTRUCTOR_TIMER_NAME).getCount(), is(equalTo(1L)));
+        assertThat("Constructor timer count is incorrect", registry.getTimers().get(CONSTRUCTOR_METRICID).getCount(), is(equalTo(1L)));
 
         // Make sure that the method timers haven't been timed yet
         assertThat("Method timer counts are incorrect", registry.getTimers(METHOD_TIMERS).values(),
@@ -104,9 +109,9 @@ public class TimedClassBeanTest {
     @Test
     @InSequence(2)
     public void callTimedMethodsOnce() {
-        assertThat("Timers are not registered correctly", registry.getTimers().keySet(), is(equalTo(TIMER_NAMES)));
+        assertThat("Timers are not registered correctly", registry.getTimers().keySet(), is(equalTo(TIMER_METRICIDS)));
         
-        assertThat("Constructor timer count is incorrect", registry.getTimers().get(CONSTRUCTOR_TIMER_NAME).getCount(), is(equalTo(1L)));
+        assertThat("Constructor timer count is incorrect", registry.getTimers().get(CONSTRUCTOR_METRICID).getCount(), is(equalTo(1L)));
 
         // Call the timed methods and assert they've been timed
         bean.timedMethodOne();

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/TimedClassBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/TimedClassBeanTest.java
@@ -59,8 +59,8 @@ public class TimedClassBeanTest {
 
     private static final MetricFilter METHOD_TIMERS = new MetricFilter() {
         @Override
-        public boolean matches(String name, Metric metric) {
-            return METHOD_TIMER_NAMES.contains(name);
+        public boolean matches(MetricID metricID, Metric metric) {
+            return METHOD_TIMER_NAMES.contains(metricID.getName());
         }
     };
 

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/TimedConstructorBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/TimedConstructorBeanTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertThat;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 
+import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.Timer;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -40,6 +41,8 @@ public class TimedConstructorBeanTest {
 
     private final static String TIMER_NAME = MetricRegistry.name(TimedConstructorBean.class, "timedConstructor");
 
+    private final static MetricID TIMER_METRICID = new MetricID(TIMER_NAME);
+    
     @Deployment
     static Archive<?> createTestArchive() {
         return ShrinkWrap.create(JavaArchive.class)
@@ -72,8 +75,8 @@ public class TimedConstructorBeanTest {
             instance.get();
         }
 
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(TIMER_NAME));
-        Timer timer = registry.getTimers().get(TIMER_NAME);
+        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(TIMER_METRICID));
+        Timer timer = registry.getTimers().get(TIMER_METRICID);
 
         // Make sure that the timer has been called
         assertThat("Timer count is incorrect", timer.getCount(), is(equalTo(count)));

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/TimedMethodBeanLookupTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/TimedMethodBeanLookupTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 
+import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.Timer;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -43,6 +44,8 @@ import org.junit.runner.RunWith;
 public class TimedMethodBeanLookupTest {
 
     private final static String TIMER_NAME = MetricRegistry.name(TimedMethodBean1.class, "timedMethod");
+    
+    private final static MetricID TIMER_METRICID = new MetricID(TIMER_NAME);
 
     private final static AtomicLong TIMER_COUNT = new AtomicLong();
 
@@ -67,8 +70,8 @@ public class TimedMethodBeanLookupTest {
         // Get a contextual instance of the bean
         TimedMethodBean1 bean = instance.get();
 
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(TIMER_NAME));
-        Timer timer = registry.getTimers().get(TIMER_NAME);
+        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(TIMER_METRICID));
+        Timer timer = registry.getTimers().get(TIMER_METRICID);
 
         // Make sure that the timer hasn't been called yet
         assertThat("Timer count is incorrect", timer.getCount(), is(equalTo(TIMER_COUNT.get())));
@@ -80,8 +83,8 @@ public class TimedMethodBeanLookupTest {
         // Get a contextual instance of the bean
         TimedMethodBean1 bean = instance.get();
 
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(TIMER_NAME));
-        Timer timer = registry.getTimers().get(TIMER_NAME);
+        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(TIMER_METRICID));
+        Timer timer = registry.getTimers().get(TIMER_METRICID);
 
         // Call the timed method and assert it's been timed
         bean.timedMethod();
@@ -96,11 +99,11 @@ public class TimedMethodBeanLookupTest {
         // Get a contextual instance of the bean
         TimedMethodBean1 bean = instance.get();
 
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(TIMER_NAME));
-        Timer timer = registry.getTimers().get(TIMER_NAME);
+        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(TIMER_METRICID));
+        Timer timer = registry.getTimers().get(TIMER_METRICID);
 
         // Remove the timer from metrics registry
-        registry.remove(TIMER_NAME);
+        registry.remove(TIMER_METRICID);
 
         try {
             // Call the timed method and assert an exception is thrown

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/TimedMethodBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/TimedMethodBeanTest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import javax.inject.Inject;
 
+import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.Timer;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -43,6 +44,8 @@ public class TimedMethodBeanTest {
 
     private final static String TIMER_NAME = MetricRegistry.name(TimedMethodBean2.class, "timedMethod");
 
+    private final static MetricID TIMER_METRICID = new MetricID(TIMER_NAME);
+    
     private final static AtomicLong TIMER_COUNT = new AtomicLong();
 
     @Deployment
@@ -63,8 +66,8 @@ public class TimedMethodBeanTest {
     @Test
     @InSequence(1)
     public void timedMethodNotCalledYet() {
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(TIMER_NAME));
-        Timer timer = registry.getTimers().get(TIMER_NAME);
+        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(TIMER_METRICID));
+        Timer timer = registry.getTimers().get(TIMER_METRICID);
 
         // Make sure that the timer hasn't been called yet
         assertThat("Timer count is incorrect", timer.getCount(), is(equalTo(TIMER_COUNT.get())));
@@ -73,8 +76,8 @@ public class TimedMethodBeanTest {
     @Test
     @InSequence(2)
     public void callTimedMethodOnce() {
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(TIMER_NAME));
-        Timer timer = registry.getTimers().get(TIMER_NAME);
+        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(TIMER_METRICID));
+        Timer timer = registry.getTimers().get(TIMER_METRICID);
 
         // Call the timed method and assert it's been timed
         bean.timedMethod();
@@ -86,8 +89,8 @@ public class TimedMethodBeanTest {
     @Test
     @InSequence(3)
     public void callSelfInvocationTimedMethodOnce() {
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(TIMER_NAME));
-        Timer timer = registry.getTimers().get(TIMER_NAME);
+        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(TIMER_METRICID));
+        Timer timer = registry.getTimers().get(TIMER_METRICID);
 
         // Call the timed method indirectly
         bean.selfInvocationTimedMethod();
@@ -103,11 +106,11 @@ public class TimedMethodBeanTest {
     @Test
     @InSequence(4)
     public void removeTimerFromRegistry() {
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(TIMER_NAME));
-        Timer timer = registry.getTimers().get(TIMER_NAME);
+        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(TIMER_METRICID));
+        Timer timer = registry.getTimers().get(TIMER_METRICID);
 
         // Remove the timer from metrics registry
-        registry.remove(TIMER_NAME);
+        registry.remove(TIMER_METRICID);
 
         try {
             // Call the timed method and assert an exception is thrown

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/TimedTagMethodBean.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/TimedTagMethodBean.java
@@ -1,0 +1,35 @@
+/*
+ **********************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICES file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+package io.astefanutti.metrics.cdi.se;
+
+import org.eclipse.microprofile.metrics.annotation.Timed;
+
+public class TimedTagMethodBean {
+
+    @Timed(name = "timedMethod", tags= {"number=one"})
+    public void timedMethodOne() {
+    }
+
+    @Timed(name = "timedMethod", tags= {"number=two"})
+    public void timedMethodTwo() {
+    }
+}

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/TimedTagMethodBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/TimedTagMethodBeanTest.java
@@ -35,7 +35,7 @@ import org.jboss.arquillian.junit.InSequence;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -52,11 +52,11 @@ public class TimedTagMethodBeanTest {
 
     @Deployment
     static Archive<?> createTestArchive() {
-        return ShrinkWrap.create(JavaArchive.class)
+        return ShrinkWrap.create(WebArchive.class)
             // Test bean
             .addClass(TimedTagMethodBean.class)
             // Bean archive deployment descriptor
-            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
     @Inject

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/TimedTagMethodBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/TimedTagMethodBeanTest.java
@@ -1,0 +1,76 @@
+/*
+ **********************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICES file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+package io.astefanutti.metrics.cdi.se;
+
+import static org.hamcrest.Matchers.hasKey;
+import static org.junit.Assert.assertThat;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.metrics.MetricID;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.Tag;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class TimedTagMethodBeanTest {
+
+    private final static String TIMER_NAME = MetricRegistry.name(TimedTagMethodBean.class, "timedMethod");
+    
+    private final static Tag NUMBER_ONE_TAG = new Tag("number", "one");
+    private final static Tag NUMBER_TWO_TAG = new Tag("number", "two");
+    
+    private final static MetricID TIMER_ONE_METRICID = new MetricID(TIMER_NAME, NUMBER_ONE_TAG);
+    private final static MetricID TIMER_TWO_METRICID = new MetricID(TIMER_NAME, NUMBER_TWO_TAG);
+
+    @Deployment
+    static Archive<?> createTestArchive() {
+        return ShrinkWrap.create(JavaArchive.class)
+            // Test bean
+            .addClass(TimedTagMethodBean.class)
+            // Bean archive deployment descriptor
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Inject
+    private MetricRegistry registry;
+
+    @Inject
+    private TimedTagMethodBean bean;
+
+    @Test
+    @InSequence(1)
+    public void timedTagMethodRegistered() {
+        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(TIMER_ONE_METRICID));
+        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(TIMER_TWO_METRICID));
+    }
+
+
+}

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/TimerFieldBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/TimerFieldBeanTest.java
@@ -65,6 +65,7 @@ public class TimerFieldBeanTest {
 
     @Test
     public void timerFieldsWithDefaultNamingConvention() {
-        assertThat("Timers are not registered correctly", registry.getMetrics().keySet(), is(equalTo(metricNames())));
+        assertThat("Timers are not registered correctly", registry.getMetrics().keySet(), 
+            is(equalTo(MetricsUtil.createMetricIDs(metricNames()))));
     }
 }

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/TimerTagFieldBean.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/TimerTagFieldBean.java
@@ -1,0 +1,38 @@
+/*
+ **********************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICES file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+package io.astefanutti.metrics.cdi.se;
+
+import org.eclipse.microprofile.metrics.Timer;
+import org.eclipse.microprofile.metrics.annotation.Metric;
+
+import javax.inject.Inject;
+
+public class TimerTagFieldBean {
+
+    @Inject
+    @Metric(name = "timerName", absolute = true, tags= {"number=one"})
+    private Timer timerOne;
+
+    @Inject
+    @Metric(name = "timerName", absolute = true, tags= {"number=two"})
+    private Timer timertwo;
+}

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/TimerTagFieldBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/TimerTagFieldBeanTest.java
@@ -33,7 +33,7 @@ import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
 import static org.junit.Assert.assertThat;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -53,11 +53,11 @@ public class TimerTagFieldBeanTest {
 
     @Deployment
     static Archive<?> createTestArchive() {
-        return ShrinkWrap.create(JavaArchive.class)
+        return ShrinkWrap.create(WebArchive.class)
             // Test bean
             .addClasses(TimerTagFieldBean.class, MetricsUtil.class)
             // Bean archive deployment descriptor
-            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
     @Inject

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/TimerTagFieldBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/TimerTagFieldBeanTest.java
@@ -1,0 +1,74 @@
+/*
+ **********************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICES file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+package io.astefanutti.metrics.cdi.se;
+
+import javax.inject.Inject;
+
+import static org.hamcrest.Matchers.hasKey;
+
+import org.eclipse.microprofile.metrics.MetricID;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.Tag;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import static org.junit.Assert.assertThat;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.astefanutti.metrics.cdi.se.util.MetricsUtil;
+
+@RunWith(Arquillian.class)
+public class TimerTagFieldBeanTest {
+
+    private final static String TIMER_NAME = "timerName";
+
+    private final static Tag NUMBER_ONE_TAG = new Tag("number", "one");
+    private final static Tag NUMBER_TWO_TAG = new Tag("number", "two");
+    
+    private final static MetricID TIMER_ONE_METRICID = new MetricID(TIMER_NAME, NUMBER_ONE_TAG);
+    private final static MetricID TIMER_TWO_METRICID = new MetricID(TIMER_NAME, NUMBER_TWO_TAG);
+
+    @Deployment
+    static Archive<?> createTestArchive() {
+        return ShrinkWrap.create(JavaArchive.class)
+            // Test bean
+            .addClasses(TimerTagFieldBean.class, MetricsUtil.class)
+            // Bean archive deployment descriptor
+            .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Inject
+    private MetricRegistry registry;
+
+    @Inject
+    private TimerTagFieldBean bean;
+    
+    @Test
+    public void timersTagFieldRegistered() {
+        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(TIMER_ONE_METRICID));
+        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(TIMER_TWO_METRICID));
+    }
+}

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/VisibilityTimedMethodBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/VisibilityTimedMethodBeanTest.java
@@ -66,7 +66,8 @@ public class VisibilityTimedMethodBeanTest {
     @Test
     @InSequence(1)
     public void timedMethodsNotCalledYet() {
-        assertThat("Timers are not registered correctly", registry.getTimers().keySet(), is(equalTo(absoluteMetricNames())));
+        assertThat("Timers are not registered correctly", registry.getTimers().keySet(), 
+            is(equalTo(MetricsUtil.createMetricIDs(absoluteMetricNames()))));
         
         // Make sure that all the timers haven't been called yet
         assertThat("Timer counts are incorrect", registry.getTimers().values(), everyItem(Matchers.<Timer>hasProperty("count", equalTo(0L))));
@@ -75,7 +76,8 @@ public class VisibilityTimedMethodBeanTest {
     @Test
     @InSequence(2)
     public void callTimedMethodsOnce() {
-        assertThat("Timers are not registered correctly", registry.getTimers().keySet(), is(equalTo(absoluteMetricNames())));
+        assertThat("Timers are not registered correctly", registry.getTimers().keySet(), 
+            is(equalTo(MetricsUtil.createMetricIDs(absoluteMetricNames()))));
         
         // Call the timed methods and assert they've all been timed once
         bean.publicTimedMethod();

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/util/MetricsUtil.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/util/MetricsUtil.java
@@ -19,6 +19,7 @@ import org.eclipse.microprofile.metrics.MetricRegistry;
 
 import java.util.HashSet;
 import java.util.Set;
+import org.eclipse.microprofile.metrics.MetricID;
 
 public final class MetricsUtil {
 
@@ -67,5 +68,13 @@ public final class MetricsUtil {
 
     public static String absoluteMetricName(Class<?> clazz, String metric, String name) {
         return MetricRegistry.name(clazz.getPackage().getName() + "." + metric, name);
+    }
+    
+    public static Set<MetricID> createMetricIDs(Set<String> metricNames){
+        Set<MetricID> metricIDSet = new HashSet<MetricID>();
+        for (String metricName : metricNames){
+            metricIDSet.add(new MetricID(metricName));
+        }
+        return metricIDSet;
     }
 }

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/GaugeTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/GaugeTest.java
@@ -28,6 +28,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.metrics.Gauge;
+import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -53,11 +54,15 @@ public class GaugeTest {
 
     @Test
     public void testManualGauge() {
-        Assert.assertNull(metrics.getGauges().get("tck.gaugetest.gaugemanual"));
+        
+        String gaugeName = "tck.gaugetest.gaugemanual";
+        MetricID gaugeMetricID = new MetricID(gaugeName);
+        
+        Assert.assertNull(metrics.getGauges().get(gaugeMetricID));
         gaugeMe();
 
-        Assert.assertEquals(0, (metrics.getGauges().get("tck.gaugetest.gaugemanual").getValue()));
-        Assert.assertEquals(1, (metrics.getGauges().get("tck.gaugetest.gaugemanual").getValue()));
+        Assert.assertEquals(0, (metrics.getGauges().get(gaugeMetricID).getValue()));
+        Assert.assertEquals(1, (metrics.getGauges().get(gaugeMetricID).getValue()));
     }
 
     public void gaugeMe() {

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/HistogramTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/HistogramTest.java
@@ -29,6 +29,7 @@ import java.util.SortedMap;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.metrics.Histogram;
+import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -99,15 +100,19 @@ public class HistogramTest {
     public void testMetricRegistry() throws Exception {
         String histogramIntName = "org.eclipse.microprofile.metrics.tck.HistogramTest.histogramInt";
         String histogramLongName = "test.longData.histogram";
-        SortedMap<String, Histogram> histograms = metrics.getHistograms();
+        
+        MetricID histogramIntNameMetricID = new MetricID(histogramIntName);
+        MetricID histogramLongNameMetricID = new MetricID(histogramLongName);
+        
+        SortedMap<MetricID, Histogram> histograms = metrics.getHistograms();
 
         Assert.assertTrue(histograms.size() == 2);
 
-        Assert.assertTrue(histograms.containsKey(histogramIntName));
-        Assert.assertTrue(histograms.containsKey(histogramLongName));
+        Assert.assertTrue(histograms.containsKey(histogramIntNameMetricID));
+        Assert.assertTrue(histograms.containsKey(histogramLongNameMetricID));
 
-        TestUtils.assertEqualsWithTolerance(48, histograms.get(histogramIntName).getSnapshot().getValue(0.5));
-        TestUtils.assertEqualsWithTolerance(480, histograms.get(histogramLongName).getSnapshot().getValue(0.5));
+        TestUtils.assertEqualsWithTolerance(48, histograms.get(histogramIntNameMetricID).getSnapshot().getValue(0.5));
+        TestUtils.assertEqualsWithTolerance(480, histograms.get(histogramLongNameMetricID).getSnapshot().getValue(0.5));
     }
 
     @Test

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/MetricFilterTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/MetricFilterTest.java
@@ -1,6 +1,6 @@
 /*
  **********************************************************************
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017, 2019 Contributors to the Eclipse Foundation
  *               2010-2013 Coda Hale, Yammer.com
  *
  * See the NOTICES file(s) distributed with this work for additional
@@ -26,6 +26,7 @@ package org.eclipse.microprofile.metrics.tck;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.metrics.Metric;
+import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricFilter;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -46,6 +47,6 @@ public class MetricFilterTest {
 
     @Test
     public void theAllFilterMatchesAllMetrics() throws Exception {
-        Assert.assertTrue(MetricFilter.ALL.matches("", metric));
+        Assert.assertTrue(MetricFilter.ALL.matches(new MetricID(""), metric));
     }
 }

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/MetricIDTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/MetricIDTest.java
@@ -1,0 +1,91 @@
+/*
+ **********************************************************************
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICES file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+
+package org.eclipse.microprofile.metrics.tck;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.hasKey;
+import static org.junit.Assert.assertThat;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.metrics.Counter;
+import org.eclipse.microprofile.metrics.MetricID;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.Tag;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class MetricIDTest {
+    
+    @Inject
+    private MetricRegistry registry;
+
+    @Deployment
+    public static JavaArchive createDeployment() {
+        return ShrinkWrap.create(JavaArchive.class).addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    }
+
+    @Test
+    @InSequence(1)
+    public void removalTest() {
+        
+        Tag tagEarth = new Tag("planet", "earth");
+        Tag tagRed = new Tag("colour", "red");
+        Tag tagBlue = new Tag("colour", "blue");
+        
+        String counterName = "org.eclipse.microprofile.metrics.tck.MetricIDTest.counterColour";
+        
+        Counter counterColour = registry.counter(counterName);
+        Counter counterRed = registry.counter(counterName,tagEarth,tagRed);
+        Counter counterBlue = registry.counter(counterName,tagEarth,tagBlue);
+        
+        MetricID counterColourMID = new MetricID(counterName);
+        MetricID counterRedMID = new MetricID(counterName, tagEarth,tagRed);
+        MetricID counterBlueMID = new MetricID(counterName, tagEarth,tagRed);
+        
+        //check multi-dimensional metrics are registered
+        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(counterColourMID));
+        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(counterRedMID));
+        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(counterBlueMID));
+        
+        //remove one metric
+        registry.remove(counterColourMID);
+        assertThat("Registry did not remove metric", registry.getCounters().size(), equalTo(2));
+        assertThat("Counter is not registered correctly", registry.getCounters(), not(hasKey(counterColourMID)));
+        
+        //remove all metrics with the given name
+        registry.remove(counterName);
+        assertThat("Counter is not registered correctly", registry.getCounters(), not(hasKey(counterRedMID)));
+        assertThat("Counter is not registered correctly", registry.getCounters(), not(hasKey(counterBlueMID)));
+        
+    }
+    
+}

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/MetricRegistryTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/MetricRegistryTest.java
@@ -26,9 +26,12 @@ import javax.inject.Inject;
 
 import org.eclipse.microprofile.metrics.Counter;
 import org.eclipse.microprofile.metrics.Histogram;
+import org.eclipse.microprofile.metrics.Metadata;
 import org.eclipse.microprofile.metrics.Meter;
 import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.MetricType;
+import org.eclipse.microprofile.metrics.Tag;
 import org.eclipse.microprofile.metrics.Timer;
 import org.eclipse.microprofile.metrics.annotation.Metric;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -96,6 +99,27 @@ public class MetricRegistryTest {
     public void removeTest() {
         metrics.remove("nameTest");
         Assert.assertFalse(metrics.getNames().contains("nameTest"));
+    }
+    
+    @Test
+    @InSequence(4)
+    public void useExistingMetaDataTest() {
+        String displayName = "displayCounterFoo";
+        String metricName = "counterFoo";
+        
+        //first to register a "complex" metadata
+        metrics.counter(Metadata.builder().withName(metricName).withDisplayName(displayName).withType(MetricType.COUNTER).build());    
+        
+        Tag purpleTag = new Tag("colour","purple");
+        //creates with a simple/template metadata or uses an existing one.
+        metrics.counter(metricName, purpleTag);
+        
+        //check both counters have been registered
+        Assert.assertTrue(metrics.getCounters().containsKey(new MetricID(metricName)));
+        Assert.assertTrue(metrics.getCounters().containsKey(new MetricID(metricName, purpleTag)));
+        
+        //check that the "original" metadata wasn't replaced by the empty default metadata
+        Assert.assertEquals(metrics.getMetadata().get(metricName).getDisplayName(), displayName);
     }
 
 }

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/MetricRegistryTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/MetricRegistryTest.java
@@ -27,6 +27,7 @@ import javax.inject.Inject;
 import org.eclipse.microprofile.metrics.Counter;
 import org.eclipse.microprofile.metrics.Histogram;
 import org.eclipse.microprofile.metrics.Meter;
+import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.Timer;
 import org.eclipse.microprofile.metrics.annotation.Metric;
@@ -78,16 +79,16 @@ public class MetricRegistryTest {
     @InSequence(2)
     public void registerTest() {
         metrics.register("regCountTemp", countTemp);
-        Assert.assertTrue(metrics.getCounters().containsKey("regCountTemp"));
+        Assert.assertTrue(metrics.getCounters().containsKey(new MetricID("regCountTemp")));
 
         metrics.register("regHistoTemp", histoTemp);
-        Assert.assertTrue(metrics.getHistograms().containsKey("regHistoTemp"));
+        Assert.assertTrue(metrics.getHistograms().containsKey(new MetricID("regHistoTemp")));
 
         metrics.register("regTimerTemp", timerTemp);
-        Assert.assertTrue(metrics.getTimers().containsKey("regTimerTemp"));
+        Assert.assertTrue(metrics.getTimers().containsKey(new MetricID("regTimerTemp")));
 
         metrics.register("regMeterTemp", meterTemp);
-        Assert.assertTrue(metrics.getMeters().containsKey("regMeterTemp"));
+        Assert.assertTrue(metrics.getMeters().containsKey(new MetricID("regMeterTemp")));
     }
 
     @Test

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/TagsTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/TagsTest.java
@@ -1,6 +1,6 @@
 /*
  **********************************************************************
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017, 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICES file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -22,33 +22,34 @@
 
 package org.eclipse.microprofile.metrics.tck;
 
-import org.eclipse.microprofile.metrics.Metadata;
+//import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.hasValue;
+import static org.junit.Assert.assertThat;
+
+import javax.inject.Inject;
+
+import org.eclipse.microprofile.metrics.Counter;
+import org.eclipse.microprofile.metrics.Histogram;
+import org.eclipse.microprofile.metrics.Meter;
 import org.eclipse.microprofile.metrics.MetricID;
-//import org.eclipse.microprofile.metrics.MetricType;
-//import org.eclipse.microprofile.metrics.MetricUnits;
+import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.Timer;
 import org.eclipse.microprofile.metrics.Tag;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
 public class TagsTest {
-
-    private Metadata metadata;
-    private MetricID metricID;
-
-    @Before
-    public void setUp() {
-        Tag one = new Tag("hello", "world");
-        Tag two = new Tag("goodbye", "friend");
-        this.metricID = new MetricID("metricName", one, two);
-    }
+    
+    @Inject
+    private MetricRegistry registry;
 
     @Deployment
     public static JavaArchive createDeployment() {
@@ -56,9 +57,133 @@ public class TagsTest {
     }
 
     @Test
-    public void tagsTest() {
-        Assert.assertTrue(metricID.getTags().containsValue("world"));
-        Assert.assertTrue(metricID.getTags().containsValue("friend"));
+    @InSequence(1)
+    public void simpleTagTest() {
+        Tag one = new Tag("hello", "world");
+        Tag two = new Tag("goodbye", "friend");
+        MetricID metricID = new MetricID("metricName", one, two);
+        
+        assertThat(metricID.getTags(), hasKey("hello"));
+        assertThat(metricID.getTags(), hasValue("world"));
+        
+        assertThat(metricID.getTags(), hasKey("goodbye"));
+        assertThat(metricID.getTags(), hasValue("friend"));
+        
+        //MP_METRICS_TAGS=tier=integration
+        assertThat("Counter's Global Tag not set properly", metricID.getTags(), hasKey("tier"));
+        assertThat("Counter's Global Tag not set properly", metricID.getTags(), hasValue("integration"));
     }
 
+    @Test
+    @InSequence(2)
+    public void lastTagValueTest() {
+        
+        Tag tagColour = new Tag("colour","red");
+        Tag tagColourTwo = new Tag("colour","blue");
+        
+        String counterName = "org.eclipse.microprofile.metrics.tck.TagTest.counter";
+        Counter counter = registry.counter(counterName, tagColour, tagColourTwo);
+        
+        //MetricID that only has colour=blue... the last tag value to be passed in
+        MetricID counterMID = new MetricID(counterName, tagColourTwo);
+        
+        //check the metric is registered
+        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(counterMID));
+    }
+    
+    @Test
+    @InSequence(3)
+    public void counterTagsTest() {
+        
+        Tag tagEarth = new Tag("planet", "earth");
+        Tag tagRed = new Tag("colour", "red");
+        Tag tagBlue = new Tag("colour", "blue");
+        
+        String counterName = "org.eclipse.microprofile.metrics.tck.TagTest.counterColour";
+        
+        Counter counterColour = registry.counter(counterName);
+        Counter counterRed = registry.counter(counterName,tagEarth,tagRed);
+        Counter counterBlue = registry.counter(counterName,tagEarth,tagBlue);
+        
+        MetricID counterColourMID = new MetricID(counterName);
+        MetricID counterRedMID = new MetricID(counterName, tagEarth,tagRed);
+        MetricID counterBlueMID = new MetricID(counterName, tagEarth,tagRed);
+        
+        //check multi-dimensional metrics are registered
+        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(counterColourMID));
+        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(counterRedMID));
+        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(counterBlueMID));
+    }
+    
+    @Test
+    @InSequence(4)
+    public void meterTagsTest() {
+        
+        Tag tagEarth = new Tag("planet", "earth");
+        Tag tagRed = new Tag("colour", "red");
+        Tag tagBlue = new Tag("colour", "blue");
+        
+        String meterName = "org.eclipse.microprofile.metrics.tck.TagTest.meterColour";
+        
+        Meter meterColour = registry.meter(meterName);
+        Meter meterRed = registry.meter(meterName,tagEarth,tagRed);
+        Meter meterBlue = registry.meter(meterName,tagEarth,tagBlue);
+        
+        MetricID meterColourMID = new MetricID(meterName);
+        MetricID meterRedMID = new MetricID(meterName, tagEarth,tagRed);
+        MetricID meterBlueMID = new MetricID(meterName, tagEarth,tagRed);
+        
+        //check multi-dimensional metrics are registered
+        assertThat("Meter is not registered correctly", registry.getMeters(), hasKey(meterColourMID));
+        assertThat("Meter is not registered correctly", registry.getMeters(), hasKey(meterRedMID));
+        assertThat("Meter is not registered correctly", registry.getMeters(), hasKey(meterBlueMID));
+    }
+    
+    @Test
+    @InSequence(5)
+    public void timerTagsTest() {
+        
+        Tag tagEarth = new Tag("planet", "earth");
+        Tag tagRed = new Tag("colour", "red");
+        Tag tagBlue = new Tag("colour", "blue");
+        
+        String timerName = "org.eclipse.microprofile.metrics.tck.TagTest.timerColour";
+        
+        Timer timerColour = registry.timer(timerName);
+        Timer timerRed = registry.timer(timerName,tagEarth,tagRed);
+        Timer timerBlue = registry.timer(timerName,tagEarth,tagBlue);
+        
+        MetricID timerColourMID = new MetricID(timerName);
+        MetricID timerRedMID = new MetricID(timerName, tagEarth,tagRed);
+        MetricID timerBlueMID = new MetricID(timerName, tagEarth,tagRed);
+        
+        //check multi-dimensional metrics are registered
+        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(timerColourMID));
+        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(timerRedMID));
+        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(timerBlueMID));
+    }
+    
+    @Test
+    @InSequence(6)
+    public void histogramTagsTest() {
+        
+        Tag tagEarth = new Tag("planet", "earth");
+        Tag tagRed = new Tag("colour", "red");
+        Tag tagBlue = new Tag("colour", "blue");
+        
+        String histogramName = "org.eclipse.microprofile.metrics.tck.TagTest.histogramColour";
+        
+        Histogram histogramColour = registry.histogram(histogramName);
+        Histogram histogramRed = registry.histogram(histogramName,tagEarth,tagRed);
+        Histogram histogramBlue = registry.histogram(histogramName,tagEarth,tagBlue);
+        
+        MetricID histogramColourMID = new MetricID(histogramName);
+        MetricID histogramRedMID = new MetricID(histogramName, tagEarth,tagRed);
+        MetricID histogramBlueMID = new MetricID(histogramName, tagEarth,tagRed);
+        
+        //check multi-dimensional metrics are registered
+        assertThat("Histogram is not registered correctly", registry.getHistograms(), hasKey(histogramColourMID));
+        assertThat("Histogram is not registered correctly", registry.getHistograms(), hasKey(histogramRedMID));
+        assertThat("Histogram is not registered correctly", registry.getHistograms(), hasKey(histogramBlueMID));
+    }
 }

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/TagsTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/TagsTest.java
@@ -23,8 +23,10 @@
 package org.eclipse.microprofile.metrics.tck;
 
 import org.eclipse.microprofile.metrics.Metadata;
-import org.eclipse.microprofile.metrics.MetricType;
-import org.eclipse.microprofile.metrics.MetricUnits;
+import org.eclipse.microprofile.metrics.MetricID;
+//import org.eclipse.microprofile.metrics.MetricType;
+//import org.eclipse.microprofile.metrics.MetricUnits;
+import org.eclipse.microprofile.metrics.Tag;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -39,12 +41,13 @@ import org.junit.runner.RunWith;
 public class TagsTest {
 
     private Metadata metadata;
+    private MetricID metricID;
 
     @Before
     public void setUp() {
-        this.metadata = Metadata.builder().withName("count").withDisplayName("countMe")
-                .withDescription("countMe tags test").withType(MetricType.COUNTER)
-                .withUnit(MetricUnits.PERCENT).addTag("colour=blue").build();
+        Tag one = new Tag("hello", "world");
+        Tag two = new Tag("goodbye", "friend");
+        this.metricID = new MetricID("metricName", one, two);
     }
 
     @Deployment
@@ -54,21 +57,8 @@ public class TagsTest {
 
     @Test
     public void tagsTest() {
-        Assert.assertNotNull(metadata);
-        Assert.assertTrue(metadata.getTags().containsValue("blue"));
-    }
-
-    @Test
-    public void addTagsTest() {
-
-        Metadata metadata2 = Metadata.builder(metadata)
-                .addTags("colour=green,size=medium").addTag("number=5").build();
-
-        Assert.assertNotNull(metadata2);
-        Assert.assertTrue(metadata2.getTags().containsKey("size"));
-        Assert.assertTrue(metadata2.getTags().containsValue("green"));
-        Assert.assertFalse(metadata2.getTags().containsValue("blue"));
-        Assert.assertTrue(metadata2.getTags().containsKey("number"));
+        Assert.assertTrue(metricID.getTags().containsValue("world"));
+        Assert.assertTrue(metricID.getTags().containsValue("friend"));
     }
 
 }

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/TagsTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/TagsTest.java
@@ -107,7 +107,7 @@ public class TagsTest {
         
         MetricID counterColourMID = new MetricID(counterName);
         MetricID counterRedMID = new MetricID(counterName, tagEarth,tagRed);
-        MetricID counterBlueMID = new MetricID(counterName, tagEarth,tagRed);
+        MetricID counterBlueMID = new MetricID(counterName, tagEarth,tagBlue);
         
         //check multi-dimensional metrics are registered
         assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(counterColourMID));
@@ -131,7 +131,7 @@ public class TagsTest {
         
         MetricID meterColourMID = new MetricID(meterName);
         MetricID meterRedMID = new MetricID(meterName, tagEarth,tagRed);
-        MetricID meterBlueMID = new MetricID(meterName, tagEarth,tagRed);
+        MetricID meterBlueMID = new MetricID(meterName, tagEarth,tagBlue);
         
         //check multi-dimensional metrics are registered
         assertThat("Meter is not registered correctly", registry.getMeters(), hasKey(meterColourMID));
@@ -155,7 +155,7 @@ public class TagsTest {
         
         MetricID timerColourMID = new MetricID(timerName);
         MetricID timerRedMID = new MetricID(timerName, tagEarth,tagRed);
-        MetricID timerBlueMID = new MetricID(timerName, tagEarth,tagRed);
+        MetricID timerBlueMID = new MetricID(timerName, tagEarth,tagBlue);
         
         //check multi-dimensional metrics are registered
         assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(timerColourMID));
@@ -179,7 +179,7 @@ public class TagsTest {
         
         MetricID histogramColourMID = new MetricID(histogramName);
         MetricID histogramRedMID = new MetricID(histogramName, tagEarth,tagRed);
-        MetricID histogramBlueMID = new MetricID(histogramName, tagEarth,tagRed);
+        MetricID histogramBlueMID = new MetricID(histogramName, tagEarth,tagBlue);
         
         //check multi-dimensional metrics are registered
         assertThat("Histogram is not registered correctly", registry.getHistograms(), hasKey(histogramColourMID));

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/TimerTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/TimerTest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.inject.Inject;
 
+import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.Timer;
 import org.eclipse.microprofile.metrics.Timer.Context;
@@ -145,14 +146,18 @@ public class TimerTest {
     public void testTimerRegistry() throws Exception {
         String timerLongName = "test.longData.timer";
         String timerTimeName = "testTime";
-
-        SortedMap<String, Timer> timers = registry.getTimers();
+        
+        MetricID timerLongNameMetricID = new MetricID(timerLongName);
+        MetricID timerTimeNameMetricID = new MetricID(timerTimeName);
+        
+        SortedMap<MetricID, Timer> timers = registry.getTimers();
+        
         Assert.assertTrue(timers.size() > 0);
 
-        Assert.assertTrue(timers.containsKey(timerLongName));
-        Assert.assertTrue(timers.containsKey(timerTimeName));
+        Assert.assertTrue(timers.containsKey(timerLongNameMetricID));
+        Assert.assertTrue(timers.containsKey(timerTimeNameMetricID));
 
-        TestUtils.assertEqualsWithTolerance(480, timers.get(timerLongName).getSnapshot().getValue(0.5));
+        TestUtils.assertEqualsWithTolerance(480, timers.get(timerLongNameMetricID).getSnapshot().getValue(0.5));
     }
 
     @Test

--- a/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MetricAppBean.java
+++ b/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MetricAppBean.java
@@ -28,6 +28,7 @@ import org.eclipse.microprofile.metrics.Gauge;
 import org.eclipse.microprofile.metrics.Histogram;
 import org.eclipse.microprofile.metrics.Metadata;
 import org.eclipse.microprofile.metrics.Meter;
+import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.MetricType;
 import org.eclipse.microprofile.metrics.MetricUnits;
@@ -84,7 +85,7 @@ public class MetricAppBean {
     public void gaugeMe() {
 
         @SuppressWarnings("unchecked")
-        Gauge<Long> gauge = metrics.getGauges().get("metricTest.test1.gauge");
+        Gauge<Long> gauge = metrics.getGauges().get(new MetricID("metricTest.test1.gauge"));
         if (gauge == null) {
             gauge = () -> {
                 return 19L;

--- a/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MpMetricTest.java
+++ b/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MpMetricTest.java
@@ -1,6 +1,6 @@
 /*
  **********************************************************************
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017, 2018 Contributors to the Eclipse Foundation
  *
  * See the NOTICES file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -47,8 +47,10 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.TreeMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import javax.inject.Inject;
 import javax.xml.parsers.DocumentBuilder;
@@ -218,14 +220,17 @@ public class MpMetricTest {
         JsonPath jsonPath = given().header(wantJson).get("/metrics/base").jsonPath();
 
         Map<String, Object> elements = jsonPath.getMap(".");
+        
         List<String> missing = new ArrayList<>();
 
-        Map<String, MiniMeta> baseNames = getExpectedMetadataFromXmlFile(MetricRegistry.Type.BASE);
+        Map<String, MiniMeta> baseNames = getExpectedMetadataFromXmlFile(MetricRegistry.Type.BASE);       
+        
         for (MiniMeta item : baseNames.values()) {
             if (item.name.startsWith("gc.")) {
                 continue;
             }
-            if (!elements.containsKey(item.toJSONName()) && !baseNames.get(item.toJSONName()).optional) {
+                
+            if (!elements.containsKey(item.toJSONName()) && !baseNames.get(item.name).optional) {
                 missing.add(item.toJSONName());
             }
         }
@@ -433,9 +438,9 @@ public class MpMetricTest {
 
                 .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.blue{tier=integration}'", equalTo(0))
 
-                .body("greenCount{tier=integration}", equalTo(0))
+                .body("'greenCount{tier=integration}'", equalTo(0))
 
-                .body("purple{tier=integration}", equalTo(0))
+                .body("'purple{app=myShop,tier=integration}'", equalTo(0))
 
                 .body("'metricTest.test1.count{tier=integration}'", equalTo(1))
 
@@ -445,29 +450,31 @@ public class MpMetricTest {
 
                 .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.gaugeMeA{tier=integration}'", equalTo(1000))
 
-                .body("'metricTest.test1.histogram'.count{tier=integration}", equalTo(1000))
-                .body("'metricTest.test1.histogram'.max{tier=integration}", equalTo(999))
-                .body("'metricTest.test1.histogram'.mean{tier=integration}", closeTo(499.5))
-                .body("'metricTest.test1.histogram'.min{tier=integration}", equalTo(0))
-                .body("'metricTest.test1.histogram'.p50{tier=integration}", closeTo(499.0))
-                .body("'metricTest.test1.histogram'.p75{tier=integration}", closeTo(749))
-                .body("'metricTest.test1.histogram'.p95{tier=integration}", closeTo(949))
-                .body("'metricTest.test1.histogram'.p98{tier=integration}", closeTo(979))
-                .body("'metricTest.test1.histogram'.p99{tier=integration}", closeTo(989))
-                .body("'metricTest.test1.histogram'.p999{tier=integration}", closeTo(998))
+                .body("'metricTest.test1.histogram'.'count{tier=integration}'", equalTo(1000))
+                .body("'metricTest.test1.histogram'.'max{tier=integration}'", equalTo(999))
+                .body("'metricTest.test1.histogram'.'mean{tier=integration}'", closeTo(499.5))
+                .body("'metricTest.test1.histogram'.'min{tier=integration}'", equalTo(0))
+                .body("'metricTest.test1.histogram'.'p50{tier=integration}'", closeTo(499.0))
+                .body("'metricTest.test1.histogram'.'p75{tier=integration}'", closeTo(749))
+                .body("'metricTest.test1.histogram'.'p95{tier=integration}'", closeTo(949))
+                .body("'metricTest.test1.histogram'.'p98{tier=integration}'", closeTo(979))
+                .body("'metricTest.test1.histogram'.'p99{tier=integration}'", closeTo(989))
+                .body("'metricTest.test1.histogram'.'p999{tier=integration}'", closeTo(998))
                 .body("'metricTest.test1.histogram'", hasKey("stddev{tier=integration}"))
 
-                .body("'metricTest.test1.meter'.count{tier=integration}", equalTo(1))
+                .body("'metricTest.test1.meter'.'count{tier=integration}'", equalTo(1))
                 .body("'metricTest.test1.meter'", hasKey("fifteenMinRate{tier=integration}"))
                 .body("'metricTest.test1.meter'", hasKey("fiveMinRate{tier=integration}"))
                 .body("'metricTest.test1.meter'", hasKey("meanRate{tier=integration}"))
                 .body("'metricTest.test1.meter'", hasKey("oneMinRate{tier=integration}"))
 
-                .body("meterMeA.count", equalTo(1)).body("meterMeA", hasKey("fifteenMinRate{tier=integration}"))
-                .body("meterMeA", hasKey("fiveMinRate{tier=integration}")).body("meterMeA", hasKey("meanRate{tier=integration}"))
+                .body("'meterMeA'.'count{tier=integration}'", equalTo(1))
+                .body("meterMeA", hasKey("fifteenMinRate{tier=integration}"))
+                .body("meterMeA", hasKey("fiveMinRate{tier=integration}"))
+                .body("meterMeA", hasKey("meanRate{tier=integration}"))
                 .body("meterMeA", hasKey("oneMinRate{tier=integration}"))
 
-                .body("'metricTest.test1.timer'.count{tier=integration}", equalTo(1))
+                .body("'metricTest.test1.timer'.'count{tier=integration}'", equalTo(1))
                 .body("'metricTest.test1.timer'", hasKey("fifteenMinRate{tier=integration}"))
                 .body("'metricTest.test1.timer'", hasKey("fiveMinRate{tier=integration}"))
                 .body("'metricTest.test1.timer'", hasKey("meanRate{tier=integration}"))
@@ -481,9 +488,9 @@ public class MpMetricTest {
                 .body("'metricTest.test1.timer'", hasKey("p98{tier=integration}"))
                 .body("'metricTest.test1.timer'", hasKey("p99{tier=integration}"))
                 .body("'metricTest.test1.timer'", hasKey("p999{tier=integration}"))
-                .body("'metricTest.test1.timer'", hasKey("stddev"))
+                .body("'metricTest.test1.timer'", hasKey("stddev{tier=integration}"))
 
-                .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.timeMeA'.count{tier=integration}", equalTo(1))
+                .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.timeMeA'.'count{tier=integration}'", equalTo(1))
                 .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.timeMeA'", hasKey("fifteenMinRate{tier=integration}"))
                 .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.timeMeA'", hasKey("fiveMinRate{tier=integration}"))
                 .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.timeMeA'", hasKey("meanRate{tier=integration}"))
@@ -509,6 +516,7 @@ public class MpMetricTest {
         JsonPath jsonPath = given().header(wantJson).options("/metrics/application").jsonPath();
 
         Map<String, Object> elements = jsonPath.getMap(".");
+        
         List<String> missing = new ArrayList<>();
 
         Map<String, MiniMeta> names = getExpectedMetadataFromXmlFile(MetricRegistry.Type.APPLICATION);
@@ -539,14 +547,13 @@ public class MpMetricTest {
     @RunAsClient
     @InSequence(21)
     public void testApplicationTagJson() {
-
-        JsonPath jsonPath = given().header("Accept", APPLICATION_JSON)
+        
+        given().header("Accept", APPLICATION_JSON)
             .when()
-            .options("/metrics/application/purple").jsonPath();
-        String tags = jsonPath.getString("purple.tags");
-        assertNotNull(tags);
-        assertTrue(tags.contains("app=myShop"));
-        assertTrue(tags.contains("tier=integration"));
+            .options("/metrics/application/purple")
+            .then().statusCode(200)
+            .and()
+            .body(containsString("purple{app=myShop,tier=integration}"));
     }
 
     @Test
@@ -683,8 +690,9 @@ public class MpMetricTest {
     public void testNonStandardUnitsJSON() {
 
         Header wantJSONFormat = new Header("Accept", APPLICATION_JSON);
+        
         given().header(wantJSONFormat).options("/metrics/application/jellybeanHistogram").then().statusCode(200)
-        .body("jellybeanHistogram{tier=integration}.unit", equalTo("jellybeans"));
+         .body("'jellybeanHistogram{tier=integration}'.unit", equalTo("jellybeans"));
 
     }
 
@@ -724,14 +732,14 @@ public class MpMetricTest {
         Map<String, MiniMeta> names = getExpectedMetadataFromXmlFile(MetricRegistry.Type.BASE);
 
         for (MiniMeta item : names.values()) {
-            if (elements.containsKey(item.toJSONName()) && names.get(item.toJSONName()).optional) {
-                String prefix = names.get(item.toJSONName()).name;
-                String type = "\""+prefix+"\""+".type";
-                String unit= "\""+prefix+"\""+".unit";
+            if (elements.containsKey(item.toJSONName()) && names.get(item.name).optional) {
+                String prefix = names.get(item.name).name;
+                String type = "'"+item.toJSONName()+"'"+".type";
+                String unit= "'"+item.toJSONName()+"'"+".unit";
 
                 given().header(wantJson).options("/metrics/base/"+prefix).then().statusCode(200)
-                .body(type, equalTo(names.get(item.toJSONName()).type))
-                .body(unit, equalTo(names.get(item.toJSONName()).unit));
+                .body(type, equalTo(names.get(item.name).type))
+                .body(unit, equalTo(names.get(item.name).unit));
             }
         }
 
@@ -883,9 +891,11 @@ public class MpMetricTest {
           mm.unit = metric.getAttribute("unit");
           mm.optional = Boolean.parseBoolean(metric.getAttribute("optional"));
           String tags = metric.getAttribute("tags");
-          for (String tag: tags.split(",")) {
-              String[] str = tag.split("=");
-              mm.tags.put(str[0], str[1]);
+          if (!(tags == null || tags.length() == 0)){
+              for (String tag: tags.split(",")) {
+                 String[] str = tag.split("=");
+                 mm.tags.put(str[0], str[1]);
+               }
           }
           metaMap.put(mm.name, mm);
       }
@@ -900,7 +910,7 @@ public class MpMetricTest {
         private String unit;
         private boolean multi;
         private boolean optional;
-        private Map<String, String> tags = new HashMap<>();
+        private Map<String, String> tags = new TreeMap<>();
 
         public MiniMeta() {
             tags.put("tier", "integration");
@@ -919,7 +929,7 @@ public class MpMetricTest {
         }
         
         String toJSONName() {
-            return name + tags.toString(); 
+            return name + "{" + tags.entrySet().stream().map(e -> e.getKey() + "=" + e.getValue()).collect(Collectors.joining(",")) + "}";
         }
 
         private String getBaseUnitAsPrometheusString(String unit) {

--- a/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/ReusableMetricsTest.java
+++ b/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/ReusableMetricsTest.java
@@ -112,9 +112,9 @@ public class ReusableMetricsTest {
     Header acceptJson = new Header("Accept", APPLICATION_JSON);
 
     given().header(acceptJson).get("/metrics/application").then()
-            .assertThat().body("countMe2{tier=integration}", equalTo(1))
-            .assertThat().body("'org.eclipse.microprofile.metrics.test.MetricAppBean2.meterMe2'.count{tier=integration}", equalTo(1))
-            .assertThat().body("timeMe2.count{tier=integration}", equalTo(1));
+            .assertThat().body("'countMe2{tier=integration}'", equalTo(1))
+            .assertThat().body("'org.eclipse.microprofile.metrics.test.MetricAppBean2.meterMe2'.'count{tier=integration}'", equalTo(1))
+            .assertThat().body("timeMe2.'count{tier=integration}'", equalTo(1));
 
 
   }
@@ -135,9 +135,9 @@ public class ReusableMetricsTest {
     Header acceptJson = new Header("Accept", APPLICATION_JSON);
 
     given().header(acceptJson).get("/metrics/application").then()
-    .assertThat().body("countMe2{tier=integration}", equalTo(2))
-    .assertThat().body("'org.eclipse.microprofile.metrics.test.MetricAppBean2.meterMe2'.count{tier=integration}", equalTo(2))
-    .assertThat().body("timeMe2.count{tier=integration}", equalTo(2));
+    .assertThat().body("'countMe2{tier=integration}'", equalTo(2))
+    .assertThat().body("'org.eclipse.microprofile.metrics.test.MetricAppBean2.meterMe2'.'count{tier=integration}'", equalTo(2))
+    .assertThat().body("timeMe2.'count{tier=integration}'", equalTo(2));
 
   }
 
@@ -156,9 +156,9 @@ public class ReusableMetricsTest {
     Header acceptJson = new Header("Accept", APPLICATION_JSON);
 
     given().header(acceptJson).get("/metrics/application").then()
-    .assertThat().body("reusableHisto.count{tier=integration}", equalTo(2))
-    .assertThat().body("reusableHisto.min{tier=integration}", equalTo(1))
-    .assertThat().body("reusableHisto.max{tier=integration}", equalTo(3));
+    .assertThat().body("reusableHisto.'count{tier=integration}'", equalTo(2))
+    .assertThat().body("reusableHisto.'min{tier=integration}'", equalTo(1))
+    .assertThat().body("reusableHisto.'max{tier=integration}'", equalTo(3));
 
   }
 

--- a/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/ReusableMetricsTest.java
+++ b/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/ReusableMetricsTest.java
@@ -112,9 +112,9 @@ public class ReusableMetricsTest {
     Header acceptJson = new Header("Accept", APPLICATION_JSON);
 
     given().header(acceptJson).get("/metrics/application").then()
-            .assertThat().body("countMe2", equalTo(1))
-            .assertThat().body("'org.eclipse.microprofile.metrics.test.MetricAppBean2.meterMe2'.count", equalTo(1))
-            .assertThat().body("timeMe2.count", equalTo(1));
+            .assertThat().body("countMe2{tier=integration}", equalTo(1))
+            .assertThat().body("'org.eclipse.microprofile.metrics.test.MetricAppBean2.meterMe2'.count{tier=integration}", equalTo(1))
+            .assertThat().body("timeMe2.count{tier=integration}", equalTo(1));
 
 
   }
@@ -135,9 +135,9 @@ public class ReusableMetricsTest {
     Header acceptJson = new Header("Accept", APPLICATION_JSON);
 
     given().header(acceptJson).get("/metrics/application").then()
-    .assertThat().body("countMe2", equalTo(2))
-    .assertThat().body("'org.eclipse.microprofile.metrics.test.MetricAppBean2.meterMe2'.count", equalTo(2))
-    .assertThat().body("timeMe2.count", equalTo(2));
+    .assertThat().body("countMe2{tier=integration}", equalTo(2))
+    .assertThat().body("'org.eclipse.microprofile.metrics.test.MetricAppBean2.meterMe2'.count{tier=integration}", equalTo(2))
+    .assertThat().body("timeMe2.count{tier=integration}", equalTo(2));
 
   }
 
@@ -156,9 +156,9 @@ public class ReusableMetricsTest {
     Header acceptJson = new Header("Accept", APPLICATION_JSON);
 
     given().header(acceptJson).get("/metrics/application").then()
-    .assertThat().body("reusableHisto.count", equalTo(2))
-    .assertThat().body("reusableHisto.min", equalTo(1))
-    .assertThat().body("reusableHisto.max", equalTo(3));
+    .assertThat().body("reusableHisto.count{tier=integration}", equalTo(2))
+    .assertThat().body("reusableHisto.min{tier=integration}", equalTo(1))
+    .assertThat().body("reusableHisto.max{tier=integration}", equalTo(3));
 
   }
 

--- a/tck/rest/src/main/resources/application_metrics.xml
+++ b/tck/rest/src/main/resources/application_metrics.xml
@@ -22,7 +22,7 @@
   <metric multi="false" name="org.eclipse.microprofile.metrics.test.MetricAppBean.redCount" type="counter" unit="none"/>
   <metric multi="false" name="org.eclipse.microprofile.metrics.test.MetricAppBean.blue" type="counter" unit="none"/>
   <metric multi="false" name="greenCount" type="counter" unit="none"/>
-  <metric multi="false" name="purple" type="counter" unit="none"/>
+  <metric multi="false" name="purple" type="counter" unit="none" tags="app=myShop"/>
   <metric multi="false" name="jellybeanHistogram" type="histogram" unit="jellybeans"/>
   <metric multi="false" name="metricTest.test1.countMeA" type="counter" unit="none"/>
   <metric multi="false" name="org.eclipse.microprofile.metrics.test.MetricAppBean.gaugeMeA" type="gauge" unit="kibibits"/>


### PR DESCRIPTION
Inherits from #277 

- Introduces concept of MetricID which holds a metric's name and tags and is used as an unique identifier for metrics in the MetricRegistry in the new multi-dimensional metric world.

- Removes tags from MetaData, DefaultMetadata and MetadataBuilder.

- Enforces the idea that metadata is mapped to a unique metric name (i.e all metrics of a given metric name must have the same Metadata information).

- The registration (or retrieval) behaviour of MetricRegistry.register(...) , MetricRegistry.counter(...) , MetricRegistry.counter(...), etc will throw exceptions if the Metadata information fed to it does not match an already pre-existing metadata registered to a given metric name (if it exists).

Signed-off-by: chdavid <chdavid@ca.ibm.com>
