### PR TITLE
Moving the "how to contribute" part to it's own file

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -1,0 +1,35 @@
+//
+// Copyright (c) 2018 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+== How to contribute
+
+Do you want to contribute to this project? Here is what you can do:
+
+* Fork the repository, make changes, then do a pull request.
+** Remember to https://help.github.com/articles/signing-commits/[sign your commits]
+** Make sure you have signed the https://www.eclipse.org/legal/ECA.php[Eclipse Contributor Agreement]
+* https://github.com/eclipse/microprofile-metrics/issues[Create or fix an issue].
+* https://gitter.im/eclipse/microprofile-metrics[Join us on Gitter to discuss this project].
+* Join our https://calendar.google.com/calendar/embed?src=gbnbc373ga40n0tvbl88nkc3r4%40group.calendar.google.com[weekly meeting] on Tuesdays at https://www.timeanddate.com/time/map/[14h00 GMT]. 
+** https://docs.google.com/document/d/1HJOg-NOVpcE5X7qhELnyBa_A7OaVTwbOPCsAOp6F1Zc/edit#[Minutes and Agenda].
+** https://bluejeans.com/2042160481[Meeting room].
+* Join the discussions on the https://groups.google.com/forum/#!forum/microprofile[MicroProfile Google Group]
+* https://microprofile.io/blog/[Contribute a blog post].
+
+Also see the https://wiki.eclipse.org/MicroProfile/ContributingGuidelines[MicroProfile Contributing Guidelines] on the https://wiki.eclipse.org/MicroProfile[Eclipse MicroProfile wiki page]

--- a/README.adoc
+++ b/README.adoc
@@ -27,3 +27,7 @@ data.
 * For the current specification see the link:spec/src/main/asciidoc/metrics_spec.adoc[Metrics Spec] document. For the specification at a given release or milestone, download link:https://github.com/eclipse/microprofile-metrics/releases[the PDF from the GitHub releases page].
 * To chat or ask questions about the spec, join the discussion on Gitter: image:https://badges.gitter.im/eclipse/microprofile-metrics.svg[link=https://gitter.im/eclipse/microprofile-metrics]
 * For announcements, visit the link:++https://groups.google.com/forum/#!forum/microprofile++[Microprofile Google Group] and filter by link:++https://groups.google.com/forum/#!tags/microprofile/metrics++[the metrics tag] to focus on topics related to this specification.
+
+== Contributing
+
+Do you want to contribute to this project? link:CONTRIBUTING.adoc[Find out how you can help here].


### PR DESCRIPTION
Signed-off-by:Phillip Kruger <phillip.kruger@gmail.com>

As discussed here: https://groups.google.com/forum/#!topic/microprofile/-o0Mqv4I2IY
Moved the how to contribute to it's own file.

