### PR TITLE
[#439] Fix assertions in intermittently failing ConcurrentGaugedClass…

### DIFF
--- a/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/ConcurrentGaugedClassBeanTest.java
+++ b/tck/api/src/main/java/io/astefanutti/metrics/cdi/se/ConcurrentGaugedClassBeanTest.java
@@ -41,10 +41,13 @@ package io.astefanutti.metrics.cdi.se;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 import io.astefanutti.metrics.cdi.se.util.MetricsUtil;
+import java.util.Map;
 import java.util.Set;
+import java.util.SortedMap;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.metrics.MetricID;
@@ -102,14 +105,25 @@ public class ConcurrentGaugedClassBeanTest {
          */
         counterMIDs = MetricsUtil.createMetricIDs(C_GAUGED_NAMES);
     }
-    
+
     @Test
     @InSequence(1)
     public void countedMethodsNotCalledYet() {
-        assertThat("Counters are not registered correctly", registry.getConcurrentGauges().keySet(), is(equalTo(counterMIDs)));
-        // Make sure that the counters haven't been incremented
-        assertThat("Concurrent Gauges max values are incorrect", registry.getConcurrentGauges().values(),
-                   everyItem(Matchers.<ConcurrentGauge>hasProperty("max", equalTo(0L))));
+        final SortedMap<MetricID, ConcurrentGauge> concurrentGauges = registry.getConcurrentGauges();
+        assertThat("Concurrent Gauges are not registered correctly", concurrentGauges.keySet(), is(equalTo(counterMIDs)));
+
+
+        MetricID constructorMetricID = new MetricID(MetricsUtil.absoluteMetricName(ConcurrentGaugedClassBean.class, CONSTRUCTOR_NAME));
+        for (Map.Entry<MetricID, ConcurrentGauge> entry : concurrentGauges.entrySet()) {
+            // make sure the max values are zero, with the exception of the constructor, where it could potentially be 1
+            if(!entry.getKey().equals(constructorMetricID)) {
+                assertEquals("Max value of metric " + entry.getKey().toString() + " should be 0", 0, entry.getValue().getMax());
+            }
+            // make sure the min values are zero
+            assertEquals("Min value of metric " + entry.getKey().toString() + " should be 0", 0, entry.getValue().getMin());
+            // make sure the current counts are zero
+            assertEquals("Current count of metric " + entry.getKey().toString() + " should be 0", 0, entry.getValue().getCount());
+        }
     }
 
     @Test


### PR DESCRIPTION
…BeanTest

Backport of https://github.com/eclipse/microprofile-metrics/pull/440 to 2.0.x. WildFly will need this fixed in 2.0.3
@Channyboy please review/test