### PR TITLE
Clarify that gauges are numbers. Fixes #304

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/metrics/Gauge.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/Gauge.java
@@ -36,10 +36,10 @@ package org.eclipse.microprofile.metrics;
  * };
  * </code></pre>
  *
- * @param <T> the type of the metric's value
+ * @param <T> the type of the metric's value. Must be numeric.
  */
 @FunctionalInterface
-public interface Gauge<T> extends Metric {
+public interface Gauge<T extends Number> extends Metric {
     /**
      * Returns the metric's current value.
      *

--- a/api/src/main/java/org/eclipse/microprofile/metrics/annotation/Gauge.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/annotation/Gauge.java
@@ -55,6 +55,8 @@ import javax.interceptor.InterceptorBinding;
  * </code></pre>
  * A gauge with the fully qualified class name + {@code value} will be created which uses the
  * annotated field value as its value.
+ *
+ * The annotated method/field must be of a numeric type (extend {@link java.lang.Number}).
  */
 @InterceptorBinding
 @Retention(RetentionPolicy.RUNTIME)

--- a/spec/src/main/asciidoc/changelog.adoc
+++ b/spec/src/main/asciidoc/changelog.adoc
@@ -25,6 +25,7 @@ Changes marked with icon:bolt[role="red"] are breaking changes relative to previ
 
 * Changes in 2.1
 ** Clarified that metric registry implementations are required to be thread-safe.
+** Clarified in the API code that Gauges must return values that extend `java.lang.Number`.
 
 * Changes in 2.0
 ** icon:bolt[role="red"] Refactoring of Counters, as the old `@Counted` was misleading in practice.


### PR DESCRIPTION
#304 
While this is technically a breaking change, this only can break code that was using non-numeric gauges, which is something that would probably not work anyway for different reasons. So I think we could get this into 2.1.