### PR TITLE
Move changelog to end of spec.

### DIFF
--- a/spec/src/main/asciidoc/changelog.adoc
+++ b/spec/src/main/asciidoc/changelog.adoc
@@ -19,7 +19,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-=== Major changes to previous versions
+== Major changes to previous versions
 
 Changes marked with icon:bolt[role="red"] are breaking changes relative to previous versions of the spec.
 
@@ -48,7 +48,7 @@ JSON format for OPTIONS requests have been modified such that the 'tags' attribu
 ** icon:bolt[role="red"] The default value of the `reusable` attribute for metric objects created programmatically (not via annotations) is now `true`
 ** icon:bolt[role="red"] Some base metrics' names have changed to follow the convention of ending the name of accumulating counters with `total`.
 ** icon:bolt[role="red"] Some base metrics' types have changed from Counter to Gauge since Counters must now count monotonically.
-** icon:bolt[role="red"] Some base metrics' names have changed because they now use tags to distinguish metrics for multiple JVM objects. For example, 
+** icon:bolt[role="red"] Some base metrics' names have changed because they now use tags to distinguish metrics for multiple JVM objects. For example,
 each existing garbage collector now has its own `gc.total` metric with the name of the garbage collector being in a tag. Names
 of some base metrics in the OpenMetrics output are also affected by the removal of conversion from camelCase to snake_case.
 ** Added a set of recommendations how application servers with multiple deployed applications should behave if they support MP Metrics.

--- a/spec/src/main/asciidoc/metrics_spec.adoc
+++ b/spec/src/main/asciidoc/metrics_spec.adoc
@@ -69,7 +69,6 @@ planning and pro-active discovery of issues (e.g. disk usage growing without bou
 Metrics can also help those scheduling systems decide when to scale the application
 to run on more or fewer machines.
 
-include::changelog.adoc[]
 
 include::architecture.adoc[]
 
@@ -80,3 +79,5 @@ include::required-metrics.adoc[]
 include::app-programming-model.adoc[]
 
 include::appendix.adoc[]
+
+include::changelog.adoc[]


### PR DESCRIPTION
Seems to be a new convention

Signed-off-by: Heiko W. Rupp <hrupp@redhat.com>