### PR TITLE
Revert "Remove shrinkwrap-resolver-maven dependency from pom.xml. Fix…

### DIFF
--- a/spec/src/main/asciidoc/changelog.adoc
+++ b/spec/src/main/asciidoc/changelog.adoc
@@ -26,7 +26,6 @@ Changes marked with icon:bolt[role="red"] are breaking changes relative to previ
 * Changes in 2.3
 ** Introduced the simple timer (`@SimplyTimed`) metric.
 ** The API code no longer requires a correctly configured MP Config implementation to be available at runtime, so it is possible to slim down deployments if MP Config is not necessary 
-** The `shrinkwrap-resolver-impl-maven` dependency was removed from the REST TCK pom.xml because it is not needed for building the TCK. Implementations that need it for running the TCK should add it to their own build file.
 ** Added ProcessCpuTime as a new optional base metric.
 ** Added `withOptional*` methods to the `MetadataBuilder`, they don't fail when null values are passed to them
 ** Added the `MetricID.getTagsAsArray()` method to the API.

--- a/tck/rest/pom.xml
+++ b/tck/rest/pom.xml
@@ -33,6 +33,7 @@
         <version.rest-assured>4.0.0</version.rest-assured>
         <version.junit>4.12</version.junit>
         <version.jackson>2.9.9.1</version.jackson>
+        <version.shrinkwrap>2.2.4</version.shrinkwrap>
 
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
@@ -73,6 +74,19 @@
             <artifactId>jackson-databind</artifactId>
             <version>${version.jackson}</version>
             <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+            <version>${version.shrinkwrap}</version>
+            <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jsoup</groupId>
+                    <artifactId>jsoup</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
…es #448"

This reverts commit 5d49e1fea7210db13632dae19ebe33768f2f9c9b.

Removing `shrinkwrap-resolver-maven` had some unexpected consequences due to which our TCK stopped working when running against TCK versions that are not yet present in Maven Central. I think it will be safer to revert back to how it is in 2.2.x