### PR TITLE
Update rest-assured to 3.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,7 @@ target
 
 /.settings/
 /.project
-/.DS_Store
-/spec/.DS_Store
-/api/.DS_Store
+.DS_Store
 bumpVersion.sh
 tck/api/.classpath
 tck/api/.project

--- a/tck/rest/pom.xml
+++ b/tck/rest/pom.xml
@@ -30,7 +30,7 @@
 
     <properties>
         <!-- TODO should come from parent pom -->
-        <version.rest-assured>2.4.0</version.rest-assured>
+        <version.rest-assured>3.0.0</version.rest-assured>
         <version.junit>4.12</version.junit>
         <version.jackson>2.8.6</version.jackson>
 
@@ -53,8 +53,9 @@
 
     <dependencies>
 
+        <!-- https://mvnrepository.com/artifact/io.rest-assured/rest-assured -->
         <dependency>
-            <groupId>com.jayway.restassured</groupId>
+            <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <version>${version.rest-assured}</version>
             <scope>compile</scope>

--- a/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MpMetricTest.java
+++ b/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MpMetricTest.java
@@ -22,25 +22,20 @@
 
 package org.eclipse.microprofile.metrics.test;
 
-import static com.jayway.restassured.RestAssured.given;
-import static com.jayway.restassured.RestAssured.when;
-import static org.hamcrest.CoreMatchers.equalTo;
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.allOf;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
-import com.jayway.restassured.response.Header;
-import com.jayway.restassured.RestAssured;
-import com.jayway.restassured.builder.ResponseBuilder;
-import com.jayway.restassured.path.json.JsonPath;
-import com.jayway.restassured.response.Response;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
@@ -48,10 +43,10 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.Set;
-import java.util.TreeMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
@@ -77,6 +72,12 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
+
+import io.restassured.RestAssured;
+import io.restassured.builder.ResponseBuilder;
+import io.restassured.http.Header;
+import io.restassured.path.json.JsonPath;
+import io.restassured.response.Response;
 
 /**
  * Rest Test Kit

--- a/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/ReusableMetricsTest.java
+++ b/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/ReusableMetricsTest.java
@@ -24,14 +24,8 @@
 
 package org.eclipse.microprofile.metrics.test;
 
+import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
-import static com.jayway.restassured.RestAssured.given;
-
-import com.jayway.restassured.RestAssured;
-import com.jayway.restassured.builder.ResponseBuilder;
-import com.jayway.restassured.path.json.JsonPath;
-import com.jayway.restassured.response.Header;
-import com.jayway.restassured.response.Response;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -48,6 +42,12 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import io.restassured.RestAssured;
+import io.restassured.builder.ResponseBuilder;
+import io.restassured.http.Header;
+import io.restassured.path.json.JsonPath;
+import io.restassured.response.Response;
 
 /**
  * @author Heiko W. Rupp


### PR DESCRIPTION
Signed-off-by: Felix Wong <fmhwong@ca.ibm.com>

Fixes #391 

Version 3.0.0 of `io.rest-assured` has the `ClassCastException` fixed.