### PR TITLE
Modify TCK so that it will preprocess the "_app" tag out if it is present

### DIFF
--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/GlobalTagsTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/GlobalTagsTest.java
@@ -41,7 +41,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import javax.inject.Inject;
+
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -72,7 +75,10 @@ public class GlobalTagsTest {
     public void fromEnvVariable() {
         registry.counter("mycounter", new Tag("foo", "bar"));
         final MetricID actualMetricId = registry.getCounters().keySet().stream().filter(id -> id.getName().equals("mycounter")).findAny().get();
-        Assert.assertThat(actualMetricId.getTagsAsList(), containsInAnyOrder(
+        List<Tag> filterList = new ArrayList<Tag>(actualMetricId.getTagsAsList());
+        //Must filter out `_app` tags 
+        filterList.removeIf( tag -> tag.getTagName().equals("_app"));
+        Assert.assertThat(filterList, containsInAnyOrder(
             new Tag("foo", "bar"),
             new Tag("tier", "integration")
         ));

--- a/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/ReusableMetricsTest.java
+++ b/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/ReusableMetricsTest.java
@@ -55,8 +55,9 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class ReusableMetricsTest {
 
-  private static final String JSON_APP_LABEL_REGEX = "_app=[A-Za-z0-9]*;"; 
-    
+  private static final String JSON_APP_LABEL_REGEX = ";_app=[/A-Za-z0-9]+([;\\\"]?)"; 
+  private static final String JSON_APP_LABEL_REGEXS_SUB = "$1";   
+  
   private static final String APPLICATION_JSON = "application/json";
   private static final String DEFAULT_PROTOCOL = "http";
   private static final String DEFAULT_HOST = "localhost";
@@ -119,7 +120,7 @@ public class ReusableMetricsTest {
         Header acceptJson = new Header("Accept", APPLICATION_JSON);
         
         Response resp = given().header(acceptJson).get("/metrics/application");
-        JsonPath filteredJSONPath = new JsonPath(resp.jsonPath().prettify().replaceAll(JSON_APP_LABEL_REGEX, ""));
+        JsonPath filteredJSONPath = new JsonPath(resp.jsonPath().prettify().replaceAll(JSON_APP_LABEL_REGEX, JSON_APP_LABEL_REGEXS_SUB));
         ResponseBuilder responseBuilder = new ResponseBuilder();
         responseBuilder.clone(resp);
         responseBuilder.setBody(filteredJSONPath.prettify());
@@ -148,7 +149,7 @@ public class ReusableMetricsTest {
     Header acceptJson = new Header("Accept", APPLICATION_JSON);
 
     Response resp = given().header(acceptJson).get("/metrics/application");
-    JsonPath filteredJSONPath = new JsonPath(resp.jsonPath().prettify().replaceAll(JSON_APP_LABEL_REGEX, ""));
+    JsonPath filteredJSONPath = new JsonPath(resp.jsonPath().prettify().replaceAll(JSON_APP_LABEL_REGEX, JSON_APP_LABEL_REGEXS_SUB));
     ResponseBuilder responseBuilder = new ResponseBuilder();
     responseBuilder.clone(resp);
     responseBuilder.setBody(filteredJSONPath.prettify());
@@ -177,7 +178,7 @@ public class ReusableMetricsTest {
     Header acceptJson = new Header("Accept", APPLICATION_JSON);
 
     Response resp = given().header(acceptJson).get("/metrics/application");
-    JsonPath filteredJSONPath = new JsonPath(resp.jsonPath().prettify().replaceAll(JSON_APP_LABEL_REGEX, ""));
+    JsonPath filteredJSONPath = new JsonPath(resp.jsonPath().prettify().replaceAll(JSON_APP_LABEL_REGEX, JSON_APP_LABEL_REGEXS_SUB));
     ResponseBuilder responseBuilder = new ResponseBuilder();
     responseBuilder.clone(resp);
     responseBuilder.setBody(filteredJSONPath.prettify());

--- a/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/ReusableMetricsTest.java
+++ b/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/ReusableMetricsTest.java
@@ -28,9 +28,14 @@ import static org.hamcrest.Matchers.equalTo;
 import static com.jayway.restassured.RestAssured.given;
 
 import com.jayway.restassured.RestAssured;
+import com.jayway.restassured.builder.ResponseBuilder;
+import com.jayway.restassured.path.json.JsonPath;
 import com.jayway.restassured.response.Header;
+import com.jayway.restassured.response.Response;
+
 import java.net.MalformedURLException;
 import java.net.URL;
+
 import javax.inject.Inject;
 
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -50,6 +55,8 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class ReusableMetricsTest {
 
+  private static final String JSON_APP_LABEL_REGEX = "_app=[A-Za-z0-9]*;"; 
+    
   private static final String APPLICATION_JSON = "application/json";
   private static final String DEFAULT_PROTOCOL = "http";
   private static final String DEFAULT_HOST = "localhost";
@@ -86,7 +93,7 @@ public class ReusableMetricsTest {
         }
 
     }
-
+    
   @Deployment
   public static WebArchive createDeployment() {
       WebArchive jar = ShrinkWrap.create(WebArchive.class).addClass(MetricAppBean2.class)
@@ -103,19 +110,25 @@ public class ReusableMetricsTest {
     metricAppBean.meterMeA();
     metricAppBean.timeMeA();
   }
-
+  
   @Test
   @RunAsClient
   @InSequence(2)
-  public void testSharedCounter() {
+    public void testSharedCounter() {
 
-    Header acceptJson = new Header("Accept", APPLICATION_JSON);
-
-    given().header(acceptJson).get("/metrics/application").then()
-            .assertThat().body("'countMe2;tier=integration'", equalTo(1))
-            .assertThat().body("'org.eclipse.microprofile.metrics.test.MetricAppBean2.meterMe2'.'count;tier=integration'", equalTo(1))
-            .assertThat().body("'timeMe2'.'count;tier=integration'", equalTo(1));
-
+        Header acceptJson = new Header("Accept", APPLICATION_JSON);
+        
+        Response resp = given().header(acceptJson).get("/metrics/application");
+        JsonPath filteredJSONPath = new JsonPath(resp.jsonPath().prettify().replaceAll(JSON_APP_LABEL_REGEX, ""));
+        ResponseBuilder responseBuilder = new ResponseBuilder();
+        responseBuilder.clone(resp);
+        responseBuilder.setBody(filteredJSONPath.prettify());
+        resp = responseBuilder.build();
+        
+        resp.then()
+                .assertThat().body("'countMe2;tier=integration'", equalTo(1))
+                .assertThat().body("'org.eclipse.microprofile.metrics.test.MetricAppBean2.meterMe2'.'count;tier=integration'", equalTo(1))
+                .assertThat().body("'timeMe2'.'count;tier=integration'", equalTo(1));
 
   }
 
@@ -134,10 +147,18 @@ public class ReusableMetricsTest {
 
     Header acceptJson = new Header("Accept", APPLICATION_JSON);
 
-    given().header(acceptJson).get("/metrics/application").then()
+    Response resp = given().header(acceptJson).get("/metrics/application");
+    JsonPath filteredJSONPath = new JsonPath(resp.jsonPath().prettify().replaceAll(JSON_APP_LABEL_REGEX, ""));
+    ResponseBuilder responseBuilder = new ResponseBuilder();
+    responseBuilder.clone(resp);
+    responseBuilder.setBody(filteredJSONPath.prettify());
+    resp = responseBuilder.build();
+    
+    resp.then()
     .assertThat().body("'countMe2;tier=integration'", equalTo(2))
     .assertThat().body("'org.eclipse.microprofile.metrics.test.MetricAppBean2.meterMe2'.'count;tier=integration'", equalTo(2))
     .assertThat().body("'timeMe2'.'count;tier=integration'", equalTo(2));
+    
 
   }
 
@@ -155,7 +176,14 @@ public class ReusableMetricsTest {
 
     Header acceptJson = new Header("Accept", APPLICATION_JSON);
 
-    given().header(acceptJson).get("/metrics/application").then()
+    Response resp = given().header(acceptJson).get("/metrics/application");
+    JsonPath filteredJSONPath = new JsonPath(resp.jsonPath().prettify().replaceAll(JSON_APP_LABEL_REGEX, ""));
+    ResponseBuilder responseBuilder = new ResponseBuilder();
+    responseBuilder.clone(resp);
+    responseBuilder.setBody(filteredJSONPath.prettify());
+    resp = responseBuilder.build();
+    
+    resp.then()
     .assertThat().body("'reusableHisto'.'count;tier=integration'", equalTo(2))
     .assertThat().body("'reusableHisto'.'min;tier=integration'", equalTo(1))
     .assertThat().body("'reusableHisto'.'max;tier=integration'", equalTo(3));


### PR DESCRIPTION
For the vendors that might _always_ provide the `_app` tag via `mp.metric.appname` config. The TCK may fail for them.

This PR updates to the TCK tests so that it will _ignore_ the '_app' tag.

Excuse the copy and paste for each test :(
In a managed environment , it needs to run _as the client_ to resolve all the RestAssured and Hamcrest classes.

Sticking a `@RunAsClient` on a private method doesn't seem to work.

Signed-off-by: chdavid <chdavid@ca.ibm.com>