### PR TITLE
Allow empty or omitted 'vendor' scope in JSON export. Fixes #264

### DIFF
--- a/spec/src/main/asciidoc/changelog.adoc
+++ b/spec/src/main/asciidoc/changelog.adoc
@@ -26,6 +26,7 @@ Changes marked with icon:bolt[role="red"] are breaking changes relative to previ
 * Changes in 2.1
 ** Clarified that metric registry implementations are required to be thread-safe.
 ** Clarified in the API code that Gauges must return values that extend `java.lang.Number`.
+** Clarified that implementations can, for JSON export of scopes containing no metrics, omit them, or that they can be present with an empty value. 
 
 * Changes in 2.0
 ** icon:bolt[role="red"] Refactoring of Counters, as the old `@Counted` was misleading in practice.

--- a/spec/src/main/asciidoc/rest-endpoints.adoc
+++ b/spec/src/main/asciidoc/rest-endpoints.adoc
@@ -117,6 +117,9 @@ In case `/metrics` is requested, then the data for the scopes are wrapped in the
 }
 ----
 
+If there is a scope that contains no metrics, then it can be either present with an empty object 
+as its value, or it can be omitted completely.
+                                        
 ==== Gauge JSON Format
 
 The value of the gauge must be equivalent to a call to the instance Gauge's `getValue()`.

--- a/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MpMetricTest.java
+++ b/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MpMetricTest.java
@@ -195,12 +195,6 @@ public class MpMetricTest {
           Map applicationData = (Map) response.get("application");
           assertThat(applicationData.size(), greaterThan(0));
         }
-
-        // There may be vendor metrics, so check if the key exists and bail if it has no data
-        if (response.containsKey("vendor")) {
-          Map vendorData = (Map) response.get("vendor");
-          assertThat(vendorData.size(), greaterThan(0));
-        }
     }
 
     @Test


### PR DESCRIPTION
https://github.com/eclipse/microprofile-metrics/issues/264