### PR TITLE
Address gpg signing failurs with jenkins build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -330,6 +330,12 @@
                                 <goals>
                                     <goal>sign</goal>
                                 </goals>
+                                <configuration>
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>


### PR DESCRIPTION
After infrastructure upgrades we're encountering jenkin build failures.
Due to :

```
[INFO] [INFO] --- maven-gpg-plugin:1.6:sign (sign-artifacts) @ microprofile-metrics-parent ---
[INFO] gpg: signing failed: Not a tty
[INFO] gpg: signing failed: Not a tty
[INFO] [INFO] -------------------------
```
See for example: https://ci.eclipse.org/microprofile/view/Release/job/MicroProfile%20Releases/283/console

The main microprofile umbrella project is able to pass their jenkins build by specying the pinentry mode to loopback
See:
https://github.com/eclipse/microprofile/blob/8228cb5e7430f44e6a58b569775a3316e4a5844f/pom.xml#L316-L321

Signed-off-by: David Chan <chdavid@ca.ibm.com>