### PR TITLE
Modified spec + TCK to better accomodate multidimensional metrics in JSON format

### DIFF
--- a/spec/src/main/asciidoc/changelog.adoc
+++ b/spec/src/main/asciidoc/changelog.adoc
@@ -38,7 +38,7 @@ The `Counted` interface lost the `dec()` methods.
 ** The 'Metadata' is mapped to a unique metric name in the `MetricRegistry` and this relationship is immutable.
 ** Tag key names are restricted to match the regex `[a-zA-Z_][a-zA-Z0-9_]*`.
 ** Tag values defined through MP_METRICS_TAGS must escape equal signs `=` and commas `,` with a backslash `\`.
-** JSON format for GET requests now includes tags along with the metric name. JSON format for OPTIONS requests
+** JSON format for GET requests now appends tags along with the metric in `metricName;tag=value;tag=value` format. JSON format for OPTIONS requests
 have been modified such that the 'tags' attribute is a list of nested lists which holds tags from different metrics that
  are associated with the metadata.
 ** Reserved characters in Prometheus format must be escaped.

--- a/spec/src/main/asciidoc/rest-endpoints.adoc
+++ b/spec/src/main/asciidoc/rest-endpoints.adoc
@@ -36,7 +36,7 @@ The following rules apply only to GET requests:
 * Tags are appended to the leaf element of the metric's JSON tree with a semicolon `;`.
 * The metric tags are represented by a semicolon `;` separated list of key/value tag pairs.
 * Tagged metrics that contain sub-resources that are registered under the same metric name will share the root element (i.e the metric name).
-* Metrics with tag values containing a semicolon `;` will be converted to underscores `_`
+* Metrics with tag values containing semicolons `;` will have their semicolons `;` converted to underscores `_`.
 
 For example:
 [source, json]
@@ -328,7 +328,7 @@ The value of the gauge must be equivalent to a call to the instance ConcurrentGa
 
 
 Metadata is exposed in a tree-like fashion with sub-trees for the sub-resources mentioned previously.
-Tags from metrics associated with the metric name are also included. The 'tags' attribute is a list of nested lists which hold tags from different metrics that are associated with the metadata.
+Tags from metrics associated with the metric name are also included. The 'tags' attribute is an array of nested arrays which hold tags from different metrics that are associated with the metadata.
 
 Example:
 

--- a/spec/src/main/asciidoc/rest-endpoints.adoc
+++ b/spec/src/main/asciidoc/rest-endpoints.adoc
@@ -34,16 +34,16 @@ A sub-tree that does not contain data must be omitted.
 The following rules apply only to GET requests:
 
 * Tags are appended to the leaf element of the metric's JSON tree with a semicolon `;`.
-* The metric tags are represented by a semicolon `;` separated list of key/value tag pairs.
-* Tagged metrics that contain sub-resources that are registered under the same metric name will share the root element (i.e the metric name).
-* Metrics with tag values containing semicolons `;` will have their semicolons `;` converted to underscores `_`.
+* For metrics with tags, the metric name must be appended with a semicolon `; followed by a semicolon-separated list of tag key/value pairs.
+* For compound metrics (those with child JSON attributes) with tags, only the "leaf" metric names are decorated with tags.
+* Semicolons `; present in tag values must be converted to underscores `_` in JSON output.
 
 For example:
 [source, json]
 ----
 {
  "carsCounter;colour=red" : 0,
- "carsCounter;colour=blue" : 0,
+ "carsCounter;colour=blue;car=sedan" : 0,
  "carsMeter": {
     "count;colour=red" : 0,
     "meanRate;colour=red" : 0,
@@ -61,7 +61,7 @@ For example:
 
 The following apply to both GET and OPTION requests:
 
-* Each tag is a key-value-pair in the format of `<key>=<value>`. The list of tags must be sorted alphabetically.
+* Each tag is a key-value-pair in the format of `<key>=<value>`. The list of tags must be sorted alphabetically by key name.
 * If the metric name or tag value contains a special reserved JSON character, these characters must be escaped in the JSON response.
 
 
@@ -125,8 +125,8 @@ The value of the gauge must be equivalent to a call to the instance Gauge's `get
 ----
 {
   "responsePercentage": 48.45632,
-  "responsePercentage;tag=two": 26.23654,
-  "responsePercentage;app=webapp;tag=three": 29.24554
+  "responsePercentage;servlet=two": 26.23654,
+  "responsePercentage;app=webapp;servlet=three": 29.24554
 }
 ----
 
@@ -139,8 +139,8 @@ The value of the counter must be equivalent to a call to the instance Counter's 
 ----
 {
   "hitCount": 45,
-  "hitCount;tag=two": 3,
-  "hitCount;app=webapp;tag=three": 4
+  "hitCount;servlet=two": 3,
+  "hitCount;app=webapp;servlet=three": 4
 }
 ----
 
@@ -243,17 +243,17 @@ The value of the gauge must be equivalent to a call to the instance ConcurrentGa
     "p98":26.0,
     "p99":26.0,
     "p999":26.0,
-    "count;tag=two":2,
-    "min;tag=two":-1624,
-    "max;tag=two":26,
-    "mean;tag=two":-799.0,
-    "stddev;tag=two":825.0,
-    "p50;tag=two":26.0,
-    "p75;tag=two":26.0,
-    "p95;tag=two":26.0,
-    "p98;tag=two":26.0,
-    "p99;tag=two":26.0,
-    "p999;tag=two":26.0
+    "count;servlet=two":2,
+    "min;servlet=two":-1624,
+    "max;servlet=two":26,
+    "mean;servlet=two":-799.0,
+    "stddev;servlet=two":825.0,
+    "p50;servlet=two":26.0,
+    "p75;servlet=two":26.0,
+    "p95;servlet=two":26.0,
+    "p98;servlet=two":26.0,
+    "p99;servlet=two":26.0,
+    "p999;servlet=two":26.0
   }
 }
 ----
@@ -305,21 +305,21 @@ The value of the gauge must be equivalent to a call to the instance ConcurrentGa
     "p98":2706543.0,
     "p99":5608694.0,
     "p999":5608694.0,
-    "count;tag=two": 29382,
-    "meanRate;tag=two":12.185627192860734,
-    "oneMinRate;tag=two": 12.563,
-    "fiveMinRate;tag=two": 12.364,
-    "fifteenMinRate;tag=two": 12.126,
-    "min;tag=two":169916,
-    "max;tag=two":5608694,
-    "mean;tag=two":415041.00024926325,
-    "stddev;tag=two":652907.9633011606,
-    "p50;tag=two":293324.0,
-    "p75;tag=two":344914.0,
-    "p95;tag=two":543647.0,
-    "p98;tag=two":2706543.0,
-    "p99;tag=two":5608694.0,
-    "p999;tag=two":5608694.0
+    "count;servlet=two": 29382,
+    "meanRate;servlet=two":12.185627192860734,
+    "oneMinRate;servlet=two": 12.563,
+    "fiveMinRate;servlet=two": 12.364,
+    "fifteenMinRate;servlet=two": 12.126,
+    "min;servlet=two":169916,
+    "max;servlet=two":5608694,
+    "mean;servlet=two":415041.00024926325,
+    "stddev;servlet=two":652907.9633011606,
+    "p50;servlet=two":293324.0,
+    "p75;servlet=two":344914.0,
+    "p95;servlet=two":543647.0,
+    "p98;servlet=two":2706543.0,
+    "p99;servlet=two":5608694.0,
+    "p999;servlet=two":5608694.0
   }
 }
 ----
@@ -537,7 +537,7 @@ The exposed metric names have suffixes as follows:
 |===
 | Value | Suffix
 
-| `getCount` |  _<none>_
+| `getCount` |  `_current`
 | `getMin` |  `_min`
 | `getMax` |  `_max`
 |===
@@ -550,7 +550,7 @@ Concurrent gauges do not have a suffix for the unit.
 ----
 # TYPE application_method_a_invocations gauge
 # HELP application_method_a_invocations The number of parallel invocations of methodA() #<1>
-application_method_a_invocations 80
+application_method_a_invocations_current 80
 # TYPE application_method_a_invocations_min gauge
 application_method_a_invocations_min 20
 # TYPE application_method_a_invocations_max gauge

--- a/spec/src/main/asciidoc/rest-endpoints.adoc
+++ b/spec/src/main/asciidoc/rest-endpoints.adoc
@@ -152,12 +152,14 @@ The value of the gauge must be equivalent to a call to the instance ConcurrentGa
 [source, json]
 ----
 {
-  "callCount": 48,
-  "callCount_min": 4,
-  "callCount_max": 50,
-  "callCount;app=backend": 23,
-  "callCount_min;app=backend": 1,
-  "callCount_max;app=backend":29
+  "callCount": {
+      "current" : 48,
+      "min": 4,
+      "max": 50,
+      "current;app=backend" : 23,
+      "min;app=backend": 1,
+      "max;app=backend": 29
+  }
 }
 ----
 

--- a/spec/src/main/asciidoc/rest-endpoints.adoc
+++ b/spec/src/main/asciidoc/rest-endpoints.adoc
@@ -29,30 +29,46 @@ This section describes the REST-api, that monitoring agents would use to retriev
 A sub-tree that does not contain data must be omitted.
 * A 'shadow tree' that responds to OPTIONS will provide the metadata and tags associated to a metric name.
 
-==== Translation rules for metric names
+==== Translation rules for metric names and handling of tags
 
 The following rules apply only to GET requests:
-* The metric name in JSON is comprised of the metric name appended with the metric tags (if they exist).
-* The metric tags are represented by a comma separated list of key/value tag pairs surrounded by braces `{` and `}`
+
+* Tags are appended to the leaf element of the metric's JSON tree with a semicolon `;`.
+* The metric tags are represented by a semicolon `;` separated list of key/value tag pairs.
+* Tagged metrics that contain sub-resources that are registered under the same metric name will share the root element (i.e the metric name).
+* Metrics with tag values containing a semicolon `;` will be converted to underscores `_`
+
+For example:
+[source, json]
+----
+{
+ "carsCounter;colour=red" : 0,
+ "carsCounter;colour=blue" : 0,
+ "carsMeter": {
+    "count;colour=red" : 0,
+    "meanRate;colour=red" : 0,
+    "oneMinRate;colour=red" : 0,
+    "fiveMinRate;colour=red" : 0,
+    "fifteenMinRate;colour=red" : 0,
+    "count;colour=blue" : 0,
+    "meanRate;colour=blue" : 0,
+    "oneMinRate;colour=blue" : 0,
+    "fiveMinRate;colour=blue" : 0,
+    "fifteenMinRate;colour=blue" : 0
+ }
+}
+----
 
 The following apply to both GET and OPTION requests:
+
 * Each tag is a key-value-pair in the format of `<key>=<value>`. The list of tags must be sorted alphabetically.
 * If the metric name or tag value contains a special reserved JSON character, these characters must be escaped in the JSON response.
 
 
-[source]
-----
-{
-  "cars{colour=red,type=sedan}" : 12,
-  "cars{colour=blue,type=sedan}" : 9,
-  "cars{colour=yellow,type=sedan}" : 16
-}
-----
-
-If the metric has no tags, the braces `{}` must be omitted.
+If the metric has no tags, the semicolon `;` must be omitted.
 
 For example,
-[source]
+[source, json]
 ----
 {
   "metricWithoutTags": 192
@@ -64,7 +80,7 @@ For example,
 
 API-objects MAY include one or more metrics as in
 
-[source]
+[source, json]
 ----
 {
   "thread.count" : 33,
@@ -77,16 +93,16 @@ API-objects MAY include one or more metrics as in
 
 or
 
-[source]
+[source, json]
 ----
 {
-  "hitCount{type=yes}": 45
+  "hitCount;type=yes": 45
 }
 ----
 
 In case `/metrics` is requested, then the data for the scopes are wrapped in the scope name:
 
-[source]
+[source, json]
 ----
 {
   "application": {
@@ -108,7 +124,9 @@ The value of the gauge must be equivalent to a call to the instance Gauge's `get
 [source, json]
 ----
 {
-  "responsePercentage": 48.45632
+  "responsePercentage": 48.45632,
+  "responsePercentage;tag=two": 26.23654,
+  "responsePercentage;app=webapp;tag=three": 29.24554
 }
 ----
 
@@ -120,7 +138,9 @@ The value of the counter must be equivalent to a call to the instance Counter's 
 [source, json]
 ----
 {
-  "hitCount": 45
+  "hitCount": 45,
+  "hitCount;tag=two": 3,
+  "hitCount;app=webapp;tag=three": 4
 }
 ----
 
@@ -132,9 +152,12 @@ The value of the gauge must be equivalent to a call to the instance ConcurrentGa
 [source, json]
 ----
 {
-  "callCount": 48
-  "callCount_min": 4
-  "callCount_max": 50
+  "callCount": 48,
+  "callCount_min": 4,
+  "callCount_max": 50,
+  "callCount;app=backend": 23,
+  "callCount_min;app=backend": 1,
+  "callCount_max;app=backend":29
 }
 ----
 
@@ -164,7 +187,17 @@ The value of the gauge must be equivalent to a call to the instance ConcurrentGa
     "meanRate": 12.223,
     "oneMinRate": 12.563,
     "fiveMinRate": 12.364,
-    "fifteenMinRate": 12.126
+    "fifteenMinRate": 12.126,
+    "count;servlet=one": 29382,
+    "meanRate;servlet=one": 12.223,
+    "oneMinRate;servlet=one": 12.563,
+    "fiveMinRate;servlet=one": 12.364,
+    "fifteenMinRate;servlet=one": 12.126,
+    "count;servlet=two": 29382,
+    "meanRate;servlet=two": 12.223,
+    "oneMinRate;servlet=two": 12.563,
+    "fiveMinRate;servlet=two": 12.364,
+    "fifteenMinRate;servlet=two": 12.126
   }
 }
 ----
@@ -207,7 +240,18 @@ The value of the gauge must be equivalent to a call to the instance ConcurrentGa
     "p95":26.0,
     "p98":26.0,
     "p99":26.0,
-    "p999":26.0
+    "p999":26.0,
+    "count;tag=two":2,
+    "min;tag=two":-1624,
+    "max;tag=two":26,
+    "mean;tag=two":-799.0,
+    "stddev;tag=two":825.0,
+    "p50;tag=two":26.0,
+    "p75;tag=two":26.0,
+    "p95;tag=two":26.0,
+    "p98;tag=two":26.0,
+    "p99;tag=two":26.0,
+    "p999;tag=two":26.0
   }
 }
 ----
@@ -258,7 +302,22 @@ The value of the gauge must be equivalent to a call to the instance ConcurrentGa
     "p95":543647.0,
     "p98":2706543.0,
     "p99":5608694.0,
-    "p999":5608694.0
+    "p999":5608694.0,
+    "count;tag=two": 29382,
+    "meanRate;tag=two":12.185627192860734,
+    "oneMinRate;tag=two": 12.563,
+    "fiveMinRate;tag=two": 12.364,
+    "fifteenMinRate;tag=two": 12.126,
+    "min;tag=two":169916,
+    "max;tag=two":5608694,
+    "mean;tag=two":415041.00024926325,
+    "stddev;tag=two":652907.9633011606,
+    "p50;tag=two":293324.0,
+    "p75;tag=two":344914.0,
+    "p95;tag=two":543647.0,
+    "p98;tag=two":2706543.0,
+    "p99;tag=two":5608694.0,
+    "p999;tag=two":5608694.0
   }
 }
 ----
@@ -267,7 +326,7 @@ The value of the gauge must be equivalent to a call to the instance ConcurrentGa
 
 
 Metadata is exposed in a tree-like fashion with sub-trees for the sub-resources mentioned previously.
-Tags from metrics associated with the metric name are also included.
+Tags from metrics associated with the metric name are also included. The 'tags' attribute is a list of nested lists which hold tags from different metrics that are associated with the metadata.
 
 Example:
 
@@ -275,7 +334,9 @@ If `GET /metrics/base/fooVal` exposes:
 
 [source]
 ----
-{"fooVal{app=webshop}": 12345}
+{
+  "fooVal;app=webshop": 12345
+}
 ----
 
 then `OPTIONS /metrics/base/fooVal` will expose:
@@ -305,9 +366,9 @@ If `GET /metrics/base` exposes multiple values like this:
 [source]
 ----
 {
-  "fooVal{app=webshop}": 12345,
-  "barVal{app=webshop,component=backend}": 42,
-  "barVal{app=webshop,component=frontend}": 63
+  "fooVal;app=webshop": 12345,
+  "barVal;app=webshop;component=backend": 42,
+  "barVal;app=webshop;component=frontend": 63
 }
 ----
 

--- a/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MetricAppBean.java
+++ b/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MetricAppBean.java
@@ -33,6 +33,7 @@ import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.MetricType;
 import org.eclipse.microprofile.metrics.MetricUnits;
 import org.eclipse.microprofile.metrics.Timer;
+import org.eclipse.microprofile.metrics.annotation.ConcurrentGauge;
 import org.eclipse.microprofile.metrics.annotation.Counted;
 import org.eclipse.microprofile.metrics.annotation.Metered;
 import org.eclipse.microprofile.metrics.annotation.Metric;
@@ -53,6 +54,95 @@ public class MetricAppBean {
     @Metric(name = "blue")
     private Counter blueCount;
 
+    public static final String TAGGED_COUNTER = "taggedCounter";
+    public static final String TAGGED_HISTOGRAM = "taggedHistogram";
+    public static final String TAGGED_TIMER = "taggedTimer";
+    public static final String TAGGED_METER = "taggedMeter";
+    public static final String TAGGED_GAUGE = "taggedGauge";
+    public static final String TAGGED_CONCURRENTGAUGE = "taggedConcurrentGauge";
+    
+    
+    @Inject
+    @Metric(name = "semiColonTaggedCounter", tags = {"scTag=semi;colons;are;bad"})
+    private Counter semiColonTaggedCounter;
+    
+    @Inject
+    @Metric(name = TAGGED_COUNTER)
+    private Counter counterNoTag;
+    
+    @Inject
+    @Metric(name = TAGGED_COUNTER, tags= {"number=one"})
+    private Counter counterNumberOneTag;
+    
+    @Inject
+    @Metric(name = TAGGED_COUNTER, tags= {"number=two"})
+    private Counter counterNumberTwoTag;
+    
+    @Inject
+    @Metric(name = TAGGED_HISTOGRAM, absolute = true, unit = "marshmellow")
+    private Histogram histogramNoTag;
+    
+    @Inject
+    @Metric(name = TAGGED_HISTOGRAM, absolute = true, unit = "marshmellow", tags= {"number=one"})
+    private Histogram histogramOneTag;
+    
+    @Inject
+    @Metric(name = TAGGED_HISTOGRAM, absolute = true, unit = "marshmellow", tags= {"number=two"})
+    private Histogram histogramTwoTag;
+    
+    @Inject
+    @Metric(name = TAGGED_TIMER, absolute = true)
+    private Timer timerNoTag;
+    
+    @Inject
+    @Metric(name = TAGGED_TIMER, absolute = true, tags= {"number=one"})
+    private Timer timerOneTag;
+    
+    @Inject
+    @Metric(name = TAGGED_TIMER, absolute = true, tags= {"number=two"})
+    private Timer timerTwoTag;
+    
+    
+    @Inject
+    @Metric(name = TAGGED_METER, absolute = true)
+    private Meter meterNoTag;
+    
+    @Inject
+    @Metric(name = TAGGED_METER, absolute = true, tags= {"number=one"})
+    private Meter meterOneTag;
+    
+    @Inject
+    @Metric(name = TAGGED_METER, absolute = true, tags= {"number=two"})
+    private Meter meterTwoTag;
+    
+    @org.eclipse.microprofile.metrics.annotation.Gauge(name = TAGGED_GAUGE,
+            absolute = true,unit = MetricUnits.NONE)
+    public long gaugeMeTagged() {
+        return 1000L;
+    }
+    
+    @org.eclipse.microprofile.metrics.annotation.Gauge(name = TAGGED_GAUGE,
+            absolute = true,unit = MetricUnits.NONE, tags= {"number=one"})
+    public long gaugeMeTaggedOne() {
+        return 1000L;
+    }
+    
+    @org.eclipse.microprofile.metrics.annotation.Gauge(name = TAGGED_GAUGE,
+            absolute = true,unit = MetricUnits.NONE, tags= {"number=two"})
+    public long gaugeMeTaggedTwo() {
+        return 1000L;
+    }
+     
+    @ConcurrentGauge(name = TAGGED_CONCURRENTGAUGE, absolute = true, tags= {"number=one"})
+    public void concurrentGaugeMeTaggedOne() {
+
+    }
+
+    @ConcurrentGauge(name = TAGGED_CONCURRENTGAUGE, absolute = true, tags= {"number=two"})
+    public void concurrentGaugeMeTaggedTwo() {
+
+    }
+    
     @Inject
     @Metric(absolute = true)
     private Counter greenCount;
@@ -89,7 +179,6 @@ public class MetricAppBean {
     public void countMeA() {
 
     }
-
 
     @Counted(name = "metricTest.test1.countMeB", absolute = true, unit = "jellybean")
     public long countMeB() {

--- a/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MpMetricTest.java
+++ b/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MpMetricTest.java
@@ -191,7 +191,7 @@ public class MpMetricTest {
     @InSequence(5)
     public void testBase() {
         given().header("Accept", APPLICATION_JSON).when().get("/metrics/base").then().statusCode(200).and()
-                .contentType(MpMetricTest.APPLICATION_JSON).and().body(containsString("thread.max.count{tier=integration}"));
+                .contentType(MpMetricTest.APPLICATION_JSON).and().body(containsString("thread.max.count;tier=integration"));
     }
 
     @Test
@@ -210,7 +210,7 @@ public class MpMetricTest {
         Header wantJson = new Header("Accept", APPLICATION_JSON);
 
         given().header(wantJson).when().get("/metrics/base/thread.max.count").then().statusCode(200).and()
-                .contentType(MpMetricTest.APPLICATION_JSON).and().body(containsString("thread.max.count{tier=integration}"));
+                .contentType(MpMetricTest.APPLICATION_JSON).and().body(containsString("thread.max.count;tier=integration"));
     }
 
     @Test
@@ -430,6 +430,10 @@ public class MpMetricTest {
         metricAppBean.gaugeMe();
         metricAppBean.gaugeMeA();
         metricAppBean.gaugeMeB();
+        metricAppBean.gaugeMeTagged();
+        metricAppBean.gaugeMeTaggedOne();
+        metricAppBean.gaugeMeTaggedTwo();
+        
         metricAppBean.histogramMe();
 
         metricAppBean.meterMe();
@@ -439,7 +443,7 @@ public class MpMetricTest {
         metricAppBean.timeMeA();
 
     }
-
+    
     @Test
     @RunAsClient
     @InSequence(18)
@@ -448,79 +452,79 @@ public class MpMetricTest {
 
         given().header(wantJson).get("/metrics/application").then().statusCode(200)
 
-                .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.redCount{tier=integration}'", equalTo(0))
+                .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.redCount;tier=integration'", equalTo(0))
 
-                .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.blue{tier=integration}'", equalTo(0))
+                .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.blue;tier=integration'", equalTo(0))
 
-                .body("'greenCount{tier=integration}'", equalTo(0))
+                .body("'greenCount;tier=integration'", equalTo(0))
 
-                .body("'purple{app=myShop,tier=integration}'", equalTo(0))
+                .body("'purple;app=myShop;tier=integration'", equalTo(0))
 
-                .body("'metricTest.test1.count{tier=integration}'", equalTo(1))
+                .body("'metricTest.test1.count;tier=integration'", equalTo(1))
 
-                .body("'metricTest.test1.countMeA{tier=integration}'", equalTo(1))
-                .body("'metricTest.test1.countMeB{tier=integration}'", equalTo(1))
+                .body("'metricTest.test1.countMeA;tier=integration'", equalTo(1))
+                .body("'metricTest.test1.countMeB;tier=integration'", equalTo(1))
 
-                .body("'metricTest.test1.gauge{tier=integration}'", equalTo(19))
+                .body("'metricTest.test1.gauge;tier=integration'", equalTo(19))
 
-                .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.gaugeMeA{tier=integration}'", equalTo(1000))
-                .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.gaugeMeB{tier=integration}'", equalTo(7777777))
+                .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.gaugeMeA;tier=integration'", equalTo(1000))
+                .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.gaugeMeB;tier=integration'", equalTo(7777777))
 
-                .body("'metricTest.test1.histogram'.'count{tier=integration}'", equalTo(1000))
-                .body("'metricTest.test1.histogram'.'max{tier=integration}'", equalTo(999))
-                .body("'metricTest.test1.histogram'.'mean{tier=integration}'", closeTo(499.5))
-                .body("'metricTest.test1.histogram'.'min{tier=integration}'", equalTo(0))
-                .body("'metricTest.test1.histogram'.'p50{tier=integration}'", closeTo(499.0))
-                .body("'metricTest.test1.histogram'.'p75{tier=integration}'", closeTo(749))
-                .body("'metricTest.test1.histogram'.'p95{tier=integration}'", closeTo(949))
-                .body("'metricTest.test1.histogram'.'p98{tier=integration}'", closeTo(979))
-                .body("'metricTest.test1.histogram'.'p99{tier=integration}'", closeTo(989))
-                .body("'metricTest.test1.histogram'.'p999{tier=integration}'", closeTo(998))
-                .body("'metricTest.test1.histogram'", hasKey("stddev{tier=integration}"))
+                .body("'metricTest.test1.histogram'.'count;tier=integration'", equalTo(1000))
+                .body("'metricTest.test1.histogram'.'max;tier=integration'", equalTo(999))
+                .body("'metricTest.test1.histogram'.'mean;tier=integration'", closeTo(499.5))
+                .body("'metricTest.test1.histogram'.'min;tier=integration'", equalTo(0))
+                .body("'metricTest.test1.histogram'.'p50;tier=integration'", closeTo(499.0))
+                .body("'metricTest.test1.histogram'.'p75;tier=integration'", closeTo(749))
+                .body("'metricTest.test1.histogram'.'p95;tier=integration'", closeTo(949))
+                .body("'metricTest.test1.histogram'.'p98;tier=integration'", closeTo(979))
+                .body("'metricTest.test1.histogram'.'p99;tier=integration'", closeTo(989))
+                .body("'metricTest.test1.histogram'.'p999;tier=integration'", closeTo(998))
+                .body("'metricTest.test1.histogram'", hasKey("stddev;tier=integration"))
 
-                .body("'metricTest.test1.meter'.'count{tier=integration}'", equalTo(1))
-                .body("'metricTest.test1.meter'", hasKey("fifteenMinRate{tier=integration}"))
-                .body("'metricTest.test1.meter'", hasKey("fiveMinRate{tier=integration}"))
-                .body("'metricTest.test1.meter'", hasKey("meanRate{tier=integration}"))
-                .body("'metricTest.test1.meter'", hasKey("oneMinRate{tier=integration}"))
+                .body("'metricTest.test1.meter'.'count;tier=integration'", equalTo(1))
+                .body("'metricTest.test1.meter'", hasKey("fifteenMinRate;tier=integration"))
+                .body("'metricTest.test1.meter'", hasKey("fiveMinRate;tier=integration"))
+                .body("'metricTest.test1.meter'", hasKey("meanRate;tier=integration"))
+                .body("'metricTest.test1.meter'", hasKey("oneMinRate;tier=integration"))
 
-                .body("'meterMeA'.'count{tier=integration}'", equalTo(1))
-                .body("meterMeA", hasKey("fifteenMinRate{tier=integration}"))
-                .body("meterMeA", hasKey("fiveMinRate{tier=integration}"))
-                .body("meterMeA", hasKey("meanRate{tier=integration}"))
-                .body("meterMeA", hasKey("oneMinRate{tier=integration}"))
+                .body("'meterMeA'.'count;tier=integration'", equalTo(1))
+                .body("'meterMeA'", hasKey("fifteenMinRate;tier=integration"))
+                .body("'meterMeA'", hasKey("fiveMinRate;tier=integration"))
+                .body("'meterMeA'", hasKey("meanRate;tier=integration"))
+                .body("'meterMeA'", hasKey("oneMinRate;tier=integration"))
 
-                .body("'metricTest.test1.timer'.'count{tier=integration}'", equalTo(1))
-                .body("'metricTest.test1.timer'", hasKey("fifteenMinRate{tier=integration}"))
-                .body("'metricTest.test1.timer'", hasKey("fiveMinRate{tier=integration}"))
-                .body("'metricTest.test1.timer'", hasKey("meanRate{tier=integration}"))
-                .body("'metricTest.test1.timer'", hasKey("oneMinRate{tier=integration}"))
-                .body("'metricTest.test1.timer'", hasKey("max{tier=integration}"))
-                .body("'metricTest.test1.timer'", hasKey("mean{tier=integration}"))
-                .body("'metricTest.test1.timer'", hasKey("min{tier=integration}"))
-                .body("'metricTest.test1.timer'", hasKey("p50{tier=integration}"))
-                .body("'metricTest.test1.timer'", hasKey("p75{tier=integration}"))
-                .body("'metricTest.test1.timer'", hasKey("p95{tier=integration}"))
-                .body("'metricTest.test1.timer'", hasKey("p98{tier=integration}"))
-                .body("'metricTest.test1.timer'", hasKey("p99{tier=integration}"))
-                .body("'metricTest.test1.timer'", hasKey("p999{tier=integration}"))
-                .body("'metricTest.test1.timer'", hasKey("stddev{tier=integration}"))
+                .body("'metricTest.test1.timer'.'count;tier=integration'", equalTo(1))
+                .body("'metricTest.test1.timer'", hasKey("fifteenMinRate;tier=integration"))
+                .body("'metricTest.test1.timer'", hasKey("fiveMinRate;tier=integration"))
+                .body("'metricTest.test1.timer'", hasKey("meanRate;tier=integration"))
+                .body("'metricTest.test1.timer'", hasKey("oneMinRate;tier=integration"))
+                .body("'metricTest.test1.timer'", hasKey("max;tier=integration"))
+                .body("'metricTest.test1.timer'", hasKey("mean;tier=integration"))
+                .body("'metricTest.test1.timer'", hasKey("min;tier=integration"))
+                .body("'metricTest.test1.timer'", hasKey("p50;tier=integration"))
+                .body("'metricTest.test1.timer'", hasKey("p75;tier=integration"))
+                .body("'metricTest.test1.timer'", hasKey("p95;tier=integration"))
+                .body("'metricTest.test1.timer'", hasKey("p98;tier=integration"))
+                .body("'metricTest.test1.timer'", hasKey("p99;tier=integration"))
+                .body("'metricTest.test1.timer'", hasKey("p999;tier=integration"))
+                .body("'metricTest.test1.timer'", hasKey("stddev;tier=integration"))
 
-                .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.timeMeA'.'count{tier=integration}'", equalTo(1))
-                .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.timeMeA'", hasKey("fifteenMinRate{tier=integration}"))
-                .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.timeMeA'", hasKey("fiveMinRate{tier=integration}"))
-                .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.timeMeA'", hasKey("meanRate{tier=integration}"))
-                .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.timeMeA'", hasKey("oneMinRate{tier=integration}"))
-                .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.timeMeA'", hasKey("max{tier=integration}"))
-                .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.timeMeA'", hasKey("mean{tier=integration}"))
-                .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.timeMeA'", hasKey("min{tier=integration}"))
-                .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.timeMeA'", hasKey("p50{tier=integration}"))
-                .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.timeMeA'", hasKey("p75{tier=integration}"))
-                .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.timeMeA'", hasKey("p95{tier=integration}"))
-                .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.timeMeA'", hasKey("p98{tier=integration}"))
-                .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.timeMeA'", hasKey("p99{tier=integration}"))
-                .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.timeMeA'", hasKey("p999{tier=integration}"))
-                .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.timeMeA'", hasKey("stddev{tier=integration}"));
+                .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.timeMeA'.'count;tier=integration'", equalTo(1))
+                .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.timeMeA'", hasKey("fifteenMinRate;tier=integration"))
+                .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.timeMeA'", hasKey("fiveMinRate;tier=integration"))
+                .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.timeMeA'", hasKey("meanRate;tier=integration"))
+                .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.timeMeA'", hasKey("oneMinRate;tier=integration"))
+                .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.timeMeA'", hasKey("max;tier=integration"))
+                .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.timeMeA'", hasKey("mean;tier=integration"))
+                .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.timeMeA'", hasKey("min;tier=integration"))
+                .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.timeMeA'", hasKey("p50;tier=integration"))
+                .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.timeMeA'", hasKey("p75;tier=integration"))
+                .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.timeMeA'", hasKey("p95;tier=integration"))
+                .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.timeMeA'", hasKey("p98;tier=integration"))
+                .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.timeMeA'", hasKey("p99;tier=integration"))
+                .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.timeMeA'", hasKey("p999;tier=integration"))
+                .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.timeMeA'", hasKey("stddev;tier=integration"));
     }
 
     @Test
@@ -951,6 +955,162 @@ public class MpMetricTest {
     }
     
     /**
+     * Test that multi-dimensional metrics are represented properly
+     * in JSON.
+     */
+    @Test
+    @RunAsClient
+    @InSequence(45)
+    public void testMultipleTaggedMetricsJSON() {
+        Header wantJson = new Header("Accept", APPLICATION_JSON);
+
+        /*
+         * This test's primary objective is to ensure that the format is correct.
+         */
+        
+        given().header(wantJson).get("/metrics/application").then().statusCode(200)
+                //counters
+                .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.taggedCounter;tier=integration'", equalTo(0))
+                .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.taggedCounter;number=one;tier=integration'", equalTo(0))
+                .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.taggedCounter;number=two;tier=integration'", equalTo(0))
+                         
+                //ConcurrentGauge - ;number=one;tier=integration
+                .body("'taggedConcurrentGauge;number=one;tier=integration'", equalTo(0)) 
+                .body("'taggedConcurrentGauge_min;number=one;tier=integration'", equalTo(0))
+                .body("'taggedConcurrentGauge_max;number=one;tier=integration'", equalTo(0))
+                //ConcurrentGauge - ;number=two;tier=integration
+                .body("'taggedConcurrentGauge;number=two;tier=integration'", equalTo(0)) 
+                .body("'taggedConcurrentGauge_min;number=two;tier=integration'", equalTo(0))
+                .body("'taggedConcurrentGauge_max;number=two;tier=integration'", equalTo(0))
+                
+                //Gauge
+                .body("'taggedGauge;number=one;tier=integration'", equalTo(1000))
+                .body("'taggedGauge;number=two;tier=integration'", equalTo(1000))
+                
+                //histogram - ;tier=integration
+                .body("'taggedHistogram'.'count;tier=integration'", equalTo(0))
+                .body("'taggedHistogram'", hasKey("max;tier=integration"))
+                .body("'taggedHistogram'", hasKey("mean;tier=integration"))
+                .body("'taggedHistogram'", hasKey("min;tier=integration"))
+                .body("'taggedHistogram'", hasKey("p50;tier=integration"))
+                .body("'taggedHistogram'", hasKey("p75;tier=integration"))
+                .body("'taggedHistogram'", hasKey("p95;tier=integration"))
+                .body("'taggedHistogram'", hasKey("p98;tier=integration"))
+                .body("'taggedHistogram'", hasKey("p99;tier=integration"))
+                .body("'taggedHistogram'", hasKey("p999;tier=integration"))
+                .body("'taggedHistogram'", hasKey("stddev;tier=integration"))
+                
+                //histogram - ;number=one;tier=integration
+                .body("'taggedHistogram'.'count;number=one;tier=integration'", equalTo(0))
+                .body("'taggedHistogram'", hasKey("max;number=one;tier=integration"))
+                .body("'taggedHistogram'", hasKey("mean;number=one;tier=integration"))
+                .body("'taggedHistogram'", hasKey("min;number=one;tier=integration"))
+                .body("'taggedHistogram'", hasKey("p50;number=one;tier=integration"))
+                .body("'taggedHistogram'", hasKey("p75;number=one;tier=integration"))
+                .body("'taggedHistogram'", hasKey("p95;number=one;tier=integration"))
+                .body("'taggedHistogram'", hasKey("p98;number=one;tier=integration"))
+                .body("'taggedHistogram'", hasKey("p99;number=one;tier=integration"))
+                .body("'taggedHistogram'", hasKey("p999;number=one;tier=integration"))
+                .body("'taggedHistogram'", hasKey("stddev;number=one;tier=integration"))
+                
+                 //histogram - ;number=two;tier=integration
+                .body("'taggedHistogram'.'count;number=two;tier=integration'", equalTo(0))
+                .body("'taggedHistogram'", hasKey("max;number=two;tier=integration"))
+                .body("'taggedHistogram'", hasKey("mean;number=two;tier=integration"))
+                .body("'taggedHistogram'", hasKey("min;number=two;tier=integration"))
+                .body("'taggedHistogram'", hasKey("p50;number=two;tier=integration"))
+                .body("'taggedHistogram'", hasKey("p75;number=two;tier=integration"))
+                .body("'taggedHistogram'", hasKey("p95;number=two;tier=integration"))
+                .body("'taggedHistogram'", hasKey("p98;number=two;tier=integration"))
+                .body("'taggedHistogram'", hasKey("p99;number=two;tier=integration"))
+                .body("'taggedHistogram'", hasKey("p999;number=two;tier=integration"))
+                .body("'taggedHistogram'", hasKey("stddev;number=two;tier=integration"))
+        
+                //timer - ;tier=integration
+                .body("'taggedTimer'.'count;tier=integration'", equalTo(0))
+                .body("'taggedTimer'", hasKey("fifteenMinRate;tier=integration"))
+                .body("'taggedTimer'", hasKey("fiveMinRate;tier=integration"))
+                .body("'taggedTimer'", hasKey("meanRate;tier=integration"))
+                .body("'taggedTimer'", hasKey("oneMinRate;tier=integration"))
+                .body("'taggedTimer'", hasKey("max;tier=integration"))
+                .body("'taggedTimer'", hasKey("mean;tier=integration"))
+                .body("'taggedTimer'", hasKey("min;tier=integration"))
+                .body("'taggedTimer'", hasKey("p50;tier=integration"))
+                .body("'taggedTimer'", hasKey("p75;tier=integration"))
+                .body("'taggedTimer'", hasKey("p95;tier=integration"))
+                .body("'taggedTimer'", hasKey("p98;tier=integration"))
+                .body("'taggedTimer'", hasKey("p99;tier=integration"))
+                .body("'taggedTimer'", hasKey("p999;tier=integration"))
+                .body("'taggedTimer'", hasKey("stddev;tier=integration"))
+                //timer - ;number=one;tier=integration
+                .body("'taggedTimer'.'count;number=one;tier=integration'", equalTo(0))
+                .body("'taggedTimer'", hasKey("fifteenMinRate;number=one;tier=integration"))
+                .body("'taggedTimer'", hasKey("fiveMinRate;number=one;tier=integration"))
+                .body("'taggedTimer'", hasKey("meanRate;number=one;tier=integration"))
+                .body("'taggedTimer'", hasKey("oneMinRate;number=one;tier=integration"))
+                .body("'taggedTimer'", hasKey("max;number=one;tier=integration"))
+                .body("'taggedTimer'", hasKey("mean;number=one;tier=integration"))
+                .body("'taggedTimer'", hasKey("min;number=one;tier=integration"))
+                .body("'taggedTimer'", hasKey("p50;number=one;tier=integration"))
+                .body("'taggedTimer'", hasKey("p75;number=one;tier=integration"))
+                .body("'taggedTimer'", hasKey("p95;number=one;tier=integration"))
+                .body("'taggedTimer'", hasKey("p98;number=one;tier=integration"))
+                .body("'taggedTimer'", hasKey("p99;number=one;tier=integration"))
+                .body("'taggedTimer'", hasKey("p999;number=one;tier=integration"))
+                .body("'taggedTimer'", hasKey("stddev;number=one;tier=integration"))
+                //timer - ;number=two;tier=integration
+                .body("'taggedTimer'.'count;number=two;tier=integration'", equalTo(0))
+                .body("'taggedTimer'", hasKey("fifteenMinRate;number=two;tier=integration"))
+                .body("'taggedTimer'", hasKey("fiveMinRate;number=two;tier=integration"))
+                .body("'taggedTimer'", hasKey("meanRate;number=two;tier=integration"))
+                .body("'taggedTimer'", hasKey("oneMinRate;number=two;tier=integration"))
+                .body("'taggedTimer'", hasKey("max;number=two;tier=integration"))
+                .body("'taggedTimer'", hasKey("mean;number=two;tier=integration"))
+                .body("'taggedTimer'", hasKey("min;number=two;tier=integration"))
+                .body("'taggedTimer'", hasKey("p50;number=two;tier=integration"))
+                .body("'taggedTimer'", hasKey("p75;number=two;tier=integration"))
+                .body("'taggedTimer'", hasKey("p95;number=two;tier=integration"))
+                .body("'taggedTimer'", hasKey("p98;number=two;tier=integration"))
+                .body("'taggedTimer'", hasKey("p99;number=two;tier=integration"))
+                .body("'taggedTimer'", hasKey("p999;number=two;tier=integration"))
+                .body("'taggedTimer'", hasKey("stddev;number=two;tier=integration"))
+        
+                //Meter - ;tier=integration
+                .body("'taggedMeter'.'count;tier=integration'", equalTo(0))
+                .body("'taggedMeter'", hasKey("fifteenMinRate;tier=integration"))
+                .body("'taggedMeter'", hasKey("fiveMinRate;tier=integration"))
+                .body("'taggedMeter'", hasKey("meanRate;tier=integration"))
+                .body("'taggedMeter'", hasKey("oneMinRate;tier=integration"))
+                //Meter - ;number=one;tier=integration
+                .body("'taggedMeter'.'count;number=one;tier=integration'", equalTo(0))
+                .body("'taggedMeter'", hasKey("fifteenMinRate;number=one;tier=integration"))
+                .body("'taggedMeter'", hasKey("fiveMinRate;number=one;tier=integration"))
+                .body("'taggedMeter'", hasKey("meanRate;number=one;tier=integration"))
+                .body("'taggedMeter'", hasKey("oneMinRate;number=one;tier=integration"))
+                //Meter - ;number=two;tier=integration
+                .body("'taggedMeter'.'count;number=two;tier=integration'", equalTo(0))
+                .body("'taggedMeter'", hasKey("fifteenMinRate;number=two;tier=integration"))
+                .body("'taggedMeter'", hasKey("fiveMinRate;number=two;tier=integration"))
+                .body("'taggedMeter'", hasKey("meanRate;number=two;tier=integration"))
+                .body("'taggedMeter'", hasKey("oneMinRate;number=two;tier=integration"));
+                
+    }
+    
+    /**
+     * Test that semicolons `;` in tag values are translated to underscores `_`
+     * in the JSON output
+     */
+    @Test
+    @RunAsClient
+    @InSequence(46)
+    public void testTranslateSemiColonToUnderScoreJSON() {
+        Header wantJson = new Header("Accept", APPLICATION_JSON);
+        given().header(wantJson).get("/metrics/application").then().statusCode(200)
+            .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.semiColonTaggedCounter;"
+                    + "scTag=semi_colons_are_bad;tier=integration'", equalTo(0));
+    }
+    
+    /**
      * Checks that the value is within tolerance of the expected value
      *
      * Note: The JSON parser only returns float for earlier versions of restassured,
@@ -1043,7 +1203,7 @@ public class MpMetricTest {
         }
         
         String toJSONName() {
-            return name + "{" + tags.entrySet().stream().map(e -> e.getKey() + "=" + e.getValue()).collect(Collectors.joining(",")) + "}";
+            return name + ";" + tags.entrySet().stream().map(e -> e.getKey() + "=" + e.getValue()).collect(Collectors.joining(";"));
         }
 
         private String getBaseUnitAsPrometheusString(String unit) {

--- a/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MpMetricTest.java
+++ b/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MpMetricTest.java
@@ -975,13 +975,13 @@ public class MpMetricTest {
                 .body("'org.eclipse.microprofile.metrics.test.MetricAppBean.taggedCounter;number=two;tier=integration'", equalTo(0))
                          
                 //ConcurrentGauge - ;number=one;tier=integration
-                .body("'taggedConcurrentGauge;number=one;tier=integration'", equalTo(0)) 
-                .body("'taggedConcurrentGauge_min;number=one;tier=integration'", equalTo(0))
-                .body("'taggedConcurrentGauge_max;number=one;tier=integration'", equalTo(0))
+                .body("'taggedConcurrentGauge'.'current;number=one;tier=integration'", equalTo(0)) 
+                .body("'taggedConcurrentGauge'.'min;number=one;tier=integration'", equalTo(0))
+                .body("'taggedConcurrentGauge'.'max;number=one;tier=integration'", equalTo(0))
                 //ConcurrentGauge - ;number=two;tier=integration
-                .body("'taggedConcurrentGauge;number=two;tier=integration'", equalTo(0)) 
-                .body("'taggedConcurrentGauge_min;number=two;tier=integration'", equalTo(0))
-                .body("'taggedConcurrentGauge_max;number=two;tier=integration'", equalTo(0))
+                .body("'taggedConcurrentGauge'.'current;number=two;tier=integration'", equalTo(0)) 
+                .body("'taggedConcurrentGauge'.'min;number=two;tier=integration'", equalTo(0))
+                .body("'taggedConcurrentGauge'.'max;number=two;tier=integration'", equalTo(0))
                 
                 //Gauge
                 .body("'taggedGauge;number=one;tier=integration'", equalTo(1000))

--- a/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/ReusableMetricsTest.java
+++ b/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/ReusableMetricsTest.java
@@ -112,9 +112,9 @@ public class ReusableMetricsTest {
     Header acceptJson = new Header("Accept", APPLICATION_JSON);
 
     given().header(acceptJson).get("/metrics/application").then()
-            .assertThat().body("'countMe2{tier=integration}'", equalTo(1))
-            .assertThat().body("'org.eclipse.microprofile.metrics.test.MetricAppBean2.meterMe2'.'count{tier=integration}'", equalTo(1))
-            .assertThat().body("timeMe2.'count{tier=integration}'", equalTo(1));
+            .assertThat().body("'countMe2;tier=integration'", equalTo(1))
+            .assertThat().body("'org.eclipse.microprofile.metrics.test.MetricAppBean2.meterMe2'.'count;tier=integration'", equalTo(1))
+            .assertThat().body("'timeMe2'.'count;tier=integration'", equalTo(1));
 
 
   }
@@ -135,9 +135,9 @@ public class ReusableMetricsTest {
     Header acceptJson = new Header("Accept", APPLICATION_JSON);
 
     given().header(acceptJson).get("/metrics/application").then()
-    .assertThat().body("'countMe2{tier=integration}'", equalTo(2))
-    .assertThat().body("'org.eclipse.microprofile.metrics.test.MetricAppBean2.meterMe2'.'count{tier=integration}'", equalTo(2))
-    .assertThat().body("timeMe2.'count{tier=integration}'", equalTo(2));
+    .assertThat().body("'countMe2;tier=integration'", equalTo(2))
+    .assertThat().body("'org.eclipse.microprofile.metrics.test.MetricAppBean2.meterMe2'.'count;tier=integration'", equalTo(2))
+    .assertThat().body("'timeMe2'.'count;tier=integration'", equalTo(2));
 
   }
 
@@ -156,9 +156,9 @@ public class ReusableMetricsTest {
     Header acceptJson = new Header("Accept", APPLICATION_JSON);
 
     given().header(acceptJson).get("/metrics/application").then()
-    .assertThat().body("reusableHisto.'count{tier=integration}'", equalTo(2))
-    .assertThat().body("reusableHisto.'min{tier=integration}'", equalTo(1))
-    .assertThat().body("reusableHisto.'max{tier=integration}'", equalTo(3));
+    .assertThat().body("'reusableHisto'.'count;tier=integration'", equalTo(2))
+    .assertThat().body("'reusableHisto'.'min;tier=integration'", equalTo(1))
+    .assertThat().body("'reusableHisto'.'max;tier=integration'", equalTo(3));
 
   }
 


### PR DESCRIPTION

- JSON format in GET requests append tags in
metricName;tag=value;tag=value format
- Metrics with sub-resources have the tags appended to the leaf element
(i.e metricName.subresource;tag=value)

Addresses Issue #331 

Signed-off-by: chdavid <chdavid@ca.ibm.com>