### PR TITLE
Modify TCK tests so that MetricID is instantiated on the server side …

### DIFF
--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/ConcreteTimedBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/ConcreteTimedBeanTest.java
@@ -32,6 +32,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -41,8 +42,8 @@ public class ConcreteTimedBeanTest {
     private final static String TIMED_NAME = MetricRegistry.name(ConcreteTimedBean.class, "timedMethod");
     private final static String EXTENDED_TIMED_NAME = MetricRegistry.name(ConcreteTimedBean.class, "normallyNotTimedMethod");
 
-    private final static MetricID TIMED_METRICID = new MetricID(TIMED_NAME);
-    private final static MetricID EXTENDED_TIMED_METRICID = new MetricID(EXTENDED_TIMED_NAME);
+    private static MetricID timerMID;
+    private static MetricID extendedTimedMID;
     
     @Deployment
     static Archive<?> createTestArchive() {
@@ -56,11 +57,26 @@ public class ConcreteTimedBeanTest {
     @Inject
     private ConcreteTimedBean bean;
 
+    @Before
+    public void instantiateTest() {
+        /*
+         * The MetricID relies on the MicroProfile Config API.
+         * Running a managed arquillian container will result
+         * with the MetricID being created in a client process
+         * that does not contain the MPConfig impl.
+         * 
+         * This will cause client instantiated MetricIDs to 
+         * throw an exception. (i.e the global MetricIDs)
+         */
+        timerMID = new MetricID(TIMED_NAME);
+        extendedTimedMID = new MetricID(EXTENDED_TIMED_NAME);
+    }
+    
     @Test
     @InSequence(1)
     public void timedMethodNotCalledYet(MetricRegistry registry) {
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(TIMED_METRICID));
-        Timer timer = registry.getTimers().get(TIMED_METRICID);
+        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(timerMID));
+        Timer timer = registry.getTimers().get(timerMID);
 
         // Make sure that the timer hasn't been called yet
         assertThat("Timer count is incorrect", timer.getCount(), is(equalTo(0L)));
@@ -69,8 +85,8 @@ public class ConcreteTimedBeanTest {
     @Test
     @InSequence(2)
     public void extendedTimedMethodNotCalledYet(MetricRegistry registry) {
-        assertThat("Timer is not registered correctly on the methods on the abstract class", registry.getTimers(), hasKey(EXTENDED_TIMED_METRICID));
-        Timer timer = registry.getTimers().get(EXTENDED_TIMED_METRICID);
+        assertThat("Timer is not registered correctly on the methods on the abstract class", registry.getTimers(), hasKey(extendedTimedMID));
+        Timer timer = registry.getTimers().get(extendedTimedMID);
 
         // Make sure that the timer hasn't been called yet
         assertThat("Timer count is incorrect", timer.getCount(), is(equalTo(0L)));
@@ -79,8 +95,8 @@ public class ConcreteTimedBeanTest {
     @Test
     @InSequence(3)
     public void callTimedMethodOnce(MetricRegistry registry) {
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(TIMED_METRICID));
-        Timer timer = registry.getTimers().get(TIMED_METRICID);
+        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(timerMID));
+        Timer timer = registry.getTimers().get(timerMID);
 
         // Call the timed method and assert it's been timed
         bean.timedMethod();
@@ -92,8 +108,8 @@ public class ConcreteTimedBeanTest {
     @Test
     @InSequence(4)
     public void callExtendedTimedMethodOnce(MetricRegistry registry) {
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(EXTENDED_TIMED_METRICID));
-        Timer timer = registry.getTimers().get(EXTENDED_TIMED_METRICID);
+        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(extendedTimedMID));
+        Timer timer = registry.getTimers().get(extendedTimedMID);
 
         // Call the timed method and assert it's been timed
         bean.normallyNotTimedMethod();

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CounterFieldBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CounterFieldBeanTest.java
@@ -32,6 +32,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -40,7 +41,7 @@ public class CounterFieldBeanTest {
 
     private final static String COUNTER_NAME = MetricRegistry.name(CounterFieldBean.class, "counterName");
 
-    private final static MetricID COUNTER_METRICID = new MetricID(COUNTER_NAME);
+    private static MetricID counterMID;
 
     @Deployment
     public static Archive<?> createTestArchive() {
@@ -57,17 +58,31 @@ public class CounterFieldBeanTest {
     @Inject
     private CounterFieldBean bean;
 
+    @Before
+    public void instantiateTest() {
+        /*
+         * The MetricID relies on the MicroProfile Config API.
+         * Running a managed arquillian container will result
+         * with the MetricID being created in a client process
+         * that does not contain the MPConfig impl.
+         * 
+         * This will cause client instantiated MetricIDs to 
+         * throw an exception. (i.e the global MetricIDs)
+         */
+        counterMID = new MetricID(COUNTER_NAME);
+    }
+    
     @Test
     @InSequence(1)
     public void counterFieldRegistered() {
-        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(COUNTER_METRICID));
+        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(counterMID));
     }
 
     @Test
     @InSequence(2)
     public void incrementCounterField() {
-        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(COUNTER_METRICID));
-        Counter counter = registry.getCounters().get(COUNTER_METRICID);
+        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(counterMID));
+        Counter counter = registry.getCounters().get(counterMID);
 
         // Call the increment method and assert the counter is up-to-date
         long value = Math.round(Math.random() * Long.MAX_VALUE);

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CounterFieldTagBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CounterFieldTagBeanTest.java
@@ -39,6 +39,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -53,9 +54,9 @@ public class CounterFieldTagBeanTest {
     private final static Tag COLOUR_RED_TAG = new Tag("colour", "red"); 
     private final static Tag COLOUR_BLUE_TAG = new Tag("colour", "blue"); 
         
-    private final static MetricID COUNTER_MID = new MetricID(COUNTER_NAME);
-    private final static MetricID COUNTER_TWO_MID = new MetricID(COUNTER_NAME, NUMBER_TWO_TAG, COLOUR_RED_TAG);
-    private final static MetricID COUNTER_THREE_MID = new MetricID(COUNTER_NAME, NUMBER_THREE_TAG, COLOUR_BLUE_TAG);
+    private static MetricID counterMID ;
+    private static MetricID counterTwoMID;
+    private static MetricID counterThreeMID;
 
     @Deployment
     public static Archive<?> createTestArchive() {
@@ -72,26 +73,42 @@ public class CounterFieldTagBeanTest {
     @Inject
     private CounterFieldTagBean bean;
 
+    @Before
+    public void instantiateTest() {
+        /*
+         * The MetricID relies on the MicroProfile Config API.
+         * Running a managed arquillian container will result
+         * with the MetricID being created in a client process
+         * that does not contain the MPConfig impl.
+         * 
+         * This will cause client instantiated MetricIDs to 
+         * throw an exception. (i.e the global MetricIDs)
+         */
+        counterMID = new MetricID(COUNTER_NAME);
+        counterTwoMID = new MetricID(COUNTER_NAME, NUMBER_TWO_TAG, COLOUR_RED_TAG);
+        counterThreeMID = new MetricID(COUNTER_NAME, NUMBER_THREE_TAG, COLOUR_BLUE_TAG);
+    }
+    
     @Test
     @InSequence(1)
     public void counterTagFieldsRegistered() {      
         
-        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(COUNTER_MID));
-        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(COUNTER_TWO_MID));
-        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(COUNTER_THREE_MID));
+        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(counterMID));
+        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(counterTwoMID));
+        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(counterThreeMID));
     }
 
     @Test
     @InSequence(2)
     public void incrementCounterTagFields() {
-        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(COUNTER_MID));
-        Counter counterOne = registry.getCounters().get(COUNTER_MID);
+        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(counterMID));
+        Counter counterOne = registry.getCounters().get(counterMID);
         
-        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(COUNTER_TWO_MID));
-        Counter counterTwo = registry.getCounters().get(COUNTER_TWO_MID);
+        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(counterTwoMID));
+        Counter counterTwo = registry.getCounters().get(counterTwoMID);
         
-        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(COUNTER_THREE_MID));
-        Counter counterThree = registry.getCounters().get(COUNTER_THREE_MID);
+        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(counterThreeMID));
+        Counter counterThree = registry.getCounters().get(counterThreeMID);
 
         // Call the increment method and assert the counter is up-to-date
         long value = Math.round(Math.random() * Long.MAX_VALUE);

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/GaugeTagMethodBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/GaugeTagMethodBeanTest.java
@@ -51,8 +51,8 @@ public class GaugeTagMethodBeanTest {
     private final static Tag NUMBER_ONE_TAG = new Tag("number", "one");
     private final static Tag NUMBER_TWO_TAG = new Tag("number", "two");
     
-    private final static MetricID GAUGE_ONE_METRICID = new MetricID(GAUGE_NAME, NUMBER_ONE_TAG);
-    private final static MetricID GAUGE_TWO_METRICID = new MetricID(GAUGE_NAME, NUMBER_TWO_TAG);
+    private static MetricID gaugeOneMID;
+    private static MetricID gaugeTwoMID;
     
     @Deployment
     public static Archive<?> createTestArchive() {
@@ -75,19 +75,30 @@ public class GaugeTagMethodBeanTest {
         // as only a proxy gets injected otherwise
         bean.getGaugeOne();
         bean.getGaugeTwo();
+        /*
+         * The MetricID relies on the MicroProfile Config API.
+         * Running a managed arquillian container will result
+         * with the MetricID being created in a client process
+         * that does not contain the MPConfig impl.
+         * 
+         * This will cause client instantiated MetricIDs to 
+         * throw an exception. (i.e the global MetricIDs)
+         */
+        gaugeOneMID = new MetricID(GAUGE_NAME, NUMBER_ONE_TAG);
+        gaugeTwoMID = new MetricID(GAUGE_NAME, NUMBER_TWO_TAG);
     }
 
     @Test
     @InSequence(1)
     public void gaugeTagCalledWithDefaultValue() {
-        assertThat("Gauge is not registered correctly", registry.getGauges(), hasKey(GAUGE_ONE_METRICID));
-        assertThat("Gauge is not registered correctly", registry.getGauges(), hasKey(GAUGE_TWO_METRICID));
+        assertThat("Gauge is not registered correctly", registry.getGauges(), hasKey(gaugeOneMID));
+        assertThat("Gauge is not registered correctly", registry.getGauges(), hasKey(gaugeTwoMID));
         
         @SuppressWarnings("unchecked")
-        Gauge<Long> gaugeOne = registry.getGauges().get(GAUGE_ONE_METRICID);
+        Gauge<Long> gaugeOne = registry.getGauges().get(gaugeOneMID);
 
         @SuppressWarnings("unchecked")
-        Gauge<Long> gaugeTwo = registry.getGauges().get(GAUGE_TWO_METRICID);
+        Gauge<Long> gaugeTwo = registry.getGauges().get(gaugeTwoMID);
         
         // Make sure that the gauge has the expected value
         assertThat("Gauge value is incorrect", gaugeOne.getValue(), is(equalTo(0L)));
@@ -97,14 +108,14 @@ public class GaugeTagMethodBeanTest {
     @Test
     @InSequence(2)
     public void callGaugeTagAfterSetterCall() {
-        assertThat("Gauge is not registered correctly", registry.getGauges(), hasKey(GAUGE_ONE_METRICID));
-        assertThat("Gauge is not registered correctly", registry.getGauges(), hasKey(GAUGE_TWO_METRICID));
+        assertThat("Gauge is not registered correctly", registry.getGauges(), hasKey(gaugeOneMID));
+        assertThat("Gauge is not registered correctly", registry.getGauges(), hasKey(gaugeTwoMID));
         
         @SuppressWarnings("unchecked")
-        Gauge<Long> gaugeOne = registry.getGauges().get(GAUGE_ONE_METRICID);
+        Gauge<Long> gaugeOne = registry.getGauges().get(gaugeOneMID);
 
         @SuppressWarnings("unchecked")
-        Gauge<Long> gaugeTwo = registry.getGauges().get(GAUGE_TWO_METRICID);
+        Gauge<Long> gaugeTwo = registry.getGauges().get(gaugeTwoMID);
 
         // Call the setter method and assert the gauge is up-to-date
         long value = Math.round(Math.random() * Long.MAX_VALUE);

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/HistogramFieldBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/HistogramFieldBeanTest.java
@@ -32,6 +32,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -39,7 +40,7 @@ import org.junit.runner.RunWith;
 public class HistogramFieldBeanTest {
 
     private final static String HISTOGRAM_NAME = MetricRegistry.name(HistogramFieldBean.class, "histogramName");
-    private final static MetricID HISTOGRAM_METRICID = new MetricID(HISTOGRAM_NAME);
+    private static MetricID histogramMID;
 
     @Deployment
     static Archive<?> createTestArchive() {
@@ -56,17 +57,31 @@ public class HistogramFieldBeanTest {
     @Inject
     private HistogramFieldBean bean;
 
+    @Before
+    public void instantiateTest() {
+        /*
+         * The MetricID relies on the MicroProfile Config API.
+         * Running a managed arquillian container will result
+         * with the MetricID being created in a client process
+         * that does not contain the MPConfig impl.
+         * 
+         * This will cause client instantiated MetricIDs to 
+         * throw an exception. (i.e the global MetricIDs)
+         */
+        histogramMID = new MetricID(HISTOGRAM_NAME);
+    }
+    
     @Test
     @InSequence(1)
     public void histogramFieldRegistered() {
-        assertThat("Histogram is not registered correctly", registry.getHistograms(), hasKey(HISTOGRAM_METRICID));
+        assertThat("Histogram is not registered correctly", registry.getHistograms(), hasKey(histogramMID));
     }
 
     @Test
     @InSequence(2)
     public void updateHistogramField() {
-        assertThat("Histogram is not registered correctly", registry.getHistograms(), hasKey(HISTOGRAM_METRICID));
-        Histogram histogram = registry.getHistograms().get(HISTOGRAM_METRICID);
+        assertThat("Histogram is not registered correctly", registry.getHistograms(), hasKey(histogramMID));
+        Histogram histogram = registry.getHistograms().get(histogramMID);
 
         // Call the update method and assert the histogram is up-to-date
         long value = Math.round(Math.random() * Long.MAX_VALUE);

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/HistogramTagFieldBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/HistogramTagFieldBeanTest.java
@@ -39,6 +39,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -50,8 +51,8 @@ public class HistogramTagFieldBeanTest {
     private final static Tag NUMBER_ONE_TAG = new Tag("number", "one");
     private final static Tag NUMBER_TWO_TAG = new Tag("number", "two");
     
-    private final static MetricID HISTOGRAM_ONE_METRICID = new MetricID(HISTOGRAM_NAME, NUMBER_ONE_TAG);
-    private final static MetricID HISTOGRAM_TWO_METRICID = new MetricID(HISTOGRAM_NAME, NUMBER_TWO_TAG);
+    private static MetricID histogramOneMID;
+    private static MetricID histogramTwoMID;
     
     @Deployment
     static Archive<?> createTestArchive() {
@@ -68,21 +69,36 @@ public class HistogramTagFieldBeanTest {
     @Inject
     private HistogramTagFieldBean bean;
 
+    @Before
+    public void instantiateTest() {
+        /*
+         * The MetricID relies on the MicroProfile Config API.
+         * Running a managed arquillian container will result
+         * with the MetricID being created in a client process
+         * that does not contain the MPConfig impl.
+         * 
+         * This will cause client instantiated MetricIDs to 
+         * throw an exception. (i.e the global MetricIDs)
+         */
+        histogramOneMID = new MetricID(HISTOGRAM_NAME, NUMBER_ONE_TAG);
+        histogramTwoMID = new MetricID(HISTOGRAM_NAME, NUMBER_TWO_TAG);
+    }
+    
     @Test
     @InSequence(1)
     public void histogramTagFieldRegistered() {
-        assertThat("Histogram is not registered correctly", registry.getHistograms(), hasKey(HISTOGRAM_ONE_METRICID));
-        assertThat("Histogram is not registered correctly", registry.getHistograms(), hasKey(HISTOGRAM_TWO_METRICID));
+        assertThat("Histogram is not registered correctly", registry.getHistograms(), hasKey(histogramOneMID));
+        assertThat("Histogram is not registered correctly", registry.getHistograms(), hasKey(histogramTwoMID));
     }
     
     @Test
     @InSequence(2)
     public void updateHistogramTagField() {
-        assertThat("Histogram is not registered correctly", registry.getHistograms(), hasKey(HISTOGRAM_ONE_METRICID));
-        assertThat("Histogram is not registered correctly", registry.getHistograms(), hasKey(HISTOGRAM_TWO_METRICID));
+        assertThat("Histogram is not registered correctly", registry.getHistograms(), hasKey(histogramOneMID));
+        assertThat("Histogram is not registered correctly", registry.getHistograms(), hasKey(histogramTwoMID));
         
-        Histogram histogramOne = registry.getHistograms().get(HISTOGRAM_ONE_METRICID);
-        Histogram histogramTwo = registry.getHistograms().get(HISTOGRAM_TWO_METRICID);
+        Histogram histogramOne = registry.getHistograms().get(histogramOneMID);
+        Histogram histogramTwo = registry.getHistograms().get(histogramTwoMID);
         
         // Call the update method and assert the histogram is up-to-date
         long value = Math.round(Math.random() * Long.MAX_VALUE);

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MeteredConstructorBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MeteredConstructorBeanTest.java
@@ -33,6 +33,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -41,7 +42,7 @@ public class MeteredConstructorBeanTest {
 
     private final static String METER_NAME = "meteredConstructor";
     
-    private final static MetricID METER_METRICID = new MetricID(METER_NAME);
+    private static MetricID meterMID;
 
     @Deployment
     static Archive<?> createTestArchive() {
@@ -64,6 +65,20 @@ public class MeteredConstructorBeanTest {
     //    assertThat("Meter is not registered correctly", registry.getMeters().keySet(), is(empty()));
     //}
 
+    @Before
+    public void instantiateTest() {
+        /*
+         * The MetricID relies on the MicroProfile Config API.
+         * Running a managed arquillian container will result
+         * with the MetricID being created in a client process
+         * that does not contain the MPConfig impl.
+         * 
+         * This will cause client instantiated MetricIDs to 
+         * throw an exception. (i.e the global MetricIDs)
+         */
+        meterMID = new MetricID(METER_NAME);
+    }
+    
     @Test
     @InSequence(1)
     public void meteredConstructorCalled() {
@@ -72,8 +87,8 @@ public class MeteredConstructorBeanTest {
             instance.get();
         }
 
-        assertThat("Meter is not registered correctly", registry.getMeters(), hasKey(METER_METRICID));
-        Meter meter = registry.getMeters().get(METER_METRICID);
+        assertThat("Meter is not registered correctly", registry.getMeters(), hasKey(meterMID));
+        Meter meter = registry.getMeters().get(meterMID);
 
         // Make sure that the meter has been called
         assertThat("Meter count is incorrect", meter.getCount(), is(equalTo(count)));

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MeteredMethodBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MeteredMethodBeanTest.java
@@ -36,6 +36,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -43,7 +44,7 @@ import org.junit.runner.RunWith;
 public class MeteredMethodBeanTest {
 
     private final static String METER_NAME = MetricRegistry.name(MeteredMethodBean1.class, "meteredMethod");
-    private final static MetricID METER_METRICID = new MetricID(METER_NAME);
+    private static MetricID meterMID;
 
     private final static AtomicLong METER_COUNT = new AtomicLong();
 
@@ -62,11 +63,25 @@ public class MeteredMethodBeanTest {
     @Inject
     private MeteredMethodBean1 bean;
 
+    @Before
+    public void instantiateTest() {
+        /*
+         * The MetricID relies on the MicroProfile Config API.
+         * Running a managed arquillian container will result
+         * with the MetricID being created in a client process
+         * that does not contain the MPConfig impl.
+         * 
+         * This will cause client instantiated MetricIDs to 
+         * throw an exception. (i.e the global MetricIDs)
+         */
+        meterMID = new MetricID(METER_NAME);
+    }
+    
     @Test
     @InSequence(1)
     public void meteredMethodNotCalledYet() {
-        assertThat("Meter is not registered correctly", registry.getMeters(), hasKey(METER_METRICID));
-        Meter meter = registry.getMeters().get(METER_METRICID);
+        assertThat("Meter is not registered correctly", registry.getMeters(), hasKey(meterMID));
+        Meter meter = registry.getMeters().get(meterMID);
 
         // Make sure that the meter hasn't been marked yet
         assertThat("Meter count is incorrect", meter.getCount(), is(equalTo(METER_COUNT.get())));
@@ -75,8 +90,8 @@ public class MeteredMethodBeanTest {
     @Test
     @InSequence(2)
     public void callMeteredMethodOnce() {
-        assertThat("Meter is not registered correctly", registry.getMeters(), hasKey(METER_METRICID));
-        Meter meter = registry.getMeters().get(METER_METRICID);
+        assertThat("Meter is not registered correctly", registry.getMeters(), hasKey(meterMID));
+        Meter meter = registry.getMeters().get(meterMID);
 
         // Call the metered method and assert it's been marked
         bean.meteredMethod();
@@ -88,11 +103,11 @@ public class MeteredMethodBeanTest {
     @Test
     @InSequence(3)
     public void removeMeterFromRegistry() {
-        assertThat("Meter is not registered correctly", registry.getMeters(), hasKey(METER_METRICID));
-        Meter meter = registry.getMeters().get(METER_METRICID);
+        assertThat("Meter is not registered correctly", registry.getMeters(), hasKey(meterMID));
+        Meter meter = registry.getMeters().get(meterMID);
 
         // Remove the meter from metrics registry
-        registry.remove(METER_METRICID);
+        registry.remove(meterMID);
 
         try {
             // Call the metered method and assert an exception is thrown

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MeteredTagMethodBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/MeteredTagMethodBeanTest.java
@@ -36,6 +36,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -47,8 +48,8 @@ public class MeteredTagMethodBeanTest {
     private final static Tag NUMBER_ONE_TAG = new Tag("number", "one");
     private final static Tag NUMBER_TWO_TAG = new Tag("number", "two");
     
-    private final static MetricID METER_ONE_METRICID = new MetricID(METER_NAME, NUMBER_ONE_TAG);
-    private final static MetricID METER_TWO_METRICID = new MetricID(METER_NAME, NUMBER_TWO_TAG);
+    private static MetricID meterOneMID;
+    private static MetricID meterTwoMID;
 
 
     @Deployment
@@ -66,10 +67,25 @@ public class MeteredTagMethodBeanTest {
     @Inject
     private MeteredTagMethodBean bean;
 
+    @Before
+    public void instantiateTest() {
+        /*
+         * The MetricID relies on the MicroProfile Config API.
+         * Running a managed arquillian container will result
+         * with the MetricID being created in a client process
+         * that does not contain the MPConfig impl.
+         * 
+         * This will cause client instantiated MetricIDs to 
+         * throw an exception. (i.e the global MetricIDs)
+         */
+        meterOneMID = new MetricID(METER_NAME, NUMBER_ONE_TAG);
+        meterTwoMID = new MetricID(METER_NAME, NUMBER_TWO_TAG);
+    }
+    
     @Test
     @InSequence(1)
     public void meteredTagMethodRegistered() {
-        assertThat("Meter is not registered correctly", registry.getMeters(), hasKey(METER_ONE_METRICID));
-        assertThat("Meter is not registered correctly", registry.getMeters(), hasKey(METER_TWO_METRICID));
+        assertThat("Meter is not registered correctly", registry.getMeters(), hasKey(meterOneMID));
+        assertThat("Meter is not registered correctly", registry.getMeters(), hasKey(meterTwoMID));
     }
 }

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/TimedConstructorBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/TimedConstructorBeanTest.java
@@ -33,6 +33,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -41,7 +42,7 @@ public class TimedConstructorBeanTest {
 
     private final static String TIMER_NAME = MetricRegistry.name(TimedConstructorBean.class, "timedConstructor");
 
-    private final static MetricID TIMER_METRICID = new MetricID(TIMER_NAME);
+    private static MetricID timerMID;
     
     @Deployment
     static Archive<?> createTestArchive() {
@@ -66,6 +67,20 @@ public class TimedConstructorBeanTest {
         assertThat("Timer is not registered correctly", registry.getTimers().keySet(), is(empty()));
     }
     */
+    
+    @Before
+    public void instantiateTest() {
+        /*
+         * The MetricID relies on the MicroProfile Config API.
+         * Running a managed arquillian container will result
+         * with the MetricID being created in a client process
+         * that does not contain the MPConfig impl.
+         * 
+         * This will cause client instantiated MetricIDs to 
+         * throw an exception. (i.e the global MetricIDs)
+         */
+        timerMID = new MetricID(TIMER_NAME);
+    }
 
     @Test
     @InSequence(1)
@@ -75,8 +90,8 @@ public class TimedConstructorBeanTest {
             instance.get();
         }
 
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(TIMER_METRICID));
-        Timer timer = registry.getTimers().get(TIMER_METRICID);
+        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(timerMID));
+        Timer timer = registry.getTimers().get(timerMID);
 
         // Make sure that the timer has been called
         assertThat("Timer count is incorrect", timer.getCount(), is(equalTo(count)));

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/TimedTagMethodBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/TimedTagMethodBeanTest.java
@@ -36,6 +36,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -47,8 +48,8 @@ public class TimedTagMethodBeanTest {
     private final static Tag NUMBER_ONE_TAG = new Tag("number", "one");
     private final static Tag NUMBER_TWO_TAG = new Tag("number", "two");
     
-    private final static MetricID TIMER_ONE_METRICID = new MetricID(TIMER_NAME, NUMBER_ONE_TAG);
-    private final static MetricID TIMER_TWO_METRICID = new MetricID(TIMER_NAME, NUMBER_TWO_TAG);
+    private static MetricID timerOneMID;
+    private static MetricID timerTwoMID;
 
     @Deployment
     static Archive<?> createTestArchive() {
@@ -65,11 +66,27 @@ public class TimedTagMethodBeanTest {
     @Inject
     private TimedTagMethodBean bean;
 
+    @Before
+    public void instantiateTest() {
+        /*
+         * The MetricID relies on the MicroProfile Config API.
+         * Running a managed arquillian container will result
+         * with the MetricID being created in a client process
+         * that does not contain the MPConfig impl.
+         * 
+         * This will cause client instantiated MetricIDs to 
+         * throw an exception. (i.e the global MetricIDs)
+         */
+        timerOneMID = new MetricID(TIMER_NAME, NUMBER_ONE_TAG);
+        timerTwoMID = new MetricID(TIMER_NAME, NUMBER_TWO_TAG);
+
+    }
+    
     @Test
     @InSequence(1)
     public void timedTagMethodRegistered() {
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(TIMER_ONE_METRICID));
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(TIMER_TWO_METRICID));
+        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(timerOneMID));
+        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(timerTwoMID));
     }
 
 

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/TimerTagFieldBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/TimerTagFieldBeanTest.java
@@ -35,6 +35,8 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import static org.junit.Assert.assertThat;
+
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -48,8 +50,8 @@ public class TimerTagFieldBeanTest {
     private final static Tag NUMBER_ONE_TAG = new Tag("number", "one");
     private final static Tag NUMBER_TWO_TAG = new Tag("number", "two");
     
-    private final static MetricID TIMER_ONE_METRICID = new MetricID(TIMER_NAME, NUMBER_ONE_TAG);
-    private final static MetricID TIMER_TWO_METRICID = new MetricID(TIMER_NAME, NUMBER_TWO_TAG);
+    private static MetricID timerOneMID;
+    private static MetricID timerTwoMID;
 
     @Deployment
     static Archive<?> createTestArchive() {
@@ -66,9 +68,25 @@ public class TimerTagFieldBeanTest {
     @Inject
     private TimerTagFieldBean bean;
     
+    @Before
+    public void instantiateTest() {
+        /*
+         * The MetricID relies on the MicroProfile Config API.
+         * Running a managed arquillian container will result
+         * with the MetricID being created in a client process
+         * that does not contain the MPConfig impl.
+         * 
+         * This will cause client instantiated MetricIDs to 
+         * throw an exception. (i.e the global MetricIDs)
+         */
+        timerOneMID = new MetricID(TIMER_NAME, NUMBER_ONE_TAG);
+        timerTwoMID = new MetricID(TIMER_NAME, NUMBER_TWO_TAG);
+
+    }
+    
     @Test
     public void timersTagFieldRegistered() {
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(TIMER_ONE_METRICID));
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(TIMER_TWO_METRICID));
+        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(timerOneMID));
+        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(timerTwoMID));
     }
 }

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/MetricFilterTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/MetricFilterTest.java
@@ -30,7 +30,7 @@ import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -39,8 +39,8 @@ import org.junit.runner.RunWith;
 public class MetricFilterTest {
 
     @Deployment
-    public static JavaArchive createDeployment() {
-        return ShrinkWrap.create(JavaArchive.class).addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+    public static WebArchive createDeployment() {
+        return ShrinkWrap.create(WebArchive.class).addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
     private Metric metric = new Metric () { };

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/MetricFilterTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/MetricFilterTest.java
@@ -23,27 +23,27 @@
 
 package org.eclipse.microprofile.metrics.tck;
 
-import javax.inject.Inject;
-
 import org.eclipse.microprofile.metrics.Metric;
 import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricFilter;
 import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
-import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
+@RunWith(Arquillian.class)
 public class MetricFilterTest {
 
     @Deployment
-    public static WebArchive createDeployment() {
-        return ShrinkWrap.create(WebArchive.class).addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+    public static JavaArchive createDeployment() {
+        return ShrinkWrap.create(JavaArchive.class).addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
-    @Inject
-    private Metric metric;
+    private Metric metric = new Metric () { };
 
     @Test
     public void theAllFilterMatchesAllMetrics() throws Exception {


### PR DESCRIPTION
…and not the client side

When running the TCK in a managed arquillian container there is a client process and server process.

For tests that instantiate the MetricID globally, the client process will then fail as it relies on a MicroProfile Config implementation. Because there is no _implementation_ on the client side., it will fail.

For tests where this occurs, it has been modified to rely on the @before  to instantiate the MetricID for each test.

See: https://github.com/eclipse/microprofile-metrics/pull/340

Signed-off-by: chdavid <chdavid@ca.ibm.com>