### PR TITLE
[#315] PrivilegedAction to read System env

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/metrics/Metadata.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/Metadata.java
@@ -23,6 +23,8 @@
  **********************************************************************/
 package org.eclipse.microprofile.metrics;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -139,7 +141,7 @@ public class Metadata {
      * <p/>
      */
     Metadata() {
-        String globalTagsFromEnv = System.getenv(GLOBAL_TAGS_VARIABLE);
+        String globalTagsFromEnv = AccessController.doPrivileged((PrivilegedAction<String>) () -> System.getenv(GLOBAL_TAGS_VARIABLE));
 
         addTags(globalTagsFromEnv);
     }


### PR DESCRIPTION
Wrap call to System.getenv in a PrivilegedAction so that the call is
allowed when the security manager is enabled.

Issue: https://github.com/eclipse/microprofile-metrics/issues/315