### PR TITLE
[#343] test for checking the gc.count and gc.time metrics

### DIFF
--- a/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MpMetricTest.java
+++ b/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MpMetricTest.java
@@ -47,6 +47,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.List;
 import java.util.Map;
@@ -66,6 +67,7 @@ import org.jboss.arquillian.junit.InSequence;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -863,6 +865,78 @@ public class MpMetricTest {
         Header wantPrometheusFormat = new Header("Accept", TEXT_PLAIN);
         given().header(wantPrometheusFormat).get("/metrics/application").then().statusCode(200)
         .and().body(containsString("TYPE application_metric_test_test1_count_me_b_total counter"));
+    }
+
+    /**
+     * Check that there is at least one metric named gc.count and that they all contain
+     * expected tags (actually this is just 'name' for now).
+     */
+    @Test
+    @RunAsClient
+    @InSequence(43)
+    public void testGcCountMetrics() {
+        Header wantJson = new Header("Accept", APPLICATION_JSON);
+        JsonPath jsonPath = given().header(wantJson).get("/metrics/base").jsonPath();
+
+        Map<String, MiniMeta> baseNames = getExpectedMetadataFromXmlFile(MetricRegistry.Type.BASE);
+        MiniMeta gcCountMetricMeta = baseNames.get("gc.count");
+        Set<String> expectedTags = gcCountMetricMeta.tags.keySet();
+
+        // obtain list of actual base metrics from the runtime and find all named gc.count
+        Map<String, Object> elements = jsonPath.getMap(".");
+        boolean found = false;
+        for (Map.Entry<String, Object> metricEntry : elements.entrySet()) {
+            if(metricEntry.getKey().startsWith("gc.count")) {
+                // We found a metric named gc.count. Now check that it contains all expected tags
+                for(String expectedTag : expectedTags) {
+                    assertThat("The metric should contain a " + expectedTag + " tag",
+                        metricEntry.getKey(), containsString(expectedTag + "="));
+                }
+                // check that the metric has a reasonable value - it should at least be numeric and not negative
+                Assert.assertTrue("gc.count value should be numeric",
+                    metricEntry.getValue() instanceof Number);
+                Assert.assertTrue("gc.count value should not be a negative number",
+                    (Integer)metricEntry.getValue() >= 0);
+                found = true;
+            }
+        }
+        Assert.assertTrue("At least one metric named gc.count is expected", found);
+    }
+
+    /**
+     * Check that there is at least one metric named gc.time and that they all contain
+     * expected tags (actually this is just 'name' for now).
+     */
+    @Test
+    @RunAsClient
+    @InSequence(44)
+    public void testGcTimeMetrics() {
+        Header wantJson = new Header("Accept", APPLICATION_JSON);
+        JsonPath jsonPath = given().header(wantJson).get("/metrics/base").jsonPath();
+
+        Map<String, MiniMeta> baseNames = getExpectedMetadataFromXmlFile(MetricRegistry.Type.BASE);
+        MiniMeta gcTimeMetricMeta = baseNames.get("gc.time");
+        Set<String> expectedTags = gcTimeMetricMeta.tags.keySet();
+
+        // obtain list of actual base metrics from the runtime and find all named gc.time
+        Map<String, Object> elements = jsonPath.getMap(".");
+        boolean found = false;
+        for (Map.Entry<String, Object> metricEntry : elements.entrySet()) {
+            if(metricEntry.getKey().startsWith("gc.time")) {
+                // We found a metric named gc.time. Now check that it contains all expected tags
+                for(String expectedTag : expectedTags) {
+                    assertThat("The metric should contain a " + expectedTag + " tag",
+                        metricEntry.getKey(), containsString(expectedTag + "="));
+                }
+                // check that the metric has a reasonable value - it should at least be numeric and not negative
+                Assert.assertTrue("gc.time value should be numeric",
+                    metricEntry.getValue() instanceof Number);
+                Assert.assertTrue("gc.time value should not be a negative number",
+                    (Integer)metricEntry.getValue() >= 0);
+                found = true;
+            }
+        }
+        Assert.assertTrue("At least one metric named gc.time is expected", found);
     }
     
     /**

--- a/tck/rest/src/main/resources/base_metrics.xml
+++ b/tck/rest/src/main/resources/base_metrics.xml
@@ -30,8 +30,8 @@
   <metric multi="false" name="classloader.totalUnloadedClass.count" type="counter" unit="none"/>
   <metric multi="false" name="cpu.availableProcessors" type="gauge" unit="none"/>
   <metric multi="false" name="jvm.uptime" type="gauge" unit="milliseconds"/>
-  <metric multi="true" name="gc.%s.count" type="counter" unit="none"/>
-  <metric multi="true" name="gc.%s.time" type="gauge" unit="milliseconds"/>
+  <metric multi="true" name="gc.count" type="counter" unit="none" tags="name=*"/>
+  <metric multi="true" name="gc.time" type="gauge" unit="milliseconds" tags="name=*"/>
   <metric multi="false" name="optional.metric" type="histogram" unit="milliseconds" optional="true"/>
   <metric multi="false" name="cpu.systemLoadAverage" type="gauge" unit="none" optional="true"/>
 </config>


### PR DESCRIPTION
For 2.0, we renamed the JVM metric `gc.%s.count` to `gc.count{name=%s}` and `gc.%s.time` to `gc.time{name=%s}` (via https://github.com/eclipse/microprofile-metrics/commit/a4902b1768cbcbef04124ee1d5b8a1c24e62f264). This should be verified in a TCK test. We can't assert particular Garbage collector names that will be present at runtime, but I guess we can reasonably expect that at least one `gc.count` and one `gc.time` metric will exist, and we can check that they contain a `name` tag (but we don't check its actual value).