### PR TITLE
Preparations for 2.2 release

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -20,7 +20,7 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.metrics</groupId>
         <artifactId>microprofile-metrics-parent</artifactId>
-        <version>2.1.0</version>
+        <version>2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>microprofile-metrics-api</artifactId>

--- a/api/src/main/java/org/eclipse/microprofile/metrics/Gauge.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/Gauge.java
@@ -36,10 +36,10 @@ package org.eclipse.microprofile.metrics;
  * };
  * </code></pre>
  *
- * @param <T> the type of the metric's value. Must be numeric.
+ * @param <T> the type of the metric's value
  */
 @FunctionalInterface
-public interface Gauge<T extends Number> extends Metric {
+public interface Gauge<T> extends Metric {
     /**
      * Returns the metric's current value.
      *

--- a/api/src/main/java/org/eclipse/microprofile/metrics/annotation/Gauge.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/annotation/Gauge.java
@@ -55,8 +55,6 @@ import javax.interceptor.InterceptorBinding;
  * </code></pre>
  * A gauge with the fully qualified class name + {@code value} will be created which uses the
  * annotated field value as its value.
- *
- * The annotated method/field must be of a numeric type (extend {@link java.lang.Number}).
  */
 @InterceptorBinding
 @Retention(RetentionPolicy.RUNTIME)

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <groupId>org.eclipse.microprofile.metrics</groupId>
     <artifactId>microprofile-metrics-parent</artifactId>
-    <version>2.1.0</version>
+    <version>2.2-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>MicroProfile Metrics</name>
     <description>Eclipse MicroProfile Metrics Feature :: Parent POM</description>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -20,7 +20,7 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.metrics</groupId>
         <artifactId>microprofile-metrics-parent</artifactId>
-        <version>2.1.0</version>
+        <version>2.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>microprofile-metrics-spec</artifactId>

--- a/spec/src/main/asciidoc/changelog.adoc
+++ b/spec/src/main/asciidoc/changelog.adoc
@@ -23,6 +23,9 @@
 
 Changes marked with icon:bolt[role="red"] are breaking changes relative to previous versions of the spec.
 
+* Changes in 2.2
+** Reverted a problematic change from 2.1 where Gauges were required to return subclasses of `java.lang.Number` 
+
 * Changes in 2.1
 ** Clarified that metric registry implementations are required to be thread-safe.
 ** Clarified in the API code that Gauges must return values that extend `java.lang.Number`.

--- a/spec/src/main/asciidoc/changelog.adoc
+++ b/spec/src/main/asciidoc/changelog.adoc
@@ -28,7 +28,7 @@ Changes marked with icon:bolt[role="red"] are breaking changes relative to previ
 
 * Changes in 2.1
 ** Clarified that metric registry implementations are required to be thread-safe.
-** Clarified in the API code that Gauges must return values that extend `java.lang.Number`.
+** Clarified in the API code that Gauges must return values that extend `java.lang.Number`. [NOTE: this caused issues with backward compatibility and was reverted in 2.2]
 ** Clarified that implementations can, for JSON export of scopes containing no metrics, omit them, or that they can be present with an empty value. 
 ** TCKs are updated to use RestAssured 4.0
 ** Added the `reusable(boolean)` method for MetadataBuilder 

--- a/tck/api/pom.xml
+++ b/tck/api/pom.xml
@@ -13,7 +13,7 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.metrics</groupId>
         <artifactId>microprofile-metrics-parent</artifactId>
-        <version>2.1.0</version>
+        <version>2.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -79,7 +79,7 @@
                 <dependency>
                         <groupId>org.eclipse.microprofile.metrics</groupId>
                         <artifactId>microprofile-metrics-api</artifactId>
-                        <version>2.1.0</version>
+                        <version>2.2-SNAPSHOT</version>
                         <scope>provided</scope>
                 </dependency>
                 <dependency>

--- a/tck/rest/pom.xml
+++ b/tck/rest/pom.xml
@@ -20,7 +20,7 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.metrics</groupId>
         <artifactId>microprofile-metrics-parent</artifactId>
-        <version>2.1.0</version>
+        <version>2.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile.metrics</groupId>
             <artifactId>microprofile-metrics-api</artifactId>
-            <version>2.1.0</version>
+            <version>2.2-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
2.2 release = 2.1.0 + revert of the problematic change with gauges
After we decide to indeed go this way and merge this, master will need to be updated to target 2.3-SNAPSHOT
This also fixes the problem that we had three numbers in 2.1.0 release version, so this turns it into 2.2 (two numbers)
Things that went into 2.1.x branch after the 2.1.0 release will later be copied over to 2.2.x branch and released as 2.2.1.
@donbourne @Emily-Jiang @OndroMih please have a look
