### PR TITLE
Introduce optional base metrics from RESTful stats

### DIFF
--- a/spec/src/main/asciidoc/appendix.adoc
+++ b/spec/src/main/asciidoc/appendix.adoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2016-2018 Contributors to the Eclipse Foundation
+// Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
 //
 // See the NOTICE file(s) distributed with this work for additional
 // information regarding copyright ownership.

--- a/spec/src/main/asciidoc/architecture.adoc
+++ b/spec/src/main/asciidoc/architecture.adoc
@@ -57,15 +57,15 @@ Section <<required-metrics#required-metrics>> lists the required metrics. This l
 These are listed here as they are dependent on the underlying JVM and not the server and thus fit better in _base_ scope
 than the _vendor_ one.
 
+The optional REST metrics are listed as base metrics as they are expected to be portable between different implementations. If the implementation provides REST metrics, it is up to the implementation to decide how to enable the REST metrics.
+
 Required base metrics are exposed under `/metrics/base`.
 
 ===== Application metrics
 
 Application specific metrics can not be baked into the server as they are supposed to be provided by the
-application at runtime. Therefore a Java API is provided. Application specific metrics are supposed to be
-portable to other implementations of the MicroProfile. That means that an application written to this
-specification which exposes metrics, can expose the same metrics on a different compliant server
-without change.
+application at runtime. Therefore a Java API is provided.  Application specific metrics are supposed to be portable to other MicroProfile implementations. That means that an application written to this specification which exposes metrics,
+can expose the same metrics on a different compliant server without change.
 
 Details of this Java API are described in <<app-programming-model#app-programming-model>>.
 

--- a/spec/src/main/asciidoc/changelog.adoc
+++ b/spec/src/main/asciidoc/changelog.adoc
@@ -24,6 +24,8 @@
 Changes marked with icon:bolt[role="red"] are breaking changes relative to previous versions of the spec.
 
 * Changes in 2.3
+** Introduced a new base metric derived from RESTful stats into the base scope.
+*** `rest.request` : Tracks the total count of requests and total elapsed time spent at the REST endpoint
 ** Introduced the simple timer (`@SimplyTimed`) metric.
 ** The API code no longer requires a correctly configured MP Config implementation to be available at runtime, so it is possible to slim down deployments if MP Config is not necessary 
 ** The `shrinkwrap-resolver-impl-maven` dependency was removed from the REST TCK pom.xml because it is not needed for building the TCK. Implementations that need it for running the TCK should add it to their own build file.
@@ -32,6 +34,8 @@ Changes marked with icon:bolt[role="red"] are breaking changes relative to previ
 ** Added the `MetricID.getTagsAsArray()` method to the API.
 ** Added the method `MetricType.fromClassName`
 ** Improved TCK - Use WebArchive for deployment
+
+
 
 * Changes in 2.2
 ** Reverted a problematic change from 2.1 where Gauges were required to return subclasses of `java.lang.Number` 

--- a/spec/src/main/asciidoc/required-metrics.adoc
+++ b/spec/src/main/asciidoc/required-metrics.adoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2016-2019 Contributors to the Eclipse Foundation
+// Copyright (c) 2016, 2020 Contributors to the Eclipse Foundation
 //
 // See the NOTICE file(s) distributed with this work for additional
 // information regarding copyright ownership.
@@ -251,3 +251,58 @@ Note: This is a vendor specific attribute/operation that is not defined in java.
 |MBean| java.lang:type=OperatingSystem (com.sun.management.UnixOperatingSystemMXBean for Oracle Java, similar one exists for IBM Java: com.ibm.lang.management.ExtendedOperatingSystem)
 Note: This is a vendor specific attribute/operation that is not defined in java.lang
 |===
+
+
+=== (Optional) REST
+
+Metrics gathered from REST stats are optional and therefore may not be available in every implementation.
+
+The MicroProfile Metrics runtime will track metrics from RESTful resource method calls during runtime (i.e GET, POST, PUT, DELETE, OPTIONS, PATCH, HEAD). It is up to the implementation to decide how to enable the REST metrics.
+
+*(Optional) RESTRequests*
+[cols="1,4"]
+|===
+|Name| REST.request
+|DisplayName| Total Requests and Response Time
+|Type| SimpleTimer
+|Unit| None
+|Multi| true
+|Tags| {class=%s1,method=%s2}
+|Description| The number of invocations and total response time of this RESTful resource method since the start of the server.
+|Notes|The `%s1` should be substituted with the fully qualified name of the RESTful resource class. 
+
+The `%s2` should be substituted with the name of the RESTful resource method and appended with its parameter types using an underscore `\_`.  Multiple parameter types are appended one after another (e.g. `<methodName>_<paramType1>_<paramType2>`).
+
+Parameter type formatting rules: +
+- The paramter types are fully qualified (e.g. `java.lang.Object`). +
+- Array paramter types will be formatted as `paramType[]` (e.g `java.lang.Object[]`). +
+- A Vararg parameter will be treated as an array. +
+- Generics will be ignored. For example `List<String>` will be formatted as `java.util.List`.
+
+|===
+
+
+For example given the following RESTful resource:
+[source, java]
+----
+
+package org.eclipse.microprofile.metrics.demo;
+
+@ApplicationScoped
+public class RestDemo {
+
+  @POST
+  public void postMethod(String... s, Object o){
+      ...
+  }
+}
+----
+
+The OpenMetrics formatted rest metrics would be:
+[source]
+----
+# TYPE base_REST_request_total counter
+base_REST_request_total{class="org.eclipse.microprofile.metrics.demo.RestDemo",method="postMethod_java.lang.String[]_java.lang.Object"} 1
+# TYPE base_REST_request_elapsedTime_seconds gauge
+base_REST_request_elapsedTime_seconds{class="org.eclipse.microprofile.metrics.demo.RestDemo",method="postMethod_java.lang.String[]_java.lang.Object"} 1.000
+----


### PR DESCRIPTION
Current mpConfig key is `mp.metrics.enable.restful.stats`
or could use `mp.metrics.collect.restful.stats`?
or any other suggestions else?

Signed-off-by: David Chan <chdavid@ca.ibm.com>