### PR TITLE
Update master to 2.3

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -20,7 +20,7 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.metrics</groupId>
         <artifactId>microprofile-metrics-parent</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>microprofile-metrics-api</artifactId>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -103,6 +103,24 @@
                     </archive>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>biz.aQute.bnd</groupId>
+                <artifactId>bnd-baseline-maven-plugin</artifactId>
+                <version>4.2.0</version>
+                <configuration>
+                    <base>
+                        <version>2.0.0</version>
+                    </base>
+                 </configuration>
+                <executions>
+                    <execution>
+                        <id>baseline</id>
+                        <goals>
+                            <goal>baseline</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -109,7 +109,7 @@
                 <version>4.2.0</version>
                 <configuration>
                     <base>
-                        <version>2.0.0</version>
+                        <version>2.2</version>
                     </base>
                  </configuration>
                 <executions>

--- a/api/src/main/java/org/eclipse/microprofile/metrics/Gauge.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/Gauge.java
@@ -36,10 +36,10 @@ package org.eclipse.microprofile.metrics;
  * };
  * </code></pre>
  *
- * @param <T> the type of the metric's value. Must be numeric.
+ * @param <T> the type of the metric's value
  */
 @FunctionalInterface
-public interface Gauge<T extends Number> extends Metric {
+public interface Gauge<T> extends Metric {
     /**
      * Returns the metric's current value.
      *

--- a/api/src/main/java/org/eclipse/microprofile/metrics/annotation/Gauge.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/annotation/Gauge.java
@@ -55,8 +55,6 @@ import javax.interceptor.InterceptorBinding;
  * </code></pre>
  * A gauge with the fully qualified class name + {@code value} will be created which uses the
  * annotated field value as its value.
- *
- * The annotated method/field must be of a numeric type (extend {@link java.lang.Number}).
  */
 @InterceptorBinding
 @Retention(RetentionPolicy.RUNTIME)

--- a/api/src/main/java/org/eclipse/microprofile/metrics/annotation/package-info.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/annotation/package-info.java
@@ -90,5 +90,5 @@
  * </pre>
  *
  */
-@org.osgi.annotation.versioning.Version("2.1")
+@org.osgi.annotation.versioning.Version("2.3")
 package org.eclipse.microprofile.metrics.annotation;

--- a/api/src/main/java/org/eclipse/microprofile/metrics/package-info.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/package-info.java
@@ -132,5 +132,5 @@
  * </code>
  * </pre>
  */
-@org.osgi.annotation.versioning.Version("2.1")
+@org.osgi.annotation.versioning.Version("2.3")
 package org.eclipse.microprofile.metrics;

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 
     <groupId>org.eclipse.microprofile.metrics</groupId>
     <artifactId>microprofile-metrics-parent</artifactId>
-    <version>2.2-SNAPSHOT</version>
+    <version>2.3-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>MicroProfile Metrics</name>
     <description>Eclipse MicroProfile Metrics Feature :: Parent POM</description>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -20,7 +20,7 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.metrics</groupId>
         <artifactId>microprofile-metrics-parent</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>microprofile-metrics-spec</artifactId>

--- a/spec/src/main/asciidoc/changelog.adoc
+++ b/spec/src/main/asciidoc/changelog.adoc
@@ -23,16 +23,19 @@
 
 Changes marked with icon:bolt[role="red"] are breaking changes relative to previous versions of the spec.
 
-* Changes in 2.2
+* Changes in 2.3
 ** Added ProcessCpuTime as a new optional base metric.
 ** Added `withOptional*` methods to the `MetadataBuilder`, they don't fail when null values are passed to them
 ** Added the `MetricID.getTagsAsArray()` method to the API.
 ** Added the method `MetricType.fromClassName`
 
+* Changes in 2.2
+** Reverted a problematic change from 2.1 where Gauges were required to return subclasses of `java.lang.Number` 
+
 * Changes in 2.1
 ** (2.1.1) Added ProcessCpuTime as a new optional base metric.
 ** Clarified that metric registry implementations are required to be thread-safe.
-** Clarified in the API code that Gauges must return values that extend `java.lang.Number`.
+** Clarified in the API code that Gauges must return values that extend `java.lang.Number`.  [NOTE: this caused issues with backward compatibility and was reverted in 2.2]
 ** Clarified that implementations can, for JSON export of scopes containing no metrics, omit them, or that they can be present with an empty value.
 ** Clarified that metrics should not be created for private methods when a class is annotated (the TCK asserted this in 2.0 anyway)
 ** TCKs are updated to use RestAssured 4.0

--- a/tck/api/pom.xml
+++ b/tck/api/pom.xml
@@ -13,7 +13,7 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.metrics</groupId>
         <artifactId>microprofile-metrics-parent</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -79,7 +79,7 @@
                 <dependency>
                         <groupId>org.eclipse.microprofile.metrics</groupId>
                         <artifactId>microprofile-metrics-api</artifactId>
-                        <version>2.2-SNAPSHOT</version>
+                        <version>2.3-SNAPSHOT</version>
                         <scope>provided</scope>
                 </dependency>
                 <dependency>

--- a/tck/rest/pom.xml
+++ b/tck/rest/pom.xml
@@ -20,7 +20,7 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.metrics</groupId>
         <artifactId>microprofile-metrics-parent</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.3-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile.metrics</groupId>
             <artifactId>microprofile-metrics-api</artifactId>
-            <version>2.2-SNAPSHOT</version>
+            <version>2.3-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
- update to `2.3-SNAPSHOT`
- enable baseline plugin, for now against 2.0
- revert the problematic change to gauges
- update version in `package-info.java` files

Don't merge until we actually release 2.2 from the contents of `2.2.x` branch