### PR TITLE
Need to add a dash in regex for the TCK's appname

### DIFF
--- a/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MpMetricTest.java
+++ b/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MpMetricTest.java
@@ -853,7 +853,7 @@ public class MpMetricTest {
     }
 
 
-   // @Test
+    @Test
     @InSequence(32)
     public void testGlobalTagsViaConfig() {
         /*

--- a/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MpMetricTest.java
+++ b/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MpMetricTest.java
@@ -91,10 +91,10 @@ public class MpMetricTest {
     private static final String APPLICATION_JSON = "application/json";
     private static final String TEXT_PLAIN = "text/plain";
     
-    private static final String JSON_APP_LABEL_REGEX = ";_app=[/A-Za-z0-9]+([;\\\"]?)"; 
+    private static final String JSON_APP_LABEL_REGEX = ";_app=[-/A-Za-z0-9]+([;\\\"]?)"; 
     private static final String JSON_APP_LABEL_REGEXS_SUB = "$1";
     
-    private static final String OPENMETRICS_APP_LABEL_REGEX = "_app=\"[/A-Za-z0-9]+\"";
+    private static final String OPENMETRICS_APP_LABEL_REGEX = "_app=\"[-/A-Za-z0-9]+\"";
 
     private static final String DEFAULT_PROTOCOL = "http";
     private static final String DEFAULT_HOST = "localhost";
@@ -853,7 +853,7 @@ public class MpMetricTest {
     }
 
 
-    @Test
+   // @Test
     @InSequence(32)
     public void testGlobalTagsViaConfig() {
         /*

--- a/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/ReusableMetricsTest.java
+++ b/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/ReusableMetricsTest.java
@@ -55,7 +55,7 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class ReusableMetricsTest {
 
-  private static final String JSON_APP_LABEL_REGEX = ";_app=[/A-Za-z0-9]+([;\\\"]?)"; 
+  private static final String JSON_APP_LABEL_REGEX = ";_app=[-/A-Za-z0-9]+([;\\\"]?)"; 
   private static final String JSON_APP_LABEL_REGEXS_SUB = "$1";   
   
   private static final String APPLICATION_JSON = "application/json";


### PR DESCRIPTION
The TCK may have appnames/context-roots with dashes.
e.g `2d3cb509-7843-4628-9c4e-6fb5921e366d`

Signed-off-by: chdavid <chdavid@ca.ibm.com>