### PR TITLE
Fix MpMetricTest.testPrometheusFormatNoBadChars in case when tags mig…

### DIFF
--- a/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MpMetricTest.java
+++ b/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MpMetricTest.java
@@ -325,10 +325,11 @@ public class MpMetricTest {
             if (line.startsWith("#")) {
                 continue;
             }
-            String[] tmp = line.split(" ");
-            assertEquals(tmp.length, 2);
-            assertFalse("Line has illegal chars " + line, tmp[0].matches("[-.]"));
-            assertFalse("Found __ in " + line, tmp[0].matches("__"));
+            String nameAndTagsPart = line.substring(0, line.lastIndexOf(" "));
+            String namePart = nameAndTagsPart.contains("{") ?
+                nameAndTagsPart.substring(0, nameAndTagsPart.lastIndexOf("{")) : nameAndTagsPart;
+            assertFalse("Name has illegal chars " + line, namePart.matches(".*[-.].*"));
+            assertFalse("Found __ in " + line, line.matches(".*__.*"));
         }
     }
 


### PR DESCRIPTION
…ht contain spaces

If there's a tag containing spaces somewhere within `base` metrics (and with the new `gc.count` and `gc.time` base metrics it's very likely), the test incorrectly splits OpenMetrics output lines into the name+tags part and the value part.