### PR TITLE
Upgraded TCK dependencies

### DIFF
--- a/tck/rest/pom.xml
+++ b/tck/rest/pom.xml
@@ -32,7 +32,8 @@
         <!-- TODO should come from parent pom -->
         <version.rest-assured>4.0.0</version.rest-assured>
         <version.junit>4.12</version.junit>
-        <version.jackson>2.8.6</version.jackson>
+        <version.jackson>2.9.9.1</version.jackson>
+        <version.shrinkwrap>2.2.4</version.shrinkwrap>
 
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -78,6 +79,7 @@
         <dependency>
             <groupId>org.jboss.shrinkwrap.resolver</groupId>
             <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+            <version>${version.shrinkwrap}</version>
             <scope>compile</scope>
         </dependency>
 

--- a/tck/rest/pom.xml
+++ b/tck/rest/pom.xml
@@ -81,6 +81,12 @@
             <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
             <version>${version.shrinkwrap}</version>
             <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jsoup</groupId>
+                    <artifactId>jsoup</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Upgrading to shrinkwrap 2.2.4 still pulls in org.jsoup:jsoup:1.7.2 as well as the latest shrinkwrap package set at 3.1.1
```
[INFO]
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ microprofile-metrics-rest-tck ---
[INFO] org.eclipse.microprofile.metrics:microprofile-metrics-rest-tck:jar:2.1-SNAPSHOT
[INFO] \- org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-impl-maven:jar:3.1.1:compile
[INFO]    \- org.apache.maven.wagon:wagon-http-lightweight:jar:2.12:compile
[INFO]       \- org.apache.maven.wagon:wagon-http-shared:jar:2.12:compile
[INFO]          \- org.jsoup:jsoup:jar:1.7.2:compile
```
```
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ microprofile-metrics-rest-tck ---
[INFO] org.eclipse.microprofile.metrics:microprofile-metrics-rest-tck:jar:2.1-SNAPSHOT
[INFO] \- org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-impl-maven:jar:2.2.4:compile
[INFO]    \- org.apache.maven.wagon:wagon-http-lightweight:jar:2.6:compile
[INFO]       \- org.apache.maven.wagon:wagon-http-shared:jar:2.6:compile
[INFO]          \- org.jsoup:jsoup:jar:1.7.2:compile
```

Will include the 2.2.4 upgrade for concurrency.
fixes #284 