### PR TITLE
Introduce MetricType.fromClassName, plus reformat some classes. 

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/metrics/ConcurrentGauge.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/ConcurrentGauge.java
@@ -28,38 +28,44 @@ package org.eclipse.microprofile.metrics;
  *
  * @author hrupp
  * @since 2.0
- *
  */
 public interface ConcurrentGauge extends Metric {
 
-  /**
-   * Get the current value of the ConcurrentGauge
-   *
-   * @return the current value.
-   */
-  long getCount();
-  /**
-   * Get the maximum value of the ConcurrentGauge for the previously completed minute.
-   *
-   * This represents the highest number of concurrent
-   * invocations in the last complete minute.
-   *
-   * @return The maximum value in the previously completed minute.
-   */
-  long getMax();
-  /**
-   * Get the minimum value of the ConcurrentGauge for the previously completed minute.
-   *
-   * This represents the lowest number of concurrent
-   * invocations in the last complete minute.
-   *
-   * @return The minimum value in the previously completed minute.
-   */
-  long getMin();
+    /**
+     * Get the current value of the ConcurrentGauge
+     *
+     * @return the current value.
+     */
+    long getCount();
 
-  /** Increment the concurrent gauge's value by 1 */
-  void inc();
-  /** Decrement the concurrent gauge's value by 1 */
-  void dec();
+    /**
+     * Get the maximum value of the ConcurrentGauge for the previously completed minute.
+     * <p>
+     * This represents the highest number of concurrent
+     * invocations in the last complete minute.
+     *
+     * @return The maximum value in the previously completed minute.
+     */
+    long getMax();
+
+    /**
+     * Get the minimum value of the ConcurrentGauge for the previously completed minute.
+     * <p>
+     * This represents the lowest number of concurrent
+     * invocations in the last complete minute.
+     *
+     * @return The minimum value in the previously completed minute.
+     */
+    long getMin();
+
+    /**
+     * Increment the concurrent gauge's value by 1
+     */
+    void inc();
+
+    /**
+     * Decrement the concurrent gauge's value by 1
+     */
+    void dec();
 
 }

--- a/api/src/main/java/org/eclipse/microprofile/metrics/MetricType.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/MetricType.java
@@ -71,51 +71,69 @@ public enum MetricType {
     /**
      * Invalid - Placeholder
      */
-    INVALID("invalid", null)
-    ;
+    INVALID("invalid", null);
 
 
-  private String type;
-  private Class<?> classtype;
+    private String type;
+    private Class<?> classtype;
 
-  MetricType(String type, Class<?> classtype) {
-    this.type = type;
-    this.classtype = classtype;
-  }
+    MetricType(String type, Class<?> classtype) {
+        this.type = type;
+        this.classtype = classtype;
+    }
 
-  public String toString() {
-    return type;
-  }
+    public String toString() {
+        return type;
+    }
 
-  private static final EnumSet<MetricType> METRIC_TYPES = EnumSet.allOf(MetricType.class);
+    private static final EnumSet<MetricType> METRIC_TYPES = EnumSet.allOf(MetricType.class);
 
     /**
-   * Convert the string representation into an enum
-   * @param in the String representation
-   * @return the matching Enum
-   * @throws IllegalArgumentException if in is not a valid enum value
-   */
-  public static MetricType from(String in) {
-    for (MetricType u : METRIC_TYPES) {
-      if (u.type.equals(in)) {
-        return u;
-      }
+     * Convert the string representation into an enum
+     *
+     * @param in the String representation (NOT the class name but rather a string like "counter", "gauge",...)
+     * @return the matching Enum
+     * @throws IllegalArgumentException if in is not a valid enum value
+     */
+    public static MetricType from(String in) {
+        for (MetricType u : METRIC_TYPES) {
+            if (u.type.equals(in)) {
+                return u;
+            }
+        }
+        throw new IllegalArgumentException(in + " is not a valid MetricType");
     }
-    throw new IllegalArgumentException(in + " is not a valid MetricType");
-  }
 
-  /**
-   * Convert the metric Java class into a MetricType
-   * @param in The metric class
-   * @return the matching MetricType value
-   * @throws IllegalArgumentException if in is not a valid metric class
-   */
-  public static MetricType from(Class<?> in) {
-    for (MetricType u : METRIC_TYPES) {
-      if (u.classtype != null && u.classtype.isAssignableFrom(in)) {
-        return u;
-      }
+    /**
+     * Convert the metric Java class into a MetricType
+     *
+     * @param in The metric class
+     * @return the matching MetricType value
+     * @throws IllegalArgumentException if in is not a valid metric class
+     */
+    public static MetricType from(Class<?> in) {
+        for (MetricType u : METRIC_TYPES) {
+            if (u.classtype != null && u.classtype.isAssignableFrom(in)) {
+                return u;
+            }
+        }
+        throw new IllegalArgumentException(in + " is not a valid metric type");
     }
-    throw new IllegalArgumentException(in + " is not a valid metric type");
-  }
+
+    /**
+     * Convert the metric Java class name into a MetricType
+     *
+     * @param className The name of a metric class
+     * @return the matching MetricType value
+     * @throws IllegalArgumentException if className is not a valid metric class
+     */
+    public static MetricType fromClassName(String className) {
+        for (MetricType u : METRIC_TYPES) {
+            if (u.classtype != null && u.classtype.getName().equals(className)) {
+                return u;
+            }
+        }
+        throw new IllegalArgumentException(className + " is not a valid metric class");
+    }
+
 }

--- a/api/src/main/java/org/eclipse/microprofile/metrics/MetricUnits.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/MetricUnits.java
@@ -32,54 +32,56 @@ package org.eclipse.microprofile.metrics;
  * @author hrupp
  */
 public final class MetricUnits {
-  /** No unit */
-  public static final String NONE = "none";
 
-  /** Represents bits. Not defined by SI, but by IEC 60027 */
-  public static final String BITS = "bits";
-  /** 1000 {@link #BITS} */
-  public static final String KILOBITS = "kilobits";
-  /** 1000 {@link #KIBIBITS} */
-  public static final String MEGABITS = "megabits";
-  /** 1000 {@link #MEGABITS} */
-  public static final String GIGABITS = "gigabits";
-  /** 1024 {@link #BITS} */
-  public static final String KIBIBITS = "kibibits";
-  /** 1024 {@link #KIBIBITS}  */
-  public static final String MEBIBITS = "mebibits";
-  /** 1024 {@link #MEBIBITS} */
-  public static final String GIBIBITS = "gibibits";
+    /** No unit */
+    public static final String NONE = "none";
 
-  /** 8 {@link #BITS} */
-  public static final String BYTES = "bytes";
-  /** 1000 {@link #BYTES} */
-  public static final String KILOBYTES = "kilobytes";
-  /** 1000 {@link #KILOBYTES} */
-  public static final String MEGABYTES = "megabytes";
-  /** 1000 {@link #MEGABYTES} */
-  public static final String GIGABYTES = "gigabytes";
+    /** Represents bits. Not defined by SI, but by IEC 60027 */
+    public static final String BITS = "bits";
+    /** 1000 {@link #BITS} */
+    public static final String KILOBITS = "kilobits";
+    /** 1000 {@link #KIBIBITS} */
+    public static final String MEGABITS = "megabits";
+    /** 1000 {@link #MEGABITS} */
+    public static final String GIGABITS = "gigabits";
+    /** 1024 {@link #BITS} */
+    public static final String KIBIBITS = "kibibits";
+    /** 1024 {@link #KIBIBITS}  */
+    public static final String MEBIBITS = "mebibits";
+    /** 1024 {@link #MEBIBITS} */
+    public static final String GIBIBITS = "gibibits";
 
-  /** 1/1000 {@link #MICROSECONDS} */
-  public static final String NANOSECONDS = "nanoseconds";
-  /** 1/1000 {@link #MILLISECONDS} */
-  public static final String MICROSECONDS = "microseconds";
-  /** 1/1000 {@link #SECONDS} */
-  public static final String MILLISECONDS = "milliseconds";
-  /** Represents seconds */
-  public static final String SECONDS = "seconds";
-  /** 60 {@link #SECONDS} */
-  public static final String MINUTES = "minutes";
-  /** 60 {@link #MINUTES} */
-  public static final String HOURS = "hours";
-  /** 24 {@link #HOURS} */
-  public static final String DAYS = "days";
+    /** 8 {@link #BITS} */
+    public static final String BYTES = "bytes";
+    /** 1000 {@link #BYTES} */
+    public static final String KILOBYTES = "kilobytes";
+    /** 1000 {@link #KILOBYTES} */
+    public static final String MEGABYTES = "megabytes";
+    /** 1000 {@link #MEGABYTES} */
+    public static final String GIGABYTES = "gigabytes";
 
-  /** Represents percentage */
-  public static final String PERCENT = "percent";
-  
-  /** Represent per second  */
-  public static final String PER_SECOND = "per_second";
-  
-  
-  private MetricUnits() {}
+    /** 1/1000 {@link #MICROSECONDS} */
+    public static final String NANOSECONDS = "nanoseconds";
+    /** 1/1000 {@link #MILLISECONDS} */
+    public static final String MICROSECONDS = "microseconds";
+    /** 1/1000 {@link #SECONDS} */
+    public static final String MILLISECONDS = "milliseconds";
+    /** Represents seconds */
+    public static final String SECONDS = "seconds";
+    /** 60 {@link #SECONDS} */
+    public static final String MINUTES = "minutes";
+    /** 60 {@link #MINUTES} */
+    public static final String HOURS = "hours";
+    /** 24 {@link #HOURS} */
+    public static final String DAYS = "days";
+
+    /** Represents percentage */
+    public static final String PERCENT = "percent";
+
+    /** Represent per second  */
+    public static final String PER_SECOND = "per_second";
+
+
+    private MetricUnits() {}
+
 }

--- a/spec/src/main/asciidoc/changelog.adoc
+++ b/spec/src/main/asciidoc/changelog.adoc
@@ -27,6 +27,7 @@ Changes marked with icon:bolt[role="red"] are breaking changes relative to previ
 ** Added ProcessCpuTime as a new optional base metric.
 ** Added `withOptional*` methods to the `MetadataBuilder`, they don't fail when null values are passed to them
 ** Added the `MetricID.getTagsAsArray()` method to the API.
+** Added the method `MetricType.fromClassName`
 
 * Changes in 2.1
 ** (2.1.1) Added ProcessCpuTime as a new optional base metric.


### PR DESCRIPTION
#455 
While at this, I noticed some classes that use 2 spaces for indentation while most other classes use 4. So I reformatted them.