### PR TITLE
MP Metrics TCK improvement - Use WebArchive for deployment

### DIFF
--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/MetricIDTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/MetricIDTest.java
@@ -51,7 +51,7 @@ public class MetricIDTest {
     @Deployment
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class)
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
     @Test

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/ConcurrentGaugeTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/ConcurrentGaugeTest.java
@@ -42,7 +42,7 @@ public class ConcurrentGaugeTest {
     @Deployment
     public static WebArchive createDeployment() {
         return ShrinkWrap.create(WebArchive.class)
-                .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
     @Inject


### PR DESCRIPTION
Replace calls to `addAsManifestResource` by `addAsWebInfResource` as
deployments are now WebArchives.

Signed-off-by: Jeff Mesnil <jmesnil@gmail.com>