### PR TITLE
Update base_metrics.xml to include processCpuTime and processCpuLoad

### DIFF
--- a/spec/src/main/asciidoc/changelog.adoc
+++ b/spec/src/main/asciidoc/changelog.adoc
@@ -27,7 +27,7 @@ Changes marked with icon:bolt[role="red"] are breaking changes relative to previ
 ** Clarified that metric registry implementations are required to be thread-safe.
 
 * Changes in 2.0
-** Added ProcessCpuTime as a new optional base metric.
+** (2.0.3) Added ProcessCpuTime as a new optional base metric.
 ** icon:bolt[role="red"] Refactoring of Counters, as the old `@Counted` was misleading in practice.
 *** Counters via `@Counted` are now always monotonic, the `monotonic` attribute is gone.
 The `Counted` interface lost the `dec()` methods.

--- a/spec/src/main/asciidoc/changelog.adoc
+++ b/spec/src/main/asciidoc/changelog.adoc
@@ -27,6 +27,7 @@ Changes marked with icon:bolt[role="red"] are breaking changes relative to previ
 ** Clarified that metric registry implementations are required to be thread-safe.
 
 * Changes in 2.0
+** Added ProcessCpuTime as a new optional base metric.
 ** icon:bolt[role="red"] Refactoring of Counters, as the old `@Counted` was misleading in practice.
 *** Counters via `@Counted` are now always monotonic, the `monotonic` attribute is gone.
 The `Counted` interface lost the `dec()` methods.

--- a/spec/src/main/asciidoc/required-metrics.adoc
+++ b/spec/src/main/asciidoc/required-metrics.adoc
@@ -240,3 +240,14 @@ Vendors should either use other metrics that are close enough as substitute or n
 Note: This is a vendor specific attribute/operation that is not defined in java.lang
 |===
 
+*(Optional) ProcessCpuTime*
+[cols="1,4"]
+|===
+|Name| cpu.processCpuTime
+|DisplayName| Process CPU Time
+|Type| Gauge
+|Unit| Nanoseconds
+|Description| Displays the CPU time used by the process on which the Java virtual machine is running in nanoseconds.
+|MBean| java.lang:type=OperatingSystem (com.sun.management.UnixOperatingSystemMXBean for Oracle Java, similar one exists for IBM Java: com.ibm.lang.management.ExtendedOperatingSystem)
+Note: This is a vendor specific attribute/operation that is not defined in java.lang
+|===

--- a/tck/rest/src/main/resources/base_metrics.xml
+++ b/tck/rest/src/main/resources/base_metrics.xml
@@ -34,4 +34,6 @@
   <metric multi="true" name="gc.time" type="gauge" unit="milliseconds" tags="name=*"/>
   <metric multi="false" name="optional.metric" type="histogram" unit="milliseconds" optional="true"/>
   <metric multi="false" name="cpu.systemLoadAverage" type="gauge" unit="none" optional="true"/>
+  <metric multi="false" name="cpu.processCpuLoad" type="gauge" unit="percent" optional="true"/>
+  <metric multi="false" name="cpu.processCpuTime" type="gauge" unit="nanoseconds" optional="true"/>
 </config>


### PR DESCRIPTION
Backporting the fix for #454 to 2.0.x
Signed-off-by: Yushan Lin <yushan.lin@ibm.com>