### PR TITLE
Rename some test methods where multiple methods with the same name ar…

### DIFF
--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/ConcurrentGaugedMethodBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/ConcurrentGaugedMethodBeanTest.java
@@ -118,7 +118,7 @@ public class ConcurrentGaugedMethodBeanTest {
 
     @Test
     @InSequence(2)
-    public void countedMethodNotCalledYet(@Metric(name = C_GAUGE_NAME, absolute = true) ConcurrentGauge instance) {
+    public void metricInjectionIntoTest(@Metric(name = C_GAUGE_NAME, absolute = true) ConcurrentGauge instance) {
         assertThat("Concurrent Gauges is not registered correctly", registry.getConcurrentGauges(), hasKey(cGaugeMID));
         ConcurrentGauge cGauge = registry.getConcurrentGauges().get(cGaugeMID);
 

--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CountedMethodBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/CountedMethodBeanTest.java
@@ -95,7 +95,7 @@ public class CountedMethodBeanTest {
 
     @Test
     @InSequence(2)
-    public void countedMethodNotCalledYet(@Metric(name = "countedMethod", absolute = true) Counter instance) {
+    public void metricInjectionIntoTest(@Metric(name = "countedMethod", absolute = true) Counter instance) {
         assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(counterMetricID));
         Counter counter = registry.getCounters().get(counterMetricID);
 


### PR DESCRIPTION
…e in one test case

Having multiple methods with the same name in one test case causes surefire reports to be confusing to read. And it doesn't bring any real value. So let's make sure we don't have any such methods in TCK test cases.