### PR TITLE
Remove usage of word 'monotonic' from counter tests

### DIFF
--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CountedClassBean.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CountedClassBean.java
@@ -17,17 +17,21 @@ package io.astefanutti.metrics.cdi.se;
 
 import org.eclipse.microprofile.metrics.annotation.Counted;
 
-import java.util.concurrent.Callable;
+@Counted(name = "countedClass")
+public class CountedClassBean {
 
-public class MonotonicCountedMethodBean<T> {
+    public void countedMethodOne() {
+    }
 
-    @Counted(name = "monotonicCountedMethod", absolute = true)
-    public T monotonicCountedMethod(Callable<T> callable) {
-        try {
-            return callable.call();
-        }
-        catch (Exception cause) {
-            throw new RuntimeException(cause);
-        }
+    public void countedMethodTwo() {
+    }
+
+    protected void countedMethodProtected() {
+    }
+
+    void countedMethodPackagedPrivate() {
+    }
+
+    private void countedMethodPrivate() {
     }
 }

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CountedClassBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CountedClassBeanTest.java
@@ -44,21 +44,21 @@ import org.junit.runner.RunWith;
 import io.astefanutti.metrics.cdi.se.util.MetricsUtil;
 
 @RunWith(Arquillian.class)
-public class MonotonicCountedClassBeanTest {
+public class CountedClassBeanTest {
 
-    private static final String CONSTRUCTOR_NAME = "MonotonicCountedClassBean";
+    private static final String CONSTRUCTOR_NAME = "CountedClassBean";
 
-    private static final String CONSTRUCTOR_COUNTER_NAME = MetricsUtil.absoluteMetricName(MonotonicCountedClassBean.class, "monotonicCountedClass",
+    private static final String CONSTRUCTOR_COUNTER_NAME = MetricsUtil.absoluteMetricName(CountedClassBean.class, "countedClass",
             CONSTRUCTOR_NAME);
 
     private static final MetricID CONSTRUCTOR_METRICID = new MetricID(CONSTRUCTOR_COUNTER_NAME);
             
     private static final String[] METHOD_NAMES = { "countedMethodOne", "countedMethodTwo", "countedMethodProtected", "countedMethodPackagedPrivate" };
 
-    private static final Set<String> METHOD_COUNTER_NAMES = MetricsUtil.absoluteMetricNames(MonotonicCountedClassBean.class, "monotonicCountedClass",
+    private static final Set<String> METHOD_COUNTER_NAMES = MetricsUtil.absoluteMetricNames(CountedClassBean.class, "countedClass",
             METHOD_NAMES);
 
-    private static final Set<String> COUNTER_NAMES = MetricsUtil.absoluteMetricNames(MonotonicCountedClassBean.class, "monotonicCountedClass",
+    private static final Set<String> COUNTER_NAMES = MetricsUtil.absoluteMetricNames(CountedClassBean.class, "countedClass",
             METHOD_NAMES, CONSTRUCTOR_NAME);
 
     private static final Set<MetricID> COUNTER_METRICIDS = MetricsUtil.createMetricIDs(COUNTER_NAMES);
@@ -76,7 +76,7 @@ public class MonotonicCountedClassBeanTest {
     static Archive<?> createTestArchive() {
         return ShrinkWrap.create(WebArchive.class)
                 // Test bean
-                .addClasses(MonotonicCountedClassBean.class, MetricsUtil.class)
+                .addClasses(CountedClassBean.class, MetricsUtil.class)
                 // Bean archive deployment descriptor
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
@@ -85,7 +85,7 @@ public class MonotonicCountedClassBeanTest {
     private MetricRegistry registry;
 
     @Inject
-    private MonotonicCountedClassBean bean;
+    private CountedClassBean bean;
 
     @Test
     @InSequence(1)

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CountedMethodBean.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CountedMethodBean.java
@@ -17,21 +17,17 @@ package io.astefanutti.metrics.cdi.se;
 
 import org.eclipse.microprofile.metrics.annotation.Counted;
 
-@Counted(name = "monotonicCountedClass")
-public class MonotonicCountedClassBean {
+import java.util.concurrent.Callable;
 
-    public void countedMethodOne() {
-    }
+public class CountedMethodBean<T> {
 
-    public void countedMethodTwo() {
-    }
-
-    protected void countedMethodProtected() {
-    }
-
-    void countedMethodPackagedPrivate() {
-    }
-
-    private void countedMethodPrivate() {
+    @Counted(name = "countedMethod", absolute = true)
+    public T countedMethod(Callable<T> callable) {
+        try {
+            return callable.call();
+        }
+        catch (Exception cause) {
+            throw new RuntimeException(cause);
+        }
     }
 }

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CountedMethodBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CountedMethodBeanTest.java
@@ -46,9 +46,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
-public class MonotonicCountedMethodBeanTest {
+public class CountedMethodBeanTest {
 
-    private final static String COUNTER_NAME = "monotonicCountedMethod";
+    private final static String COUNTER_NAME = "countedMethod";
     private final static MetricID COUNTER_METRICID = new MetricID(COUNTER_NAME);
 
     private final static AtomicLong COUNTER_COUNT = new AtomicLong();
@@ -57,7 +57,7 @@ public class MonotonicCountedMethodBeanTest {
     static Archive<?> createTestArchive() {
         return ShrinkWrap.create(WebArchive.class)
             // Test bean
-            .addClass(MonotonicCountedMethodBean.class)
+            .addClass(CountedMethodBean.class)
             // Bean archive deployment descriptor
             .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
@@ -66,7 +66,7 @@ public class MonotonicCountedMethodBeanTest {
     private MetricRegistry registry;
 
     @Inject
-    private MonotonicCountedMethodBean<Long> bean;
+    private CountedMethodBean<Long> bean;
 
     @Test
     @InSequence(1)
@@ -80,7 +80,7 @@ public class MonotonicCountedMethodBeanTest {
 
     @Test
     @InSequence(2)
-    public void countedMethodNotCalledYet(@Metric(name = "monotonicCountedMethod", absolute = true) Counter instance) {
+    public void countedMethodNotCalledYet(@Metric(name = "countedMethod", absolute = true) Counter instance) {
         assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(COUNTER_METRICID));
         Counter counter = registry.getCounters().get(COUNTER_METRICID);
 
@@ -100,7 +100,7 @@ public class MonotonicCountedMethodBeanTest {
             @Override
             public void run() {
                 try {
-                    exchanger.exchange(bean.monotonicCountedMethod(new Callable<Long>() {
+                    exchanger.exchange(bean.countedMethod(new Callable<Long>() {
                         @Override
                         public Long call() throws Exception {
                             exchanger.exchange(0L);
@@ -144,7 +144,7 @@ public class MonotonicCountedMethodBeanTest {
 
     @Test
     @InSequence(4)
-    public void removeMonotonicCounterFromRegistry() {
+    public void removeCounterFromRegistry() {
         assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(COUNTER_METRICID));
         Counter counter = registry.getCounters().get(COUNTER_METRICID);
 
@@ -153,7 +153,7 @@ public class MonotonicCountedMethodBeanTest {
 
         try {
             // Call the counted method and assert an exception is thrown
-            bean.monotonicCountedMethod(new Callable<Long>() {
+            bean.countedMethod(new Callable<Long>() {
                 @Override
                 public Long call() throws Exception {
                     return null;

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MonotonicCountedMethodBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MonotonicCountedMethodBeanTest.java
@@ -117,6 +117,7 @@ public class MonotonicCountedMethodBeanTest {
         thread.setUncaughtExceptionHandler(new Thread.UncaughtExceptionHandler() {
             @Override
             public void uncaughtException(Thread t, Throwable e) {
+                e.printStackTrace();
                 uncaught.incrementAndGet();
             }
         });


### PR DESCRIPTION
Remove usage of word 'monotonic' from counter tests because all counters are now monotonic

Also makes CounterBeanMethod test a bit easier to troubleshoot - the uncaught exception in the auxiliary thread is currently getting discarded and will not be shown anywhere in the test log, with this commit it should be seen. (yes, exactly this happened to me when implementing SmallRye 2.0)