### PR TITLE
Modified TCK to satisfy metric name/type updates

### DIFF
--- a/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MpMetricTest.java
+++ b/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MpMetricTest.java
@@ -225,7 +225,7 @@ public class MpMetricTest {
         responseBuilder.setBody(filterOutAppLabelOpenMetrics(resp.getBody().asString()));
         resp = responseBuilder.build();
         resp.then().statusCode(200).and().contentType(TEXT_PLAIN).and()
-            .body(containsString("# TYPE base_thread_max_count_total"), containsString("base_thread_max_count_total{tier=\"integration\"}"));
+            .body(containsString("# TYPE base_thread_max_count"), containsString("base_thread_max_count{tier=\"integration\"}"));
     }
 
     @Test
@@ -282,8 +282,8 @@ public class MpMetricTest {
         responseBuilder.setBody(filterOutAppLabelOpenMetrics(resp.getBody().asString()));
         resp = responseBuilder.build();
         resp.then().statusCode(200).and()
-        .contentType(TEXT_PLAIN).and().body(containsString("# TYPE base_thread_max_count_total"),
-                containsString("base_thread_max_count_total{tier=\"integration\"}"));
+        .contentType(TEXT_PLAIN).and().body(containsString("# TYPE base_thread_max_count"),
+                containsString("base_thread_max_count{tier=\"integration\"}"));
     }
 
     @Test
@@ -436,7 +436,7 @@ public class MpMetricTest {
         Map<String, Object> elements = jsonPath.getMap(".");
         for (String name : elements.keySet()) {
             if (name.startsWith("gc.")) {
-                assertTrue(name.endsWith(".count") || name.endsWith(".time"));
+                assertTrue(name.endsWith(".total") || name.endsWith(".time"));
                 count++;
             }
         }
@@ -957,7 +957,7 @@ public class MpMetricTest {
     }
 
     /**
-     * Check that there is at least one metric named gc.count and that they all contain
+     * Check that there is at least one metric named gc.total and that they all contain
      * expected tags (actually this is just 'name' for now).
      */
     @Test
@@ -968,28 +968,28 @@ public class MpMetricTest {
         JsonPath jsonPath = given().header(wantJson).get("/metrics/base").jsonPath();
 
         Map<String, MiniMeta> baseNames = getExpectedMetadataFromXmlFile(MetricRegistry.Type.BASE);
-        MiniMeta gcCountMetricMeta = baseNames.get("gc.count");
+        MiniMeta gcCountMetricMeta = baseNames.get("gc.total");
         Set<String> expectedTags = gcCountMetricMeta.tags.keySet();
 
-        // obtain list of actual base metrics from the runtime and find all named gc.count
+        // obtain list of actual base metrics from the runtime and find all named gc.total
         Map<String, Object> elements = jsonPath.getMap(".");
         boolean found = false;
         for (Map.Entry<String, Object> metricEntry : elements.entrySet()) {
-            if(metricEntry.getKey().startsWith("gc.count")) {
-                // We found a metric named gc.count. Now check that it contains all expected tags
+            if(metricEntry.getKey().startsWith("gc.total")) {
+                // We found a metric named gc.total. Now check that it contains all expected tags
                 for(String expectedTag : expectedTags) {
                     assertThat("The metric should contain a " + expectedTag + " tag",
                         metricEntry.getKey(), containsString(expectedTag + "="));
                 }
                 // check that the metric has a reasonable value - it should at least be numeric and not negative
-                Assert.assertTrue("gc.count value should be numeric",
+                Assert.assertTrue("gc.total value should be numeric",
                     metricEntry.getValue() instanceof Number);
-                Assert.assertTrue("gc.count value should not be a negative number",
+                Assert.assertTrue("gc.total value should not be a negative number",
                     (Integer)metricEntry.getValue() >= 0);
                 found = true;
             }
         }
-        Assert.assertTrue("At least one metric named gc.count is expected", found);
+        Assert.assertTrue("At least one metric named gc.total is expected", found);
     }
 
     /**

--- a/tck/rest/src/main/resources/base_metrics.xml
+++ b/tck/rest/src/main/resources/base_metrics.xml
@@ -25,9 +25,9 @@
   <metric multi="false" name="memory.maxHeap" type="gauge" unit="bytes"/>
   <metric multi="false" name="memory.usedHeap" type="gauge" unit="bytes"/>
   <metric multi="false" name="memory.committedHeap" type="gauge" unit="bytes"/>
-  <metric multi="false" name="classloader.currentLoadedClass.count" type="gauge" unit="none"/>
-  <metric multi="false" name="classloader.loadedClass.total" type="counter" unit="none"/>
-  <metric multi="false" name="classloader.unloadedClass.total" type="counter" unit="none"/>
+  <metric multi="false" name="classloader.loadedClasses.count" type="gauge" unit="none"/>
+  <metric multi="false" name="classloader.loadedClasses.total" type="counter" unit="none"/>
+  <metric multi="false" name="classloader.unloadedClasses.total" type="counter" unit="none"/>
   <metric multi="false" name="cpu.availableProcessors" type="gauge" unit="none"/>
   <metric multi="false" name="jvm.uptime" type="gauge" unit="milliseconds"/>
   <metric multi="true" name="gc.total" type="counter" unit="none" tags="name=*"/>

--- a/tck/rest/src/main/resources/base_metrics.xml
+++ b/tck/rest/src/main/resources/base_metrics.xml
@@ -19,18 +19,18 @@
     SPDX-License-Identifier: Apache-2.0
 -->
 <config>
-  <metric multi="false" name="thread.count" type="counter" unit="none"/>
-  <metric multi="false" name="thread.max.count" type="counter" unit="none"/>
-  <metric multi="false" name="thread.daemon.count" type="counter" unit="none"/>
+  <metric multi="false" name="thread.count" type="gauge" unit="none"/>
+  <metric multi="false" name="thread.max.count" type="gauge" unit="none"/>
+  <metric multi="false" name="thread.daemon.count" type="gauge" unit="none"/>
   <metric multi="false" name="memory.maxHeap" type="gauge" unit="bytes"/>
   <metric multi="false" name="memory.usedHeap" type="gauge" unit="bytes"/>
   <metric multi="false" name="memory.committedHeap" type="gauge" unit="bytes"/>
-  <metric multi="false" name="classloader.currentLoadedClass.count" type="counter" unit="none"/>
-  <metric multi="false" name="classloader.totalLoadedClass.count" type="counter" unit="none"/>
-  <metric multi="false" name="classloader.totalUnloadedClass.count" type="counter" unit="none"/>
+  <metric multi="false" name="classloader.currentLoadedClass.count" type="gauge" unit="none"/>
+  <metric multi="false" name="classloader.loadedClass.total" type="counter" unit="none"/>
+  <metric multi="false" name="classloader.unloadedClass.total" type="counter" unit="none"/>
   <metric multi="false" name="cpu.availableProcessors" type="gauge" unit="none"/>
   <metric multi="false" name="jvm.uptime" type="gauge" unit="milliseconds"/>
-  <metric multi="true" name="gc.count" type="counter" unit="none" tags="name=*"/>
+  <metric multi="true" name="gc.total" type="counter" unit="none" tags="name=*"/>
   <metric multi="true" name="gc.time" type="gauge" unit="milliseconds" tags="name=*"/>
   <metric multi="false" name="optional.metric" type="histogram" unit="milliseconds" optional="true"/>
   <metric multi="false" name="cpu.systemLoadAverage" type="gauge" unit="none" optional="true"/>


### PR DESCRIPTION
As per April 23rd discussion

```
gc.%s.count                                 // .count -> .total
classloader.totalLoadedClass.count          // .count -> .total (loadedClasses.total)
classloader.totalUnloadedClass.count        // .count -> .total (unloadedClasses.total)

thread.count                                // Counter -> Gauge
thread.daemon.count                         // Counter -> Gauge
classloader.currentLoadedClass.count        // Counter -> Gauge

thread.max.count                            // Counter -> Gauge? (leave counters for use as accumulating counts)
```

Spec update followed up by @donbourne 

Signed-off-by: chdavid <chdavid@ca.ibm.com>