### PR TITLE
Move version to 2.0.2-SNAPSHOT

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -20,7 +20,7 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.metrics</groupId>
         <artifactId>microprofile-metrics-parent</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>microprofile-metrics-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <groupId>org.eclipse.microprofile.metrics</groupId>
     <artifactId>microprofile-metrics-parent</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.0.2-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>MicroProfile Metrics</name>
     <description>Eclipse MicroProfile Metrics Feature :: Parent POM</description>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -20,7 +20,7 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.metrics</groupId>
         <artifactId>microprofile-metrics-parent</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>microprofile-metrics-spec</artifactId>

--- a/tck/api/pom.xml
+++ b/tck/api/pom.xml
@@ -13,7 +13,7 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.metrics</groupId>
         <artifactId>microprofile-metrics-parent</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.0.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -79,7 +79,7 @@
                 <dependency>
                         <groupId>org.eclipse.microprofile.metrics</groupId>
                         <artifactId>microprofile-metrics-api</artifactId>
-                        <version>2.0.1-SNAPSHOT</version>
+                        <version>2.0.2-SNAPSHOT</version>
                         <scope>provided</scope>
                 </dependency>
                 <dependency>

--- a/tck/rest/pom.xml
+++ b/tck/rest/pom.xml
@@ -20,7 +20,7 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.metrics</groupId>
         <artifactId>microprofile-metrics-parent</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.0.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile.metrics</groupId>
             <artifactId>microprofile-metrics-api</artifactId>
-            <version>2.0.1-SNAPSHOT</version>
+            <version>2.0.2-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
Seems that after releasing 2.0.1 we didn't set the development version to `2.0.2-SNAPSHOT`