### PR TITLE
MetricRegistry Key based Lookup

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/metrics/MetricRegistry.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/MetricRegistry.java
@@ -202,11 +202,7 @@ public interface MetricRegistry {
      * @param metricID the ID of the metric
      * @return a new or pre-existing {@link Counter}
      *
-<<<<<<< HEAD
-     * @since 2.4
-=======
      * @since 3.0
->>>>>>> Updates @since annotation for added methods from 2.4 to 3.0
      */
     Counter counter(MetricID metricID);
 
@@ -274,11 +270,7 @@ public interface MetricRegistry {
      * @param metricID the ID of the metric
      * @return a new or pre-existing {@link ConcurrentGauge}
      *
-<<<<<<< HEAD
-     * @since 2.4
-=======
      * @since 3.0
->>>>>>> Updates @since annotation for added methods from 2.4 to 3.0
      */
     ConcurrentGauge concurrentGauge(MetricID metricID);
 
@@ -316,17 +308,8 @@ public interface MetricRegistry {
     /**
      * Return the {@link Gauge} registered under the {@link MetricID} with this name and with no tags;
      * or create and register this gauge if none is registered.
-<<<<<<< HEAD
-<<<<<<< HEAD
      *
-     * If a {@link Histogram} was created, a {@link Metadata} object will be registered with the name
-=======
-     * 
-=======
-     *
->>>>>>> Updates @since annotation for added methods from 2.4 to 3.0
      * If a {@link Gauge} was created, a {@link Metadata} object will be registered with the name
->>>>>>> fixes checkstyle and javadoc warnings
      * and type. If a {@link Metadata} object is already registered with this metric name then that
      * {@link Metadata} will be used.
      *
@@ -334,11 +317,7 @@ public interface MetricRegistry {
      * @param gauge the {@link Gauge} to use if none is registered already
      * @return the pre-existing or provided {@link Gauge}
      *
-<<<<<<< HEAD
-     * @since 2.4
-=======
      * @since 3.0
->>>>>>> Updates @since annotation for added methods from 2.4 to 3.0
      */
     default Gauge<?> gauge(String name, Gauge<?> gauge) {
         return gauge(new MetricID(name), gauge);
@@ -347,17 +326,8 @@ public interface MetricRegistry {
     /**
      * Return the {@link Gauge} registered under the {@link MetricID} with this name and with the
      * provided {@link Tag}s; or create and register this gauge if none is registered.
-<<<<<<< HEAD
-<<<<<<< HEAD
      *
-     * If a {@link Histogram} was created, a {@link Metadata} object will be registered with the name
-=======
-     * 
-=======
-     *
->>>>>>> Updates @since annotation for added methods from 2.4 to 3.0
      * If a {@link Gauge} was created, a {@link Metadata} object will be registered with the name
->>>>>>> fixes checkstyle and javadoc warnings
      * and type. If a {@link Metadata} object is already registered with this metric name then that
      * {@link Metadata} will be used.
      *
@@ -365,11 +335,7 @@ public interface MetricRegistry {
      * @param gauge the {@link Gauge} to use if none is registered already
      * @return the pre-existing or provided {@link Gauge}
      *
-<<<<<<< HEAD
-     * @since 2.4
-=======
      * @since 3.0
->>>>>>> Updates @since annotation for added methods from 2.4 to 3.0
      */
     default Gauge<?> gauge(String name, Gauge<?> gauge, Tag...tags) {
         return gauge(new MetricID(name, tags), gauge);
@@ -378,17 +344,8 @@ public interface MetricRegistry {
     /**
      * Return the {@link Gauge} registered under the {@link MetricID}; or create and register this
      * gauge if none is registered.
-<<<<<<< HEAD
-<<<<<<< HEAD
      *
-     * If a {@link Histogram} was created, a {@link Metadata} object will be registered with the name
-=======
-     * 
-=======
-     *
->>>>>>> Updates @since annotation for added methods from 2.4 to 3.0
      * If a {@link Gauge} was created, a {@link Metadata} object will be registered with the name
->>>>>>> fixes checkstyle and javadoc warnings
      * and type. If a {@link Metadata} object is already registered with this metric name then that
      * {@link Metadata} will be used.
      *
@@ -396,11 +353,7 @@ public interface MetricRegistry {
      * @param gauge the {@link Gauge} to use if none is registered already
      * @return the pre-existing or provided {@link Gauge}
      *
-<<<<<<< HEAD
-     * @since 2.4
-=======
      * @since 3.0
->>>>>>> Updates @since annotation for added methods from 2.4 to 3.0
      */
     Gauge<?> gauge(MetricID metricID, Gauge<?> gauge);
 
@@ -448,11 +401,7 @@ public interface MetricRegistry {
      * @param metricID the ID of the metric
      * @return a new or pre-existing {@link Histogram}
      *
-<<<<<<< HEAD
-     * @since 2.4
-=======
      * @since 3.0
->>>>>>> Updates @since annotation for added methods from 2.4 to 3.0
      */
     Histogram histogram(MetricID metricID);
 
@@ -532,11 +481,7 @@ public interface MetricRegistry {
      * @param metricID the ID of the metric
      * @return a new or pre-existing {@link Meter}
      *
-<<<<<<< HEAD
-     * @since 2.4
-=======
      * @since 3.0
->>>>>>> Updates @since annotation for added methods from 2.4 to 3.0
      */
     Meter meter(MetricID metricID);
 
@@ -616,11 +561,7 @@ public interface MetricRegistry {
      * @param metricID the ID of the metric
      * @return a new or pre-existing {@link Timer}
      *
-<<<<<<< HEAD
-     * @since 2.4
-=======
      * @since 3.0
->>>>>>> Updates @since annotation for added methods from 2.4 to 3.0
      */
     Timer timer(MetricID metricID);
 
@@ -778,11 +719,7 @@ public interface MetricRegistry {
      * @return the {@link Counter} registered for the key or {@code null} if none has been registered so far
      * @throws IllegalArgumentException If the registered metric was not assignable to {@link Counter}
      *
-<<<<<<< HEAD
-     * @since 2.4
-=======
      * @since 3.0
->>>>>>> Updates @since annotation for added methods from 2.4 to 3.0
      */
     default Counter getCounter(MetricID metricID) {
         return getMetric(metricID, Counter.class);
@@ -795,11 +732,7 @@ public interface MetricRegistry {
      * @return the {@link ConcurrentGauge} registered for the key or {@code null} if none has been registered so far
      * @throws IllegalArgumentException If the registered metric was not assignable to {@link ConcurrentGauge}
      *
-<<<<<<< HEAD
-     * @since 2.4
-=======
      * @since 3.0
->>>>>>> Updates @since annotation for added methods from 2.4 to 3.0
      */
     default ConcurrentGauge getConcurrentGauge(MetricID metricID) {
         return getMetric(metricID, ConcurrentGauge.class);
@@ -812,11 +745,7 @@ public interface MetricRegistry {
      * @return the {@link  Gauge} registered for the key or {@code null} if none has been registered so far
      * @throws IllegalArgumentException If the registered metric was not assignable to {@link  Gauge}
      *
-<<<<<<< HEAD
-     * @since 2.4
-=======
      * @since 3.0
->>>>>>> Updates @since annotation for added methods from 2.4 to 3.0
      */
     default Gauge<?> getGauge(MetricID metricID) {
         return getMetric(metricID, Gauge.class);
@@ -829,11 +758,7 @@ public interface MetricRegistry {
      * @return the {@link Histogram} registered for the key or {@code null} if none has been registered so far
      * @throws IllegalArgumentException If the registered metric was not assignable to {@link Histogram}
      *
-<<<<<<< HEAD
-     * @since 2.4
-=======
      * @since 3.0
->>>>>>> Updates @since annotation for added methods from 2.4 to 3.0
      */
     default Histogram getHistogram(MetricID metricID) {
         return getMetric(metricID, Histogram.class);
@@ -846,11 +771,7 @@ public interface MetricRegistry {
      * @return the {@link  Meter} registered for the key or {@code null} if none has been registered so far
      * @throws IllegalArgumentException If the registered metric was not assignable to {@link  Meter}
      *
-<<<<<<< HEAD
-     * @since 2.4
-=======
      * @since 3.0
->>>>>>> Updates @since annotation for added methods from 2.4 to 3.0
      */
     default Meter getMeter(MetricID metricID) {
         return getMetric(metricID, Meter.class);
@@ -863,11 +784,7 @@ public interface MetricRegistry {
      * @return the {@link  Timer} registered for the key or {@code null} if none has been registered so far
      * @throws IllegalArgumentException If the registered metric was not assignable to {@link  Timer}
      *
-<<<<<<< HEAD
-     * @since 2.4
-=======
      * @since 3.0
->>>>>>> Updates @since annotation for added methods from 2.4 to 3.0
      */
     default Timer getTimer(MetricID metricID) {
         return getMetric(metricID, Timer.class);

--- a/api/src/main/java/org/eclipse/microprofile/metrics/MetricRegistry.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/MetricRegistry.java
@@ -199,7 +199,7 @@ public interface MetricRegistry {
      * and type. If a {@link Metadata} object is already registered with this metric name then that
      * {@link Metadata} will be used.
      *
-     * @param name the name of the metric
+     * @param metricID the ID of the metric
      * @return a new or pre-existing {@link Counter}
      *
      * @since 2.4
@@ -267,7 +267,7 @@ public interface MetricRegistry {
      * a new {@link ConcurrentGauge} if none is registered.
      * If a {@link ConcurrentGauge} was created, a {@link Metadata} object will be registered with the name and type.
      *
-     * @param name the name of the metric
+     * @param metricID the ID of the metric
      * @return a new or pre-existing {@link ConcurrentGauge}
      *
      * @since 2.4
@@ -308,8 +308,13 @@ public interface MetricRegistry {
     /**
      * Return the {@link Gauge} registered under the {@link MetricID} with this name and with no tags;
      * or create and register this gauge if none is registered.
+<<<<<<< HEAD
      *
      * If a {@link Histogram} was created, a {@link Metadata} object will be registered with the name
+=======
+     * 
+     * If a {@link Gauge} was created, a {@link Metadata} object will be registered with the name
+>>>>>>> fixes checkstyle and javadoc warnings
      * and type. If a {@link Metadata} object is already registered with this metric name then that
      * {@link Metadata} will be used.
      *
@@ -326,8 +331,13 @@ public interface MetricRegistry {
     /**
      * Return the {@link Gauge} registered under the {@link MetricID} with this name and with the
      * provided {@link Tag}s; or create and register this gauge if none is registered.
+<<<<<<< HEAD
      *
      * If a {@link Histogram} was created, a {@link Metadata} object will be registered with the name
+=======
+     * 
+     * If a {@link Gauge} was created, a {@link Metadata} object will be registered with the name
+>>>>>>> fixes checkstyle and javadoc warnings
      * and type. If a {@link Metadata} object is already registered with this metric name then that
      * {@link Metadata} will be used.
      *
@@ -344,12 +354,17 @@ public interface MetricRegistry {
     /**
      * Return the {@link Gauge} registered under the {@link MetricID}; or create and register this
      * gauge if none is registered.
+<<<<<<< HEAD
      *
      * If a {@link Histogram} was created, a {@link Metadata} object will be registered with the name
+=======
+     * 
+     * If a {@link Gauge} was created, a {@link Metadata} object will be registered with the name
+>>>>>>> fixes checkstyle and javadoc warnings
      * and type. If a {@link Metadata} object is already registered with this metric name then that
      * {@link Metadata} will be used.
      *
-     * @param name the name of the metric
+     * @param metricID the ID of the metric
      * @param gauge the {@link Gauge} to use if none is registered already
      * @return the pre-existing or provided {@link Gauge}
      *
@@ -398,7 +413,7 @@ public interface MetricRegistry {
      * and type. If a {@link Metadata} object is already registered with this metric name then that
      * {@link Metadata} will be used.
      *
-     * @param name the name of the metric
+     * @param metricID the ID of the metric
      * @return a new or pre-existing {@link Histogram}
      *
      * @since 2.4
@@ -478,7 +493,7 @@ public interface MetricRegistry {
      * and type. If a {@link Metadata} object is already registered with this metric name then that
      * {@link Metadata} will be used.
      *
-     * @param name the name of the metric
+     * @param metricID the ID of the metric
      * @return a new or pre-existing {@link Meter}
      *
      * @since 2.4
@@ -558,7 +573,7 @@ public interface MetricRegistry {
      * and type. If a {@link Metadata} object is already registered with this metric name then that
      * {@link Metadata} will be used.
      *
-     * @param name the name of the metric
+     * @param metricID the ID of the metric
      * @return a new or pre-existing {@link Timer}
      *
      * @since 2.4
@@ -640,7 +655,7 @@ public interface MetricRegistry {
      * and type. If a {@link Metadata} object is already registered with this metric name then that
      * {@link Metadata} will be used.
      *
-     * @param name the name of the metric
+     * @param metricID the ID of the metric
      * @return a new or pre-existing {@link SimpleTimer}
      *
      * @since 2.4
@@ -706,7 +721,8 @@ public interface MetricRegistry {
     default <T extends Metric> T getMetric(MetricID metricID, Class<T> asType) {
         try {
             return asType.cast(getMetric(metricID));
-        } catch (ClassCastException e) {
+        }
+        catch (ClassCastException e) {
             throw new IllegalArgumentException(metricID + " was not of expected type " + asType, e);
         }
     }

--- a/api/src/main/java/org/eclipse/microprofile/metrics/MetricRegistry.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/MetricRegistry.java
@@ -202,7 +202,11 @@ public interface MetricRegistry {
      * @param metricID the ID of the metric
      * @return a new or pre-existing {@link Counter}
      *
+<<<<<<< HEAD
      * @since 2.4
+=======
+     * @since 3.0
+>>>>>>> Updates @since annotation for added methods from 2.4 to 3.0
      */
     Counter counter(MetricID metricID);
 
@@ -270,7 +274,11 @@ public interface MetricRegistry {
      * @param metricID the ID of the metric
      * @return a new or pre-existing {@link ConcurrentGauge}
      *
+<<<<<<< HEAD
      * @since 2.4
+=======
+     * @since 3.0
+>>>>>>> Updates @since annotation for added methods from 2.4 to 3.0
      */
     ConcurrentGauge concurrentGauge(MetricID metricID);
 
@@ -309,10 +317,14 @@ public interface MetricRegistry {
      * Return the {@link Gauge} registered under the {@link MetricID} with this name and with no tags;
      * or create and register this gauge if none is registered.
 <<<<<<< HEAD
+<<<<<<< HEAD
      *
      * If a {@link Histogram} was created, a {@link Metadata} object will be registered with the name
 =======
      * 
+=======
+     *
+>>>>>>> Updates @since annotation for added methods from 2.4 to 3.0
      * If a {@link Gauge} was created, a {@link Metadata} object will be registered with the name
 >>>>>>> fixes checkstyle and javadoc warnings
      * and type. If a {@link Metadata} object is already registered with this metric name then that
@@ -322,7 +334,11 @@ public interface MetricRegistry {
      * @param gauge the {@link Gauge} to use if none is registered already
      * @return the pre-existing or provided {@link Gauge}
      *
+<<<<<<< HEAD
      * @since 2.4
+=======
+     * @since 3.0
+>>>>>>> Updates @since annotation for added methods from 2.4 to 3.0
      */
     default Gauge<?> gauge(String name, Gauge<?> gauge) {
         return gauge(new MetricID(name), gauge);
@@ -332,10 +348,14 @@ public interface MetricRegistry {
      * Return the {@link Gauge} registered under the {@link MetricID} with this name and with the
      * provided {@link Tag}s; or create and register this gauge if none is registered.
 <<<<<<< HEAD
+<<<<<<< HEAD
      *
      * If a {@link Histogram} was created, a {@link Metadata} object will be registered with the name
 =======
      * 
+=======
+     *
+>>>>>>> Updates @since annotation for added methods from 2.4 to 3.0
      * If a {@link Gauge} was created, a {@link Metadata} object will be registered with the name
 >>>>>>> fixes checkstyle and javadoc warnings
      * and type. If a {@link Metadata} object is already registered with this metric name then that
@@ -345,7 +365,11 @@ public interface MetricRegistry {
      * @param gauge the {@link Gauge} to use if none is registered already
      * @return the pre-existing or provided {@link Gauge}
      *
+<<<<<<< HEAD
      * @since 2.4
+=======
+     * @since 3.0
+>>>>>>> Updates @since annotation for added methods from 2.4 to 3.0
      */
     default Gauge<?> gauge(String name, Gauge<?> gauge, Tag...tags) {
         return gauge(new MetricID(name, tags), gauge);
@@ -355,10 +379,14 @@ public interface MetricRegistry {
      * Return the {@link Gauge} registered under the {@link MetricID}; or create and register this
      * gauge if none is registered.
 <<<<<<< HEAD
+<<<<<<< HEAD
      *
      * If a {@link Histogram} was created, a {@link Metadata} object will be registered with the name
 =======
      * 
+=======
+     *
+>>>>>>> Updates @since annotation for added methods from 2.4 to 3.0
      * If a {@link Gauge} was created, a {@link Metadata} object will be registered with the name
 >>>>>>> fixes checkstyle and javadoc warnings
      * and type. If a {@link Metadata} object is already registered with this metric name then that
@@ -368,7 +396,11 @@ public interface MetricRegistry {
      * @param gauge the {@link Gauge} to use if none is registered already
      * @return the pre-existing or provided {@link Gauge}
      *
+<<<<<<< HEAD
      * @since 2.4
+=======
+     * @since 3.0
+>>>>>>> Updates @since annotation for added methods from 2.4 to 3.0
      */
     Gauge<?> gauge(MetricID metricID, Gauge<?> gauge);
 
@@ -416,7 +448,11 @@ public interface MetricRegistry {
      * @param metricID the ID of the metric
      * @return a new or pre-existing {@link Histogram}
      *
+<<<<<<< HEAD
      * @since 2.4
+=======
+     * @since 3.0
+>>>>>>> Updates @since annotation for added methods from 2.4 to 3.0
      */
     Histogram histogram(MetricID metricID);
 
@@ -496,7 +532,11 @@ public interface MetricRegistry {
      * @param metricID the ID of the metric
      * @return a new or pre-existing {@link Meter}
      *
+<<<<<<< HEAD
      * @since 2.4
+=======
+     * @since 3.0
+>>>>>>> Updates @since annotation for added methods from 2.4 to 3.0
      */
     Meter meter(MetricID metricID);
 
@@ -576,7 +616,11 @@ public interface MetricRegistry {
      * @param metricID the ID of the metric
      * @return a new or pre-existing {@link Timer}
      *
+<<<<<<< HEAD
      * @since 2.4
+=======
+     * @since 3.0
+>>>>>>> Updates @since annotation for added methods from 2.4 to 3.0
      */
     Timer timer(MetricID metricID);
 
@@ -658,7 +702,7 @@ public interface MetricRegistry {
      * @param metricID the ID of the metric
      * @return a new or pre-existing {@link SimpleTimer}
      *
-     * @since 2.4
+     * @since 3.0
      */
     SimpleTimer simpleTimer(MetricID metricID);
 
@@ -702,7 +746,7 @@ public interface MetricRegistry {
      * @return the {@link Metric} registered for the provided {@link MetricID}
      *         or {@code null} if none has been registered so far
      *
-     * @since 2.4
+     * @since 3.0
      */
     Metric getMetric(MetricID metricID);
 
@@ -716,7 +760,7 @@ public interface MetricRegistry {
      *         or {@code null} if none has been registered so far
      * @throws IllegalArgumentException If the registered metric was not assignable to the provided type
      *
-     * @since 2.4
+     * @since 3.0
      */
     default <T extends Metric> T getMetric(MetricID metricID, Class<T> asType) {
         try {
@@ -734,7 +778,11 @@ public interface MetricRegistry {
      * @return the {@link Counter} registered for the key or {@code null} if none has been registered so far
      * @throws IllegalArgumentException If the registered metric was not assignable to {@link Counter}
      *
+<<<<<<< HEAD
      * @since 2.4
+=======
+     * @since 3.0
+>>>>>>> Updates @since annotation for added methods from 2.4 to 3.0
      */
     default Counter getCounter(MetricID metricID) {
         return getMetric(metricID, Counter.class);
@@ -747,7 +795,11 @@ public interface MetricRegistry {
      * @return the {@link ConcurrentGauge} registered for the key or {@code null} if none has been registered so far
      * @throws IllegalArgumentException If the registered metric was not assignable to {@link ConcurrentGauge}
      *
+<<<<<<< HEAD
      * @since 2.4
+=======
+     * @since 3.0
+>>>>>>> Updates @since annotation for added methods from 2.4 to 3.0
      */
     default ConcurrentGauge getConcurrentGauge(MetricID metricID) {
         return getMetric(metricID, ConcurrentGauge.class);
@@ -760,7 +812,11 @@ public interface MetricRegistry {
      * @return the {@link  Gauge} registered for the key or {@code null} if none has been registered so far
      * @throws IllegalArgumentException If the registered metric was not assignable to {@link  Gauge}
      *
+<<<<<<< HEAD
      * @since 2.4
+=======
+     * @since 3.0
+>>>>>>> Updates @since annotation for added methods from 2.4 to 3.0
      */
     default Gauge<?> getGauge(MetricID metricID) {
         return getMetric(metricID, Gauge.class);
@@ -773,7 +829,11 @@ public interface MetricRegistry {
      * @return the {@link Histogram} registered for the key or {@code null} if none has been registered so far
      * @throws IllegalArgumentException If the registered metric was not assignable to {@link Histogram}
      *
+<<<<<<< HEAD
      * @since 2.4
+=======
+     * @since 3.0
+>>>>>>> Updates @since annotation for added methods from 2.4 to 3.0
      */
     default Histogram getHistogram(MetricID metricID) {
         return getMetric(metricID, Histogram.class);
@@ -786,7 +846,11 @@ public interface MetricRegistry {
      * @return the {@link  Meter} registered for the key or {@code null} if none has been registered so far
      * @throws IllegalArgumentException If the registered metric was not assignable to {@link  Meter}
      *
+<<<<<<< HEAD
      * @since 2.4
+=======
+     * @since 3.0
+>>>>>>> Updates @since annotation for added methods from 2.4 to 3.0
      */
     default Meter getMeter(MetricID metricID) {
         return getMetric(metricID, Meter.class);
@@ -799,7 +863,11 @@ public interface MetricRegistry {
      * @return the {@link  Timer} registered for the key or {@code null} if none has been registered so far
      * @throws IllegalArgumentException If the registered metric was not assignable to {@link  Timer}
      *
+<<<<<<< HEAD
      * @since 2.4
+=======
+     * @since 3.0
+>>>>>>> Updates @since annotation for added methods from 2.4 to 3.0
      */
     default Timer getTimer(MetricID metricID) {
         return getMetric(metricID, Timer.class);
@@ -812,7 +880,7 @@ public interface MetricRegistry {
      * @return the {@link  SimpleTimer} registered for the key or {@code null} if none has been registered so far
      * @throws IllegalArgumentException If the registered metric was not assignable to {@link  SimpleTimer}
      *
-     * @since 2.4
+     * @since 3.0
      */
     default SimpleTimer getSimpleTimer(MetricID metricID) {
         return getMetric(metricID, SimpleTimer.class);
@@ -824,7 +892,7 @@ public interface MetricRegistry {
      * @param name the name of the metric
      * @return the {@link Metadata} for the provided name of {@code null} if none has been registered for that name
      *
-     * @since 2.4
+     * @since 3.0
      */
     Metadata getMetadata(String name);
 
@@ -995,7 +1063,7 @@ public interface MetricRegistry {
      * @param filter the metric filter to match
      * @return all the metrics in the registry
      *
-     * @since 2.4
+     * @since 3.0
      */
     SortedMap<MetricID, Metric> getMetrics(MetricFilter filter);
 
@@ -1007,7 +1075,7 @@ public interface MetricRegistry {
      *
      * @return all the metrics in the registry
      *
-     * @since 2.4
+     * @since 3.0
      */
     @SuppressWarnings("unchecked")
     default <T extends Metric> SortedMap<MetricID, T> getMetrics(Class<T> ofType, MetricFilter filter) {

--- a/spec/src/main/asciidoc/changelog.adoc
+++ b/spec/src/main/asciidoc/changelog.adoc
@@ -28,7 +28,31 @@ Changes marked with icon:bolt[role="red"] are breaking changes relative to previ
 == Changes in 3.0
 
 === API/SPI Changes
+** `MetricRegistry` changed from `abstract class` to `interface` with some existing methods now implemented as `default` methods
 ** Added the `MetricRegistry.getType()` method
+** Added the `MetricRegistry.counter(MetricID)` method
+** Added the `MetricRegistry.concurrentGauge(MetricID)` method
+** Added the `MetricRegistry.gauge(MetricID, Gauge)` method
+** Added the `MetricRegistry.gauge(String, Gauge)` method
+** Added the `MetricRegistry.gauge(String, Gauge, Tag[])` method
+** Added the `MetricRegistry.histogram(MetricID)` method
+** Added the `MetricRegistry.meter(MetricID)` method
+** Added the `MetricRegistry.timer(MetricID)` method
+** Added the `MetricRegistry.simpleTimer(MetricID)` method
+** Added the `MetricRegistry.getMetric(MetricID)` method
+** Added the `MetricRegistry.getMetric(MetricID metricID, Class)` method
+** Added the `MetricRegistry.getCounter(MetricID)` method
+** Added the `MetricRegistry.getConcurrentGauge(MetricID)` method
+** Added the `MetricRegistry.getGauge(MetricID)` method
+** Added the `MetricRegistry.getHistogram(MetricID)` method
+** Added the `MetricRegistry.getMeter(MetricID)` method
+** Added the `MetricRegistry.getTimer(MetricID)` method
+** Added the `MetricRegistry.getSimpleTimer(MetricID)` method
+** Added the `MetricRegistry.getMetadata(String)` method
+** Added the `MetricRegistry.getMetrics(MetricFilter)` method
+** Added the `MetricRegistry.getMetrics(Class, MetricFilter)` method
+** `MetricRegistry.getMetrics()` is now deprecated
+** `MetricRegistry.getMetadata()` is now deprecated
 ** Added `SimpleTimer.getMaxTimeDuration()` and `SimpleTimer.getMaxTimeDuration()` methods which return a `java.time.Duration` object (https://github.com/eclipse/microprofile-metrics/issues/523[#523])
 ** Timer class updated  (https://github.com/eclipse/microprofile-metrics/issues/524[#524])
 *** Changed `Timer.update(long duration, java.util.concurrent.TimeUnit)` to `Timer.update(java.time.Duration duration)`
@@ -40,6 +64,9 @@ Changes marked with icon:bolt[role="red"] are breaking changes relative to previ
 
 === Specification Changes
 ** Clarified how the implementation must handle metrics applied via CDI stereotypes
+
+=== TCK enhancement
+** Improved TCK - Use newly introduced `MetricRegistry` methods to retrieve single metrics and avoid now deprecated methods `getMetrics()` and `getMetadata()`
 
 [[release_notes_2_3]]
 == Changes in 2.3
@@ -110,7 +137,7 @@ A full list of changes may be found on the link:https://github.com/eclipse/micro
 ** TCKs are updated to use RestAssured 4.0
 
 === Miscellaneous
-** Explicitly excluded the transitive dependency on `javax.el-api` from the build of the specification. It wasn't actually used anywhere in the build so there should be no impact. 
+** Explicitly excluded the transitive dependency on `javax.el-api` from the build of the specification. It wasn't actually used anywhere in the build so there should be no impact.
 Implementations can still support the Expression Language if they choose to. (https://github.com/eclipse/microprofile-metrics/issues/417[#417])
 
 [[release_notes_2_0]]
@@ -149,7 +176,7 @@ JSON format for OPTIONS requests have been modified such that the 'tags' attribu
 ** icon:bolt[role="red"] Some base metrics' names have changed to follow the convention of ending the name of accumulating counters with `total`. (https://github.com/eclipse/microprofile-metrics/issues/375[#375])
 ** icon:bolt[role="red"] Some base metrics' types have changed from Counter to Gauge since Counters must now count monotonically. (https://github.com/eclipse/microprofile-metrics/issues/375[#375])
 ** icon:bolt[role="red"] Some base metrics' names have changed because they now use tags to distinguish metrics for multiple JVM objects. For example,
-each existing garbage collector now has its own `gc.total` metric with the name of the garbage collector being in a tag. Names 
+each existing garbage collector now has its own `gc.total` metric with the name of the garbage collector being in a tag. Names
 of some base metrics in the OpenMetrics output are also affected by the removal of conversion from camelCase to snake_case. (https://github.com/eclipse/microprofile-metrics/issues/375[#375])
 
 === Specification Changes
@@ -171,7 +198,7 @@ The `Counted` interface lost the `dec()` methods.
 ** icon:bolt[role="red"] Some base metrics' names have changed to follow the convention of ending the name of accumulating counters with `total`. (https://github.com/eclipse/microprofile-metrics/issues/375[#375])
 ** icon:bolt[role="red"] Some base metrics' types have changed from Counter to Gauge since Counters must now count monotonically. (https://github.com/eclipse/microprofile-metrics/issues/375[#375])
 ** icon:bolt[role="red"] Some base metrics' names have changed because they now use tags to distinguish metrics for multiple JVM objects. For example,
-each existing garbage collector now has its own `gc.total` metric with the name of the garbage collector being in a tag. Names 
+each existing garbage collector now has its own `gc.total` metric with the name of the garbage collector being in a tag. Names
 of some base metrics in the OpenMetrics output are also affected by the removal of conversion from camelCase to snake_case. (https://github.com/eclipse/microprofile-metrics/issues/375[#375])
 ** Added a set of recommendations how application servers with multiple deployed applications should behave if they support MP Metrics. (https://github.com/eclipse/microprofile-metrics/issues/240[#240])
 

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/MetricIDTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/MetricIDTest.java
@@ -23,8 +23,8 @@
 package org.eclipse.microprofile.metrics.tck;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 import javax.inject.Inject;
@@ -73,19 +73,19 @@ public class MetricIDTest {
         MetricID counterBlueMID = new MetricID(counterName, tagEarth,tagRed);
         
         //check multi-dimensional metrics are registered
-        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(counterColourMID));
-        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(counterRedMID));
-        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(counterBlueMID));
+        assertThat("Counter is not registered correctly", registry.getCounter(counterColourMID), notNullValue());
+        assertThat("Counter is not registered correctly", registry.getCounter(counterRedMID), notNullValue());
+        assertThat("Counter is not registered correctly", registry.getCounter(counterBlueMID), notNullValue());
         
         //remove one metric
         registry.remove(counterColourMID);
         assertThat("Registry did not remove metric", registry.getCounters().size(), equalTo(2));
-        assertThat("Counter is not registered correctly", registry.getCounters(), not(hasKey(counterColourMID)));
+        assertThat("Counter is not registered correctly", registry.getCounter(counterColourMID), nullValue());
         
         //remove all metrics with the given name
         registry.remove(counterName);
-        assertThat("Counter is not registered correctly", registry.getCounters(), not(hasKey(counterRedMID)));
-        assertThat("Counter is not registered correctly", registry.getCounters(), not(hasKey(counterBlueMID)));
+        assertThat("Counter is not registered correctly", registry.getCounter(counterRedMID), nullValue());
+        assertThat("Counter is not registered correctly", registry.getCounter(counterBlueMID), nullValue());
         
     }
     

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/MetricRegistryTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/MetricRegistryTest.java
@@ -22,6 +22,8 @@
 
 package org.eclipse.microprofile.metrics.tck;
 
+import static org.junit.Assert.assertNotNull;
+
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.metrics.ConcurrentGauge;
@@ -92,36 +94,36 @@ public class MetricRegistryTest {
     @InSequence(1)
     public void nameTest() {
         Assert.assertNotNull(metrics);
-        Assert.assertTrue(metrics.getNames().contains("nameTest"));
+        Assert.assertNotNull(metrics.getMetadata("nameTest"));
     }
 
     @Test
     @InSequence(2)
     public void registerTest() {
         metrics.register("regCountTemp", countTemp);
-        Assert.assertTrue(metrics.getCounters().containsKey(new MetricID("regCountTemp")));
+        assertExists(Counter.class, new MetricID("regCountTemp"));
 
         metrics.register("regHistoTemp", histoTemp);
-        Assert.assertTrue(metrics.getHistograms().containsKey(new MetricID("regHistoTemp")));
+        assertExists(Histogram.class, new MetricID("regHistoTemp"));
 
         metrics.register("regTimerTemp", timerTemp);
-        Assert.assertTrue(metrics.getTimers().containsKey(new MetricID("regTimerTemp")));
+        assertExists(Timer.class, new MetricID("regTimerTemp"));
 
         metrics.register("regSimpleTimerTemp", simpleTimerTemp);
-        Assert.assertTrue(metrics.getSimpleTimers().containsKey(new MetricID("regSimpleTimerTemp")));
+        assertExists(SimpleTimer.class, new MetricID("regSimpleTimerTemp"));
 
         metrics.register("regConcurrentGaugeTemp", concurrentGaugeTemp);
-        Assert.assertTrue(metrics.getConcurrentGauges().containsKey(new MetricID("regConcurrentGaugeTemp")));
+        assertExists(ConcurrentGauge.class, new MetricID("regConcurrentGaugeTemp"));
 
         metrics.register("regMeterTemp", meterTemp);
-        Assert.assertTrue(metrics.getMeters().containsKey(new MetricID("regMeterTemp")));
+        assertExists(Meter.class, new MetricID("regMeterTemp"));
     }
 
     @Test
     @InSequence(3)
     public void removeTest() {
         metrics.remove("nameTest");
-        Assert.assertFalse(metrics.getNames().contains("nameTest"));
+        Assert.assertNull(metrics.getMetadata("nameTest"));
     }
 
     @Test
@@ -138,11 +140,11 @@ public class MetricRegistryTest {
         metrics.counter(metricName, purpleTag);
 
         //check both counters have been registered
-        Assert.assertTrue(metrics.getCounters().containsKey(new MetricID(metricName)));
-        Assert.assertTrue(metrics.getCounters().containsKey(new MetricID(metricName, purpleTag)));
+        assertExists(Counter.class, new MetricID(metricName));
+        assertExists(Counter.class, new MetricID(metricName, purpleTag));
 
         //check that the "original" metadata wasn't replaced by the empty default metadata
-        Assert.assertEquals(metrics.getMetadata().get(metricName).getDisplayName(), displayName);
+        Assert.assertEquals(metrics.getMetadata(metricName).getDisplayName(), displayName);
     }
 
     @Test
@@ -153,4 +155,7 @@ public class MetricRegistryTest {
         Assert.assertEquals(MetricRegistry.Type.VENDOR, vendorMetrics.getType());
     }
 
+    private void assertExists(Class<? extends org.eclipse.microprofile.metrics.Metric> expected, MetricID metricID) {
+        assertNotNull("Metric expected to exist but was undefined: " + metricID, metrics.getMetric(metricID, expected));
+    }
 }

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/cdi/ApplicationScopedTimedMethodBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/cdi/ApplicationScopedTimedMethodBeanTest.java
@@ -16,8 +16,8 @@
 package org.eclipse.microprofile.metrics.tck.cdi;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
 import javax.inject.Inject;
@@ -77,8 +77,8 @@ public class ApplicationScopedTimedMethodBeanTest {
     @Test
     @InSequence(1)
     public void timedMethodNotCalledYet() {
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(timerMID));
-        Timer timer = registry.getTimers().get(timerMID);
+        Timer timer = registry.getTimer(timerMID);
+        assertThat("Timer is not registered correctly", timer, notNullValue());
 
         // Make sure that the timer hasn't been called yet
         assertThat("Timer count is incorrect", timer.getCount(), is(equalTo(0L)));
@@ -87,8 +87,8 @@ public class ApplicationScopedTimedMethodBeanTest {
     @Test
     @InSequence(2)
     public void callTimedMethodOnce() {
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(timerMID));
-        Timer timer = registry.getTimers().get(timerMID);
+        Timer timer = registry.getTimer(timerMID);
+        assertThat("Timer is not registered correctly", timer, notNullValue());
 
         // Call the timed method and assert it's been timed
         bean.applicationScopedTimedMethod();

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/cdi/MetricProducerFieldBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/cdi/MetricProducerFieldBeanTest.java
@@ -20,6 +20,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
 import javax.inject.Inject;
@@ -93,12 +94,12 @@ public class MetricProducerFieldBeanTest {
                 not(hasKey(notRegMID))
             )
         );
-        Counter counter1 = registry.getCounters().get(counter1MID);
-        Counter counter2 = registry.getCounters().get(counter2MID);
+        Counter counter1 = registry.getCounter(counter1MID);
+        Counter counter2 = registry.getCounter(counter2MID);
 
-        assertThat("Gauge is not registered correctly", registry.getGauges(), hasKey(ratioGaugeMID));
         @SuppressWarnings("unchecked")
-        Gauge<Double> gauge = (Gauge<Double>) registry.getGauges().get(ratioGaugeMID);
+        Gauge<Double> gauge = (Gauge<Double>) registry.getGauge(ratioGaugeMID);
+        assertThat("Gauge is not registered correctly", gauge, notNullValue());
 
         assertThat("Gauge value is incorrect", gauge.getValue(), is(equalTo(((double) counter1.getCount()) / ((double) counter2.getCount()))));
     }
@@ -113,12 +114,12 @@ public class MetricProducerFieldBeanTest {
                 not(hasKey(notRegMID))
             )
         );
-        Counter counter1 = registry.getCounters().get(counter1MID);
-        Counter counter2 = registry.getCounters().get(counter2MID);
+        Counter counter1 = registry.getCounter(counter1MID);
+        Counter counter2 = registry.getCounter(counter2MID);
 
-        assertThat("Gauge is not registered correctly", registry.getGauges(), hasKey(ratioGaugeMID));
         @SuppressWarnings("unchecked")
-        Gauge<Double> gauge = (Gauge<Double>) registry.getGauges().get(ratioGaugeMID);
+        Gauge<Double> gauge = (Gauge<Double>) registry.getGauge(ratioGaugeMID);
+        assertThat("Gauge is not registered correctly", gauge, notNullValue());
 
         counter1.inc(Math.round(Math.random() * Integer.MAX_VALUE));
         counter2.inc(Math.round(Math.random() * Integer.MAX_VALUE));
@@ -136,9 +137,9 @@ public class MetricProducerFieldBeanTest {
 
         assertThat("Gauge value is incorrect", gauge.getValue(), is(equalTo(((double) counter1.getCount()) / ((double) counter2.getCount()))));
 
-        assertThat("Gauge is not registered correctly", registry.getGauges(), hasKey("ratioGauge"));
         @SuppressWarnings("unchecked")
-        Gauge<Double> gaugeFromRegistry = (Gauge<Double>) registry.getGauges().get("ratioGauge");
+        Gauge<Double> gaugeFromRegistry = (Gauge<Double>) registry.getGauge(new MetricID("ratioGauge"));
+        assertThat("Gauge is not registered correctly", gaugeFromRegistry, notNullValue());
 
         assertThat("Gauge values from registry and injection do not match", gauge.getValue(), is(equalTo(gaugeFromRegistry.getValue())));
     }

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/cdi/MetricProducerMethodBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/cdi/MetricProducerMethodBeanTest.java
@@ -15,9 +15,8 @@
  */
 package org.eclipse.microprofile.metrics.tck.cdi;
 
-import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
@@ -91,17 +90,12 @@ public class MetricProducerMethodBeanTest {
     @Test
     @InSequence(1)
     public void cachedMethodNotCalledYet() {
-        assertThat("Metrics are not registered correctly", registry.getMetrics(),
-            allOf(
-                hasKey(callsMID),
-                hasKey(hitsMID),
-                hasKey(cacheHitsMID)
-            )
-        );
-        Timer calls = registry.getTimers().get(callsMID);
-        Meter hits = registry.getMeters().get(hitsMID);
+        assertThat("Metrics are not registered correctly", registry.getMetricIDs(),
+            contains(callsMID, hitsMID, cacheHitsMID));
+        Timer calls = registry.getTimer(callsMID);
+        Meter hits = registry.getMeter(hitsMID);
         @SuppressWarnings("unchecked")
-        Gauge<Double> gauge = (Gauge<Double>) registry.getGauges().get(cacheHitsMID);
+        Gauge<Double> gauge = (Gauge<Double>) registry.getGauge(cacheHitsMID);
 
         assertThat("Gauge value is incorrect", gauge.getValue(), is(equalTo(((double) hits.getCount() / (double) calls.getCount()))));
     }
@@ -109,17 +103,12 @@ public class MetricProducerMethodBeanTest {
     @Test
     @InSequence(2)
     public void callCachedMethodMultipleTimes() {
-        assertThat("Metrics are not registered correctly", registry.getMetrics(),
-            allOf(
-                hasKey(callsMID),
-                hasKey(hitsMID),
-                hasKey(cacheHitsMID)
-            )
-        );
-        Timer calls = registry.getTimers().get(callsMID);
-        Meter hits = registry.getMeters().get(hitsMID);
+        assertThat("Metrics are not registered correctly", registry.getMetricIDs(),
+            contains(callsMID, hitsMID, cacheHitsMID));
+        Timer calls = registry.getTimer(callsMID);
+        Meter hits = registry.getMeter(hitsMID);
         @SuppressWarnings("unchecked")
-        Gauge<Double> gauge = (Gauge<Double>) registry.getGauges().get(cacheHitsMID);
+        Gauge<Double> gauge = (Gauge<Double>) registry.getGauge(cacheHitsMID);
 
         long count = 10 + Math.round(Math.random() * 10);
         for (int i = 0; i < count; i++) {

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/cdi/stereotype/StereotypeCountedClassBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/cdi/stereotype/StereotypeCountedClassBeanTest.java
@@ -37,6 +37,7 @@ import org.junit.runner.RunWith;
 import javax.inject.Inject;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(Arquillian.class)
@@ -64,31 +65,31 @@ public class StereotypeCountedClassBeanTest {
     @Test
     public void testPlainAnnotation() {
         MetricID constructorMetricId = new MetricID(StereotypeCountedClassBean.class.getName() + ".StereotypeCountedClassBean");
-        assertTrue(metricRegistry.getCounters().containsKey(constructorMetricId));
+        assertNotNull(metricRegistry.getCounter(constructorMetricId));
         MetricID methodMetricId = new MetricID(StereotypeCountedClassBean.class.getName() + ".foo");
-        assertTrue(metricRegistry.getCounters().containsKey(methodMetricId));
+        assertNotNull(metricRegistry.getCounter(methodMetricId));
         bean.foo();
-        assertEquals(1, metricRegistry.getCounters().get(methodMetricId).getCount());
+        assertEquals(1, metricRegistry.getCounter(methodMetricId).getCount());
     }
 
     @Test
     public void testWithMetadata() {
         String constructorMetricName = "org.eclipse.microprofile.metrics.tck.cdi.stereotype.bloop.StereotypeCountedClassBeanWithSpecifiedMetadata";
         MetricID constructorMetricId = new MetricID(constructorMetricName);
-        assertTrue(metricRegistry.getCounters().containsKey(constructorMetricId));
-        Metadata constructorMetadata = metricRegistry.getMetadata().get(constructorMetricName);
+        assertNotNull(metricRegistry.getCounter(constructorMetricId));
+        Metadata constructorMetadata = metricRegistry.getMetadata(constructorMetricName);
         assertEquals("description", constructorMetadata.getDescription().orElse(null));
         assertEquals("displayName", constructorMetadata.getDisplayName());
 
         String methodMetricName = "org.eclipse.microprofile.metrics.tck.cdi.stereotype.bloop.foo";
         MetricID methodMetricId = new MetricID(methodMetricName);
-        assertTrue(metricRegistry.getCounters().containsKey(methodMetricId));
-        Metadata methodMetadata = metricRegistry.getMetadata().get(methodMetricName);
+        assertNotNull(metricRegistry.getCounter(methodMetricId));
+        Metadata methodMetadata = metricRegistry.getMetadata(methodMetricName);
         assertEquals("description", methodMetadata.getDescription().orElse(null));
         assertEquals("displayName", methodMetadata.getDisplayName());
 
         beanWithSpecifiedMetadata.foo();
-        assertEquals(1, metricRegistry.getCounters().get(methodMetricId).getCount());
+        assertEquals(1, metricRegistry.getCounter(methodMetricId).getCount());
     }
 
 }

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/cdi/stereotype/StereotypeCountedClassBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/cdi/stereotype/StereotypeCountedClassBeanTest.java
@@ -38,7 +38,6 @@ import javax.inject.Inject;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 @RunWith(Arquillian.class)
 public class StereotypeCountedClassBeanTest {

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/inheritance/InheritedGaugeMethodBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/inheritance/InheritedGaugeMethodBeanTest.java
@@ -15,9 +15,8 @@
  */
 package org.eclipse.microprofile.metrics.tck.inheritance;
 
-import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 import org.eclipse.microprofile.metrics.MetricID;
 
@@ -90,12 +89,12 @@ public class InheritedGaugeMethodBeanTest {
     @Test
     @InSequence(1)
     public void gaugesCalledWithDefaultValues() {
-        assertThat("Gauges are not registered correctly", registry.getGauges(), allOf(hasKey(parentMID), hasKey(childMID)));
-
         @SuppressWarnings("unchecked")
-        Gauge<Long> parentGauge = registry.getGauges().get(parentMID);
+        Gauge<Long> parentGauge = (Gauge<Long>) registry.getGauge(parentMID);
         @SuppressWarnings("unchecked")
-        Gauge<Long> childGauge = registry.getGauges().get(childMID);
+        Gauge<Long> childGauge = (Gauge<Long>) registry.getGauge(childMID);
+        assertThat("Gauges are not registered correctly", parentGauge, notNullValue());
+        assertThat("Gauges are not registered correctly", childGauge, notNullValue());
 
         // Make sure that the gauge has the expected value
         assertThat("Gauge values are incorrect", Arrays.asList(parentGauge.getValue(), childGauge.getValue()), contains(0L, 0L));
@@ -104,11 +103,12 @@ public class InheritedGaugeMethodBeanTest {
     @Test
     @InSequence(2)
     public void callGaugesAfterSetterCalls() {
-        assertThat("Gauges are not registered correctly", registry.getGauges(), allOf(hasKey(parentMID), hasKey(childMID)));
         @SuppressWarnings("unchecked")
-        Gauge<Long> parentGauge = registry.getGauges().get(parentMID);
+        Gauge<Long> parentGauge = (Gauge<Long>) registry.getGauge(parentMID);
         @SuppressWarnings("unchecked")
-        Gauge<Long> childGauge = registry.getGauges().get(childMID);
+        Gauge<Long> childGauge = (Gauge<Long>) registry.getGauge(childMID);
+        assertThat("Gauges are not registered correctly", parentGauge, notNullValue());
+        assertThat("Gauges are not registered correctly", childGauge, notNullValue());
 
         // Call the setter methods and assert the gauges are up-to-date
         long parentValue = Math.round(Math.random() * Long.MAX_VALUE);

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/ConcreteExtendedTimedBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/ConcreteExtendedTimedBeanTest.java
@@ -16,8 +16,8 @@
 package org.eclipse.microprofile.metrics.tck.metrics;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
 import javax.inject.Inject;
@@ -72,12 +72,11 @@ public class ConcreteExtendedTimedBeanTest {
         extendedTimedMID = new MetricID(EXTENDED_TIMED_NAME);
     }
 
-    
     @Test
     @InSequence(1)
     public void timedMethodNotCalledYet(MetricRegistry registry) {
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(timedMID));
-        Timer timer = registry.getTimers().get(timedMID);
+        Timer timer = registry.getTimer(timedMID);
+        assertThat("Timer is not registered correctly", timer, notNullValue());
 
         // Make sure that the timer hasn't been called yet
         assertThat("Timer count is incorrect", timer.getCount(), is(equalTo(0L)));
@@ -86,8 +85,8 @@ public class ConcreteExtendedTimedBeanTest {
     @Test
     @InSequence(2)
     public void extendedTimedMethodNotCalledYet(MetricRegistry registry) {
-        assertThat("Timer is not registered correctly on the methods on the abstract class", registry.getTimers(), hasKey(extendedTimedMID));
-        Timer timer = registry.getTimers().get(extendedTimedMID);
+        Timer timer = registry.getTimer(extendedTimedMID);
+        assertThat("Timer is not registered correctly on the methods on the abstract class", timer, notNullValue());
 
         // Make sure that the timer hasn't been called yet
         assertThat("Timer count is incorrect", timer.getCount(), is(equalTo(0L)));
@@ -96,8 +95,8 @@ public class ConcreteExtendedTimedBeanTest {
     @Test
     @InSequence(3)
     public void callTimedMethodOnce(MetricRegistry registry) {
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(timedMID));
-        Timer timer = registry.getTimers().get(timedMID);
+        Timer timer = registry.getTimer(timedMID);
+        assertThat("Timer is not registered correctly", timer, notNullValue());
 
         // Call the timed method and assert it's been timed
         bean.timedMethod();
@@ -109,8 +108,8 @@ public class ConcreteExtendedTimedBeanTest {
     @Test
     @InSequence(4)
     public void callExtendedTimedMethodOnce(MetricRegistry registry) {
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(extendedTimedMID));
-        Timer timer = registry.getTimers().get(extendedTimedMID);
+        Timer timer = registry.getTimer(extendedTimedMID);
+        assertThat("Timer is not registered correctly", timer, notNullValue());
 
         // Call the timed method and assert it's been timed
         bean.anotherTimedMethod();

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/ConcreteTimedBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/ConcreteTimedBeanTest.java
@@ -16,8 +16,8 @@
 package org.eclipse.microprofile.metrics.tck.metrics;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
 import javax.inject.Inject;
@@ -75,8 +75,8 @@ public class ConcreteTimedBeanTest {
     @Test
     @InSequence(1)
     public void timedMethodNotCalledYet(MetricRegistry registry) {
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(timerMID));
-        Timer timer = registry.getTimers().get(timerMID);
+        Timer timer = registry.getTimer(timerMID);
+        assertThat("Timer is not registered correctly", timer, notNullValue());
 
         // Make sure that the timer hasn't been called yet
         assertThat("Timer count is incorrect", timer.getCount(), is(equalTo(0L)));
@@ -85,8 +85,8 @@ public class ConcreteTimedBeanTest {
     @Test
     @InSequence(2)
     public void extendedTimedMethodNotCalledYet(MetricRegistry registry) {
-        assertThat("Timer is not registered correctly on the methods on the abstract class", registry.getTimers(), hasKey(extendedTimedMID));
-        Timer timer = registry.getTimers().get(extendedTimedMID);
+        Timer timer = registry.getTimer(extendedTimedMID);
+        assertThat("Timer is not registered correctly on the methods on the abstract class", timer, notNullValue());
 
         // Make sure that the timer hasn't been called yet
         assertThat("Timer count is incorrect", timer.getCount(), is(equalTo(0L)));
@@ -95,8 +95,8 @@ public class ConcreteTimedBeanTest {
     @Test
     @InSequence(3)
     public void callTimedMethodOnce(MetricRegistry registry) {
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(timerMID));
-        Timer timer = registry.getTimers().get(timerMID);
+        Timer timer = registry.getTimer(timerMID);
+        assertThat("Timer is not registered correctly", timer, notNullValue());
 
         // Call the timed method and assert it's been timed
         bean.timedMethod();
@@ -108,8 +108,8 @@ public class ConcreteTimedBeanTest {
     @Test
     @InSequence(4)
     public void callExtendedTimedMethodOnce(MetricRegistry registry) {
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(extendedTimedMID));
-        Timer timer = registry.getTimers().get(extendedTimedMID);
+        Timer timer = registry.getTimer(extendedTimedMID);
+        assertThat("Timer is not registered correctly", timer, notNullValue());
 
         // Call the timed method and assert it's been timed
         bean.normallyNotTimedMethod();

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/ConcurrentGaugeFunctionalTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/ConcurrentGaugeFunctionalTest.java
@@ -26,6 +26,7 @@ package org.eclipse.microprofile.metrics.tck.metrics;
 import org.eclipse.microprofile.metrics.tck.util.ControlledInvocation;
 import org.eclipse.microprofile.metrics.tck.util.BeanWithControlledInvocation;
 import org.eclipse.microprofile.metrics.tck.util.TimeUtil;
+import org.eclipse.microprofile.metrics.ConcurrentGauge;
 import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -88,10 +89,9 @@ public class ConcurrentGaugeFunctionalTest {
             invocation2.stop();
             TimeUtil.waitForNextMinute();
             invocation1.stop();
-            assertEquals("Minimum should be 1 ", 1,
-                metricRegistry.getConcurrentGauges().get(new MetricID("mygauge")).getMin());
-            assertEquals("Maximum should be 2", 2,
-                metricRegistry.getConcurrentGauges().get(new MetricID("mygauge")).getMax());
+            ConcurrentGauge cGauge = metricRegistry.getConcurrentGauge(new MetricID("mygauge"));
+            assertEquals("Minimum should be 1 ", 1, cGauge.getMin());
+            assertEquals("Maximum should be 2", 2, cGauge.getMax());
         }
         finally {
             invocation1.stop();
@@ -110,17 +110,16 @@ public class ConcurrentGaugeFunctionalTest {
         ControlledInvocation[] invocations = new ControlledInvocation[NUMBER_OF_INVOCATIONS];
         try {
             // run some clients for the first method, see the 'count' of the concurrent gauge increment over time
+            ConcurrentGauge cGauge = metricRegistry.getConcurrentGauge(new MetricID("mygauge"));
             for (int i = 0; i < NUMBER_OF_INVOCATIONS; i++) {
                 invocations[i] = new ControlledInvocation(bean);
                 invocations[i].start();
-                assertEquals(i + 1,
-                    metricRegistry.getConcurrentGauges().get(new MetricID("mygauge")).getCount());
+                assertEquals(i + 1, cGauge.getCount());
             }
             // stop all clients and see the 'count' of the concurrent gauge decrement over time
             for (int i = 0; i < NUMBER_OF_INVOCATIONS; i++) {
                 invocations[i].stop();
-                assertEquals(NUMBER_OF_INVOCATIONS - i - 1,
-                    metricRegistry.getConcurrentGauges().get(new MetricID("mygauge")).getCount());
+                assertEquals(NUMBER_OF_INVOCATIONS - i - 1, cGauge.getCount());
             }
         }
         finally {

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/ConcurrentGaugedConstructorBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/ConcurrentGaugedConstructorBeanTest.java
@@ -39,8 +39,8 @@
 package org.eclipse.microprofile.metrics.tck.metrics;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
 import javax.enterprise.inject.Instance;
@@ -112,8 +112,8 @@ public class ConcurrentGaugedConstructorBeanTest {
             instance.get();
         }
 
-        assertThat("Concurrent Gauge is not registered correctly", registry.getConcurrentGauges(), hasKey(counterMID));
-        ConcurrentGauge concurrentGauge = registry.getConcurrentGauges().get(counterMID);
+        ConcurrentGauge concurrentGauge = registry.getConcurrentGauge(counterMID);
+        assertThat("Concurrent Gauge is not registered correctly", concurrentGauge, notNullValue());
 
         assertThat("Concurrent gauge count is incorrect", concurrentGauge.getCount(), is(equalTo(0L)));
     }

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/CountedClassBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/CountedClassBeanTest.java
@@ -127,6 +127,6 @@ public class CountedClassBeanTest {
                 everyItem(Matchers.<Counter> hasProperty("count", equalTo(1L))));
 
         assertThat("Constructor's metric should be incremented at least once",
-            registry.getCounters().get(constructorMID).getCount(), is(greaterThanOrEqualTo(1L)));
+            registry.getCounter(constructorMID).getCount(), is(greaterThanOrEqualTo(1L)));
     }
 }

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/CountedMethodBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/CountedMethodBeanTest.java
@@ -16,8 +16,8 @@
 package org.eclipse.microprofile.metrics.tck.metrics;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
@@ -86,8 +86,8 @@ public class CountedMethodBeanTest {
     @Test
     @InSequence(1)
     public void countedMethodNotCalledYet() {
-        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(counterMetricID));
-        Counter counter = registry.getCounters().get(counterMetricID);
+        Counter counter = registry.getCounter(counterMetricID);
+        assertThat("Counter is not registered correctly", counter, notNullValue());
 
         // Make sure that the counter hasn't been called yet
         assertThat("Counter count is incorrect", counter.getCount(), is(equalTo(COUNTER_COUNT.get())));
@@ -96,8 +96,8 @@ public class CountedMethodBeanTest {
     @Test
     @InSequence(2)
     public void metricInjectionIntoTest(@Metric(name = "countedMethod", absolute = true) Counter instance) {
-        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(counterMetricID));
-        Counter counter = registry.getCounters().get(counterMetricID);
+        Counter counter = registry.getCounter(counterMetricID);
+        assertThat("Counter is not registered correctly", counter, notNullValue());
 
         // Make sure that the counter registered and the bean instance are the same
         assertThat("Counter and bean instance are not equal", instance, is(equalTo(counter)));
@@ -106,8 +106,8 @@ public class CountedMethodBeanTest {
     @Test
     @InSequence(3)
     public void callCountedMethodOnce() throws InterruptedException, TimeoutException {
-        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(counterMetricID));
-        Counter counter = registry.getCounters().get(counterMetricID);
+        Counter counter = registry.getCounter(counterMetricID);
+        assertThat("Counter is not registered correctly", counter, notNullValue());
 
         // Call the counted method, block and assert it's been counted
         final Exchanger<Long> exchanger = new Exchanger<>();
@@ -160,8 +160,8 @@ public class CountedMethodBeanTest {
     @Test
     @InSequence(4)
     public void removeCounterFromRegistry() {
-        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(counterMetricID));
-        Counter counter = registry.getCounters().get(counterMetricID);
+        Counter counter = registry.getCounter(counterMetricID);
+        assertThat("Counter is not registered correctly", counter, notNullValue());
 
         // Remove the counter from metrics registry
         registry.remove(counterMetricID);

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/CountedMethodTagBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/CountedMethodTagBeanTest.java
@@ -25,7 +25,7 @@ package org.eclipse.microprofile.metrics.tck.metrics;
 import static org.junit.Assert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.notNullValue;
 
 import javax.inject.Inject;
 
@@ -90,20 +90,20 @@ public class CountedMethodTagBeanTest {
     @Test
     @InSequence(1)
     public void counterTagMethodsRegistered() {
-        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(counterOneMID));
-        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(counterTwoMID));
+        assertThat("Counter is not registered correctly", registry.getCounter(counterOneMID), notNullValue());
+        assertThat("Counter is not registered correctly", registry.getCounter(counterTwoMID), notNullValue());
     }
     
     @Test
     @InSequence(2)
     public void countedTagMethodNotCalledYet(@Metric(name = "countedMethod", absolute = true, tags = {"number=one"}) Counter instanceOne,
                                              @Metric(name = "countedMethod", absolute = true, tags = {"number=two"}) Counter instanceTwo) {
-        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(counterOneMID));
-        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(counterTwoMID));
-        
-        Counter counterOne = registry.getCounters().get(counterOneMID);
-        Counter counterTwo = registry.getCounters().get(counterTwoMID);
-        
+        Counter counterOne = registry.getCounter(counterOneMID);
+        Counter counterTwo = registry.getCounter(counterTwoMID);
+
+        assertThat("Counter is not registered correctly", counterOne, notNullValue());
+        assertThat("Counter is not registered correctly", counterTwo, notNullValue());
+
         // Make sure that the counter registered and the bean instance are the same
         assertThat("Counter and bean instance are not equal", instanceOne, is(equalTo(counterOne)));
         assertThat("Counter and bean instance are not equal", instanceTwo, is(equalTo(counterTwo)));

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/CounterFieldBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/CounterFieldBeanTest.java
@@ -16,8 +16,8 @@
 package org.eclipse.microprofile.metrics.tck.metrics;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
 import javax.inject.Inject;
@@ -75,14 +75,14 @@ public class CounterFieldBeanTest {
     @Test
     @InSequence(1)
     public void counterFieldRegistered() {
-        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(counterMID));
+        assertThat("Counter is not registered correctly", registry.getCounter(counterMID), notNullValue());
     }
 
     @Test
     @InSequence(2)
     public void incrementCounterField() {
-        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(counterMID));
-        Counter counter = registry.getCounters().get(counterMID);
+        Counter counter = registry.getCounter(counterMID);
+        assertThat("Counter is not registered correctly", counter, notNullValue());
 
         // Call the increment method and assert the counter is up-to-date
         long value = Math.round(Math.random() * Long.MAX_VALUE);

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/DefaultNameMetricMethodBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/DefaultNameMetricMethodBeanTest.java
@@ -64,6 +64,6 @@ public class DefaultNameMetricMethodBeanTest {
 
     @Test
     public void metricMethodsWithDefaultNamingConvention() {
-        assertThat("Metrics are not registered correctly", registry.getMetrics().keySet(), is(equalTo(MetricsUtil.createMetricIDs(metricNames()))));
+        assertThat("Metrics are not registered correctly", registry.getMetricIDs(), is(equalTo(MetricsUtil.createMetricIDs(metricNames()))));
     }
 }

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/GaugeMethodBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/GaugeMethodBeanTest.java
@@ -16,8 +16,8 @@
 package org.eclipse.microprofile.metrics.tck.metrics;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
 import javax.inject.Inject;
@@ -78,9 +78,9 @@ public class GaugeMethodBeanTest {
     @Test
     @InSequence(1)
     public void gaugeCalledWithDefaultValue() {
-        assertThat("Gauge is not registered correctly", registry.getGauges(), hasKey(gaugeMID));
         @SuppressWarnings("unchecked")
-        Gauge<Long> gauge = registry.getGauges().get(gaugeMID);
+        Gauge<Long> gauge = (Gauge<Long>) registry.getGauge(gaugeMID);
+        assertThat("Gauge is not registered correctly", gauge, notNullValue());
 
         // Make sure that the gauge has the expected value
         assertThat("Gauge value is incorrect", gauge.getValue(), is(equalTo(0L)));
@@ -89,9 +89,9 @@ public class GaugeMethodBeanTest {
     @Test
     @InSequence(2)
     public void callGaugeAfterSetterCall() {
-        assertThat("Gauge is not registered correctly", registry.getGauges(), hasKey(gaugeMID));
         @SuppressWarnings("unchecked")
-        Gauge<Long> gauge = registry.getGauges().get(gaugeMID);
+        Gauge<Long> gauge = (Gauge<Long>) registry.getGauge(gaugeMID);
+        assertThat("Gauge is not registered correctly", gauge, notNullValue());
 
         // Call the setter method and assert the gauge is up-to-date
         long value = Math.round(Math.random() * Long.MAX_VALUE);

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/GaugeTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/GaugeTest.java
@@ -54,24 +54,19 @@ public class GaugeTest {
 
     @Test
     public void testManualGauge() {
+        MetricID gaugeMetricID = new MetricID("tck.gaugetest.gaugemanual");
         
-        String gaugeName = "tck.gaugetest.gaugemanual";
-        MetricID gaugeMetricID = new MetricID(gaugeName);
-        
-        Assert.assertNull(metrics.getGauges().get(gaugeMetricID));
+        Gauge<?> gauge = metrics.getGauge(gaugeMetricID);
+        Assert.assertNull(gauge);
         gaugeMe();
-
-        Assert.assertEquals(0, (metrics.getGauges().get(gaugeMetricID).getValue()));
-        Assert.assertEquals(1, (metrics.getGauges().get(gaugeMetricID).getValue()));
+        gauge = metrics.getGauge(gaugeMetricID);
+        
+        Assert.assertEquals(0, gauge.getValue());
+        Assert.assertEquals(1, gauge.getValue());
     }
 
     public void gaugeMe() {
-        @SuppressWarnings("unchecked")
-        Gauge<Integer> gaugeManual = metrics.getGauges().get("tck.gaugetest.gaugemanual");
-        if (gaugeManual == null) {
-            gaugeManual = value::getAndIncrement;
-            metrics.register("tck.gaugetest.gaugemanual", gaugeManual);
-        }
+        metrics.gauge("tck.gaugetest.gaugemanual", value::getAndIncrement);
     }
 
 }

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/HistogramFieldBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/HistogramFieldBeanTest.java
@@ -16,8 +16,8 @@
 package org.eclipse.microprofile.metrics.tck.metrics;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
 import javax.inject.Inject;
@@ -74,14 +74,14 @@ public class HistogramFieldBeanTest {
     @Test
     @InSequence(1)
     public void histogramFieldRegistered() {
-        assertThat("Histogram is not registered correctly", registry.getHistograms(), hasKey(histogramMID));
+        assertThat("Histogram is not registered correctly", registry.getHistogram(histogramMID), notNullValue());
     }
 
     @Test
     @InSequence(2)
     public void updateHistogramField() {
-        assertThat("Histogram is not registered correctly", registry.getHistograms(), hasKey(histogramMID));
-        Histogram histogram = registry.getHistograms().get(histogramMID);
+        Histogram histogram = registry.getHistogram(histogramMID);
+        assertThat("Histogram is not registered correctly", histogram, notNullValue());
 
         // Call the update method and assert the histogram is up-to-date
         long value = Math.round(Math.random() * Long.MAX_VALUE);

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/HistogramTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/HistogramTest.java
@@ -23,8 +23,10 @@
 
 package org.eclipse.microprofile.metrics.tck.metrics;
 
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
 import java.util.Arrays;
-import java.util.SortedMap;
 
 import javax.inject.Inject;
 
@@ -101,19 +103,18 @@ public class HistogramTest {
     public void testMetricRegistry() throws Exception {
         String histogramIntName = "org.eclipse.microprofile.metrics.tck.metrics.HistogramTest.histogramInt";
         String histogramLongName = "test.longData.histogram";
-        
+
         MetricID histogramIntNameMetricID = new MetricID(histogramIntName);
         MetricID histogramLongNameMetricID = new MetricID(histogramLongName);
-        
-        SortedMap<MetricID, Histogram> histograms = metrics.getHistograms();
 
-        Assert.assertTrue(histograms.size() == 2);
+        Histogram histogramInt = metrics.getHistogram(histogramIntNameMetricID);
+        Histogram histogramLong = metrics.getHistogram(histogramLongNameMetricID);
 
-        Assert.assertTrue(histograms.containsKey(histogramIntNameMetricID));
-        Assert.assertTrue(histograms.containsKey(histogramLongNameMetricID));
+        assertThat("Histogram is not registered correctly", histogramInt, notNullValue());
+        assertThat("Histogram is not registered correctly", histogramLong, notNullValue());
 
-        TestUtils.assertEqualsWithTolerance(48, histograms.get(histogramIntNameMetricID).getSnapshot().getValue(0.5));
-        TestUtils.assertEqualsWithTolerance(480, histograms.get(histogramLongNameMetricID).getSnapshot().getValue(0.5));
+        TestUtils.assertEqualsWithTolerance(48, histogramInt.getSnapshot().getValue(0.5));
+        TestUtils.assertEqualsWithTolerance(480, histogramLong.getSnapshot().getValue(0.5));
     }
 
     @Test

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/MeteredClassBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/MeteredClassBeanTest.java
@@ -129,6 +129,6 @@ public class MeteredClassBeanTest {
                 everyItem(Matchers.<Meter> hasProperty("count", equalTo(METHOD_COUNT.incrementAndGet()))));
 
         assertThat("Constructor's metric should be incremented at least once",
-            registry.getMeters().get(constructorMID).getCount(), is(greaterThanOrEqualTo(1L)));
+            registry.getMeter(constructorMID).getCount(), is(greaterThanOrEqualTo(1L)));
     }
 }

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/MeteredConstructorBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/MeteredConstructorBeanTest.java
@@ -16,8 +16,8 @@
 package org.eclipse.microprofile.metrics.tck.metrics;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
 import javax.enterprise.inject.Instance;
@@ -87,8 +87,8 @@ public class MeteredConstructorBeanTest {
             instance.get();
         }
 
-        assertThat("Meter is not registered correctly", registry.getMeters(), hasKey(meterMID));
-        Meter meter = registry.getMeters().get(meterMID);
+        Meter meter = registry.getMeter(meterMID);
+        assertThat("Meter is not registered correctly", meter, notNullValue());
 
         // Make sure that the meter has been called
         assertThat("Meter count is incorrect", meter.getCount(), is(equalTo(count)));

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/MeteredMethodBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/MeteredMethodBeanTest.java
@@ -16,9 +16,9 @@
 package org.eclipse.microprofile.metrics.tck.metrics;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
@@ -80,8 +80,8 @@ public class MeteredMethodBeanTest {
     @Test
     @InSequence(1)
     public void meteredMethodNotCalledYet() {
-        assertThat("Meter is not registered correctly", registry.getMeters(), hasKey(meterMID));
-        Meter meter = registry.getMeters().get(meterMID);
+        Meter meter = registry.getMeter(meterMID);
+        assertThat("Meter is not registered correctly", meter, notNullValue());
 
         // Make sure that the meter hasn't been marked yet
         assertThat("Meter count is incorrect", meter.getCount(), is(equalTo(METER_COUNT.get())));
@@ -90,8 +90,8 @@ public class MeteredMethodBeanTest {
     @Test
     @InSequence(2)
     public void callMeteredMethodOnce() {
-        assertThat("Meter is not registered correctly", registry.getMeters(), hasKey(meterMID));
-        Meter meter = registry.getMeters().get(meterMID);
+        Meter meter = registry.getMeter(meterMID);
+        assertThat("Meter is not registered correctly", meter, notNullValue());
 
         // Call the metered method and assert it's been marked
         bean.meteredMethod();
@@ -103,8 +103,8 @@ public class MeteredMethodBeanTest {
     @Test
     @InSequence(3)
     public void removeMeterFromRegistry() {
-        assertThat("Meter is not registered correctly", registry.getMeters(), hasKey(meterMID));
-        Meter meter = registry.getMeters().get(meterMID);
+        Meter meter = registry.getMeter(meterMID);
+        assertThat("Meter is not registered correctly", meter, notNullValue());
 
         // Remove the meter from metrics registry
         registry.remove(meterMID);

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/MultipleMetricsConstructorBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/MultipleMetricsConstructorBeanTest.java
@@ -74,11 +74,11 @@ public class MultipleMetricsConstructorBeanTest {
         }
 
         // Make sure that the metrics have been called
-        assertThat("Counter count is incorrect", registry.getCounters()
-                .get(new MetricID(absoluteMetricName("counter"))).getCount(), is(equalTo(count)));
-        assertThat("Meter count is incorrect", registry.getMeters()
-                .get(new MetricID(absoluteMetricName("meter"))).getCount(), is(equalTo(count)));
-        assertThat("Timer count is incorrect", registry.getTimers()
-                .get(new MetricID(absoluteMetricName("timer"))).getCount(), is(equalTo(count)));
+        assertThat("Counter count is incorrect", registry.getCounter(
+                new MetricID(absoluteMetricName("counter"))).getCount(), is(equalTo(count)));
+        assertThat("Meter count is incorrect", registry.getMeter(
+                new MetricID(absoluteMetricName("meter"))).getCount(), is(equalTo(count)));
+        assertThat("Timer count is incorrect", registry.getTimer(
+                new MetricID(absoluteMetricName("timer"))).getCount(), is(equalTo(count)));
     }
 }

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/MultipleMetricsMethodBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/MultipleMetricsMethodBeanTest.java
@@ -76,29 +76,29 @@ public class MultipleMetricsMethodBeanTest {
     @Test
     @InSequence(1)
     public void metricsMethodNotCalledYet() {
-        assertThat("Metrics are not registered correctly", registry.getMetrics().keySet(), 
+        assertThat("Metrics are not registered correctly", registry.getMetricIDs(), 
             is(equalTo(MetricsUtil.createMetricIDs(absoluteMetricNames()))));
     }
 
     @Test
     @InSequence(2)
     public void callMetricsMethodOnce() {
-        assertThat("Metrics are not registered correctly", registry.getMetrics().keySet(),
+        assertThat("Metrics are not registered correctly", registry.getMetricIDs(),
             is(equalTo(MetricsUtil.createMetricIDs(absoluteMetricNames()))));
 
         // Call the monitored method and assert it's been instrumented
         bean.metricsMethod();
 
         // Make sure that the metrics have been called
-        assertThat("Counter count is incorrect", registry.getCounters()
-                .get(new MetricID(absoluteMetricName("counter"))).getCount(), is(equalTo(1L)));
-        assertThat("Meter count is incorrect", registry.getMeters()
-                .get(new MetricID(absoluteMetricName("meter"))).getCount(), is(equalTo(1L)));
-        assertThat("Timer count is incorrect", registry.getTimers()
-                .get(new MetricID(absoluteMetricName("timer"))).getCount(), is(equalTo(1L)));
+        assertThat("Counter count is incorrect", registry.getCounter(
+                new MetricID(absoluteMetricName("counter"))).getCount(), is(equalTo(1L)));
+        assertThat("Meter count is incorrect", registry.getMeter(
+                new MetricID(absoluteMetricName("meter"))).getCount(), is(equalTo(1L)));
+        assertThat("Timer count is incorrect", registry.getTimer(
+                new MetricID(absoluteMetricName("timer"))).getCount(), is(equalTo(1L)));
         // Let's call the gauge at the end as Weld is intercepting the gauge
         // invocation while OWB not
-        assertThat("Gauge value is incorrect", registry.getGauges()
-                .get(new MetricID(absoluteMetricName("gauge"))).getValue(), is(equalTo(1234L)));
+        assertThat("Gauge value is incorrect", registry.getGauge(
+                new MetricID(absoluteMetricName("gauge"))).getValue(), is(equalTo(1234L)));
     }
 }

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/OverloadedTimedMethodBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/OverloadedTimedMethodBeanTest.java
@@ -68,7 +68,7 @@ public class OverloadedTimedMethodBeanTest {
     @InSequence(1)
     public void overloadedTimedMethodNotCalledYet() {
         Assert.assertTrue("Metrics are not registered correctly", 
-            registry.getMetrics().keySet().containsAll(MetricsUtil.createMetricIDs(absoluteMetricNames())));
+            registry.getMetricIDs().containsAll(MetricsUtil.createMetricIDs(absoluteMetricNames())));
 
         // Make sure that all the timers haven't been called yet
         assertThat("Timer counts are incorrect", registry.getTimers().values(), hasItem(Matchers.<Timer> hasProperty("count", equalTo(0L))));
@@ -78,7 +78,7 @@ public class OverloadedTimedMethodBeanTest {
     @InSequence(2)
     public void callOverloadedTimedMethodOnce() {
         Assert.assertTrue("Metrics are not registered correctly", 
-            registry.getMetrics().keySet().containsAll(MetricsUtil.createMetricIDs(absoluteMetricNames())));
+            registry.getMetricIDs().containsAll(MetricsUtil.createMetricIDs(absoluteMetricNames())));
 
         // Call the timed methods and assert they've all been timed once
         bean.overloadedTimedMethod();

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/SimpleTimerFieldBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/SimpleTimerFieldBeanTest.java
@@ -74,7 +74,7 @@ public class SimpleTimerFieldBeanTest {
 
     @Test
     public void simpleTimerFieldsWithDefaultNamingConvention() {
-        assertThat("SimpleTimers are not registered correctly", registry.getMetrics().keySet(), 
+        assertThat("SimpleTimers are not registered correctly", registry.getMetricIDs(), 
             is(equalTo(MetricsUtil.createMetricIDs(metricNames()))));
     }
 }

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/SimpleTimerTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/SimpleTimerTest.java
@@ -97,13 +97,8 @@ public class SimpleTimerTest {
         MetricID simpleTimerLongNameMetricID = new MetricID(simpleTimerLongName);
         MetricID simpleTimerTimeNameMetricID = new MetricID(simpleTimerTimeName);
         
-        SortedMap<MetricID, SimpleTimer> simpleTimers = registry.getSimpleTimers();
-        
-        Assert.assertTrue(simpleTimers.size() > 0);
-
-        Assert.assertTrue(simpleTimers.containsKey(simpleTimerLongNameMetricID));
-        Assert.assertTrue(simpleTimers.containsKey(simpleTimerTimeNameMetricID));
-
+        Assert.assertNotNull(registry.getSimpleTimer(simpleTimerLongNameMetricID));
+        Assert.assertNotNull(registry.getSimpleTimer(simpleTimerTimeNameMetricID));
     }
 
     @Test

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/SimpleTimerTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/SimpleTimerTest.java
@@ -23,7 +23,6 @@
  */
 package org.eclipse.microprofile.metrics.tck.metrics;
 
-import java.util.SortedMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import javax.inject.Inject;
@@ -68,7 +67,7 @@ public class SimpleTimerTest {
 
         isInitialized = true;
     }
-    
+
     @Test
     @InSequence(1)
     public void testTime() throws Exception {
@@ -78,11 +77,11 @@ public class SimpleTimerTest {
         Context context = simpleTimer.time();
         double afterStartTime = System.nanoTime();
         Thread.sleep(1000);
-        
+
         double beforeStopTime = System.nanoTime();
         double time = context.stop();
         double afterStopTime = System.nanoTime();
-        
+
 
         double delta = (afterStartTime - beforeStartTime) + (afterStopTime - beforeStopTime);
         Assert.assertEquals(beforeStopTime - beforeStartTime, time, delta);
@@ -93,10 +92,10 @@ public class SimpleTimerTest {
     public void testTimerRegistry() throws Exception {
         String simpleTimerLongName = "test.longData.simpleTimer";
         String simpleTimerTimeName = "testSimpleTime";
-        
+
         MetricID simpleTimerLongNameMetricID = new MetricID(simpleTimerLongName);
         MetricID simpleTimerTimeNameMetricID = new MetricID(simpleTimerTimeName);
-        
+
         Assert.assertNotNull(registry.getSimpleTimer(simpleTimerLongNameMetricID));
         Assert.assertNotNull(registry.getSimpleTimer(simpleTimerTimeNameMetricID));
     }

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/SimplyTimedClassBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/SimplyTimedClassBeanTest.java
@@ -130,7 +130,7 @@ public class SimplyTimedClassBeanTest {
     public void simplyTimedMethodsNotCalledYet() {
         assertThat("SimpleTimers are not registered correctly", registry.getSimpleTimers().keySet(), is(equalTo(simpleTimerMIDsIncludingToString)));
         
-        assertThat("Constructor timer count is incorrect", registry.getSimpleTimers().get(constructorMID).getCount(), is(equalTo(1L)));
+        assertThat("Constructor timer count is incorrect", registry.getSimpleTimer(constructorMID).getCount(), is(equalTo(1L)));
 
         // Make sure that the method timers haven't been simplyTimed yet
         assertThat("Method simple timer counts are incorrect", registry.getSimpleTimers(METHOD_SIMPLE_TIMERS).values(),
@@ -142,7 +142,7 @@ public class SimplyTimedClassBeanTest {
     public void callSimplyTimedMethodsOnce() {
         assertThat("SimpleTimers are not registered correctly", registry.getSimpleTimers().keySet(), is(equalTo(simpleTimerMIDsIncludingToString)));
         
-        assertThat("Constructor simple timer count is incorrect", registry.getSimpleTimers().get(constructorMID).getCount(), is(equalTo(1L)));
+        assertThat("Constructor simple timer count is incorrect", registry.getSimpleTimer(constructorMID).getCount(), is(equalTo(1L)));
 
         // Call the simplyTimed methods and assert they've been simplyTimed
         bean.simplyTimedMethodOne();

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/SimplyTimedConstructorBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/SimplyTimedConstructorBeanTest.java
@@ -24,8 +24,8 @@
 package org.eclipse.microprofile.metrics.tck.metrics;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
 import javax.enterprise.inject.Instance;
@@ -98,8 +98,8 @@ public class SimplyTimedConstructorBeanTest {
             instance.get();
         }
 
-        assertThat("SimpleTimer is not registered correctly", registry.getSimpleTimers(), hasKey(simpleTimerMID));
-        SimpleTimer simpleTimer = registry.getSimpleTimers().get(simpleTimerMID);
+        SimpleTimer simpleTimer = registry.getSimpleTimer(simpleTimerMID);
+        assertThat("SimpleTimer is not registered correctly", simpleTimer, notNullValue());
 
         // Make sure that the simpleTimer has been called
         assertThat("SimpleTimer count is incorrect", simpleTimer.getCount(), is(equalTo(count)));

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/SimplyTimedMethodBeanLookupTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/SimplyTimedMethodBeanLookupTest.java
@@ -24,9 +24,9 @@
 package org.eclipse.microprofile.metrics.tck.metrics;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
@@ -95,8 +95,8 @@ public class SimplyTimedMethodBeanLookupTest {
         // Get a contextual instance of the bean
         SimplyTimedMethodBean1 bean = instance.get();
 
-        assertThat("SimplyTimed is not registered correctly", registry.getSimpleTimers(), hasKey(simpleTimerMID));
-        SimpleTimer simpleTimer = registry.getSimpleTimers().get(simpleTimerMID);
+        SimpleTimer simpleTimer = registry.getSimpleTimer(simpleTimerMID);
+        assertThat("SimplyTimed is not registered correctly", simpleTimer, notNullValue());
 
         // Make sure that the simpleTimer hasn't been called yet
         assertThat("SimplyTimed count is incorrect", simpleTimer.getCount(), is(equalTo(SIMPLE_TIMER_COUNT.get())));
@@ -108,8 +108,8 @@ public class SimplyTimedMethodBeanLookupTest {
         // Get a contextual instance of the bean
         SimplyTimedMethodBean1 bean = instance.get();
 
-        assertThat("SimplyTimed is not registered correctly", registry.getSimpleTimers(), hasKey(simpleTimerMID));
-        SimpleTimer simpleTimer = registry.getSimpleTimers().get(simpleTimerMID);
+        SimpleTimer simpleTimer = registry.getSimpleTimer(simpleTimerMID);
+        assertThat("SimplyTimed is not registered correctly", simpleTimer, notNullValue());
 
         // Call the simplyTimed method and assert it's been simplyTimed
         bean.simplyTimedMethod();
@@ -125,8 +125,8 @@ public class SimplyTimedMethodBeanLookupTest {
         // Get a contextual instance of the bean
         SimplyTimedMethodBean1 bean = instance.get();
 
-        assertThat("SimplyTimed is not registered correctly", registry.getSimpleTimers(), hasKey(simpleTimerMID));
-        SimpleTimer simpleTimer = registry.getSimpleTimers().get(simpleTimerMID);
+        SimpleTimer simpleTimer = registry.getSimpleTimer(simpleTimerMID);
+        assertThat("SimplyTimed is not registered correctly", simpleTimer, notNullValue());
 
         // Remove the simpleTimer from metrics registry
         registry.remove(simpleTimerMID);

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/SimplyTimedMethodBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/SimplyTimedMethodBeanTest.java
@@ -24,9 +24,9 @@
 package org.eclipse.microprofile.metrics.tck.metrics;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
@@ -55,7 +55,7 @@ public class SimplyTimedMethodBeanTest {
     private final static String SIMPLE_TIMER_NAME = MetricRegistry.name(SimplyTimedMethodBean2.class, "simplyTimedMethod");
 
     private static MetricID simpleTimerMID;
-    
+
     private final static AtomicLong SIMPLE_TIMER_COUNT = new AtomicLong();
 
     @Deployment
@@ -81,29 +81,29 @@ public class SimplyTimedMethodBeanTest {
          * Running a managed arquillian container will result
          * with the MetricID being created in a client process
          * that does not contain the MPConfig impl.
-         * 
-         * This will cause client instantiated MetricIDs to 
+         *
+         * This will cause client instantiated MetricIDs to
          * throw an exception. (i.e the global MetricIDs)
          */
         simpleTimerMID = new MetricID(SIMPLE_TIMER_NAME);
     }
-    
+
     @Test
     @InSequence(1)
     public void simplyTimedMethodNotCalledYet() {
-        assertThat("SimpleTimer is not registered correctly", registry.getSimpleTimers(), hasKey(simpleTimerMID));
-        SimpleTimer simpleTimer = registry.getSimpleTimers().get(simpleTimerMID);
+        SimpleTimer simpleTimer = registry.getSimpleTimer(simpleTimerMID);
+        assertThat("SimpleTimer is not registered correctly", simpleTimer, notNullValue());
 
         // Make sure that the simpleTimer hasn't been called yet
         assertThat("SimpleTimer count is incorrect", simpleTimer.getCount(), is(equalTo(SIMPLE_TIMER_COUNT.get())));
-        
+
     }
 
     @Test
     @InSequence(2)
     public void callSimplyTimedMethodOnce() throws InterruptedException {
-        assertThat("SimpleTimer is not registered correctly", registry.getSimpleTimers(), hasKey(simpleTimerMID));
-        SimpleTimer simpleTimer = registry.getSimpleTimers().get(simpleTimerMID);
+        SimpleTimer simpleTimer = registry.getSimpleTimer(simpleTimerMID);
+        assertThat("SimpleTimer is not registered correctly", simpleTimer, notNullValue());
 
         // Call the simplyTimed method and assert it's been simplyTimed
         bean.simplyTimedMethod();
@@ -116,8 +116,8 @@ public class SimplyTimedMethodBeanTest {
     @Test
     @InSequence(3)
     public void removeSimpleTimerFromRegistry() throws InterruptedException {
-        assertThat("SimpleTimer is not registered correctly", registry.getSimpleTimers(), hasKey(simpleTimerMID));
-        SimpleTimer simpleTimer = registry.getSimpleTimers().get(simpleTimerMID);
+        SimpleTimer simpleTimer = registry.getSimpleTimer(simpleTimerMID);
+        assertThat("SimpleTimer is not registered correctly", simpleTimer, notNullValue());
 
         // Remove the simpleTimer from metrics registry
         registry.remove(simpleTimerMID);

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/TimedClassBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/TimedClassBeanTest.java
@@ -119,7 +119,7 @@ public class TimedClassBeanTest {
     public void timedMethodsNotCalledYet() {
         assertThat("Timers are not registered correctly", registry.getTimers().keySet(), is(equalTo(timerMIDsIncludingToString)));
         
-        assertThat("Constructor timer count is incorrect", registry.getTimers().get(constructorMID).getCount(), is(equalTo(1L)));
+        assertThat("Constructor timer count is incorrect", registry.getTimer(constructorMID).getCount(), is(equalTo(1L)));
 
         // Make sure that the method timers haven't been timed yet
         assertThat("Method timer counts are incorrect", registry.getTimers(METHOD_TIMERS).values(),
@@ -131,7 +131,7 @@ public class TimedClassBeanTest {
     public void callTimedMethodsOnce() {
         assertThat("Timers are not registered correctly", registry.getTimers().keySet(), is(equalTo(timerMIDsIncludingToString)));
         
-        assertThat("Constructor timer count is incorrect", registry.getTimers().get(constructorMID).getCount(), is(equalTo(1L)));
+        assertThat("Constructor timer count is incorrect", registry.getTimer(constructorMID).getCount(), is(equalTo(1L)));
 
         // Call the timed methods and assert they've been timed
         bean.timedMethodOne();

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/TimedConstructorBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/TimedConstructorBeanTest.java
@@ -16,8 +16,8 @@
 package org.eclipse.microprofile.metrics.tck.metrics;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
 import javax.enterprise.inject.Instance;
@@ -90,8 +90,8 @@ public class TimedConstructorBeanTest {
             instance.get();
         }
 
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(timerMID));
-        Timer timer = registry.getTimers().get(timerMID);
+        Timer timer = registry.getTimer(timerMID);
+        assertThat("Timer is not registered correctly", timer, notNullValue());
 
         // Make sure that the timer has been called
         assertThat("Timer count is incorrect", timer.getCount(), is(equalTo(count)));

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/TimedMethodBeanLookupTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/TimedMethodBeanLookupTest.java
@@ -16,9 +16,9 @@
 package org.eclipse.microprofile.metrics.tck.metrics;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
@@ -87,8 +87,8 @@ public class TimedMethodBeanLookupTest {
         // Get a contextual instance of the bean
         TimedMethodBean1 bean = instance.get();
 
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(timerMID));
-        Timer timer = registry.getTimers().get(timerMID);
+        Timer timer = registry.getTimer(timerMID);
+        assertThat("Timer is not registered correctly", timer, notNullValue());
 
         // Make sure that the timer hasn't been called yet
         assertThat("Timer count is incorrect", timer.getCount(), is(equalTo(TIMER_COUNT.get())));
@@ -100,8 +100,8 @@ public class TimedMethodBeanLookupTest {
         // Get a contextual instance of the bean
         TimedMethodBean1 bean = instance.get();
 
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(timerMID));
-        Timer timer = registry.getTimers().get(timerMID);
+        Timer timer = registry.getTimer(timerMID);
+        assertThat("Timer is not registered correctly", timer, notNullValue());
 
         // Call the timed method and assert it's been timed
         bean.timedMethod();
@@ -117,8 +117,8 @@ public class TimedMethodBeanLookupTest {
         // Get a contextual instance of the bean
         TimedMethodBean1 bean = instance.get();
 
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(timerMID));
-        Timer timer = registry.getTimers().get(timerMID);
+        Timer timer = registry.getTimer(timerMID);
+        assertThat("Timer is not registered correctly", timer, notNullValue());
 
         // Remove the timer from metrics registry
         registry.remove(timerMID);

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/TimedMethodBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/TimedMethodBeanTest.java
@@ -16,9 +16,9 @@
 package org.eclipse.microprofile.metrics.tck.metrics;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
@@ -47,7 +47,7 @@ public class TimedMethodBeanTest {
     private final static String TIMER_NAME = MetricRegistry.name(TimedMethodBean2.class, "timedMethod");
 
     private static MetricID timerMID;
-    
+
     private final static AtomicLong TIMER_COUNT = new AtomicLong();
 
     @Deployment
@@ -73,18 +73,18 @@ public class TimedMethodBeanTest {
          * Running a managed arquillian container will result
          * with the MetricID being created in a client process
          * that does not contain the MPConfig impl.
-         * 
-         * This will cause client instantiated MetricIDs to 
+         *
+         * This will cause client instantiated MetricIDs to
          * throw an exception. (i.e the global MetricIDs)
          */
         timerMID = new MetricID(TIMER_NAME);
     }
-    
+
     @Test
     @InSequence(1)
     public void timedMethodNotCalledYet() {
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(timerMID));
-        Timer timer = registry.getTimers().get(timerMID);
+        Timer timer = registry.getTimer(timerMID);
+        assertThat("Timer is not registered correctly", timer, notNullValue());
 
         // Make sure that the timer hasn't been called yet
         assertThat("Timer count is incorrect", timer.getCount(), is(equalTo(TIMER_COUNT.get())));
@@ -93,8 +93,8 @@ public class TimedMethodBeanTest {
     @Test
     @InSequence(2)
     public void callTimedMethodOnce() throws InterruptedException {
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(timerMID));
-        Timer timer = registry.getTimers().get(timerMID);
+        Timer timer = registry.getTimer(timerMID);
+        assertThat("Timer is not registered correctly", timer, notNullValue());
 
         // Call the timed method and assert it's been timed
         bean.timedMethod();
@@ -107,8 +107,8 @@ public class TimedMethodBeanTest {
     @Test
     @InSequence(3)
     public void removeTimerFromRegistry() throws InterruptedException {
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(timerMID));
-        Timer timer = registry.getTimers().get(timerMID);
+        Timer timer = registry.getTimer(timerMID);
+        assertThat("Timer is not registered correctly", timer, notNullValue());
 
         // Remove the timer from metrics registry
         registry.remove(timerMID);

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/TimerFieldBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/TimerFieldBeanTest.java
@@ -65,7 +65,7 @@ public class TimerFieldBeanTest {
 
     @Test
     public void timerFieldsWithDefaultNamingConvention() {
-        assertThat("Timers are not registered correctly", registry.getMetrics().keySet(), 
+        assertThat("Timers are not registered correctly", registry.getMetricIDs(), 
             is(equalTo(MetricsUtil.createMetricIDs(metricNames()))));
     }
 }

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/tags/CounterFieldTagBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/tags/CounterFieldTagBeanTest.java
@@ -24,6 +24,7 @@ package org.eclipse.microprofile.metrics.tck.tags;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
 import javax.inject.Inject;
@@ -32,6 +33,7 @@ import org.eclipse.microprofile.metrics.Counter;
 import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.Tag;
+import org.hamcrest.Matchers;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
@@ -92,23 +94,22 @@ public class CounterFieldTagBeanTest {
     @Test
     @InSequence(1)
     public void counterTagFieldsRegistered() {      
-        
-        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(counterMID));
-        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(counterTwoMID));
-        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(counterThreeMID));
+        assertThat("Counter is not registered correctly", registry.getCounter(counterMID), notNullValue());
+        assertThat("Counter is not registered correctly", registry.getCounter(counterTwoMID), notNullValue());
+        assertThat("Counter is not registered correctly", registry.getCounter(counterThreeMID), notNullValue());
     }
 
     @Test
     @InSequence(2)
     public void incrementCounterTagFields() {
-        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(counterMID));
-        Counter counterOne = registry.getCounters().get(counterMID);
-        
-        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(counterTwoMID));
-        Counter counterTwo = registry.getCounters().get(counterTwoMID);
-        
-        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(counterThreeMID));
-        Counter counterThree = registry.getCounters().get(counterThreeMID);
+        Counter counterOne = registry.getCounter(counterMID);
+        assertThat("Counter is not registered correctly", counterOne, notNullValue());
+
+        Counter counterTwo = registry.getCounter(counterTwoMID);
+        assertThat("Counter is not registered correctly", counterTwo, notNullValue());
+
+        Counter counterThree = registry.getCounter(counterThreeMID);
+        assertThat("Counter is not registered correctly", counterThree, notNullValue());
 
         // Call the increment method and assert the counter is up-to-date
         long value = Math.round(Math.random() * Long.MAX_VALUE);

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/tags/CounterFieldTagBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/tags/CounterFieldTagBeanTest.java
@@ -22,7 +22,6 @@
 package org.eclipse.microprofile.metrics.tck.tags;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
@@ -33,7 +32,6 @@ import org.eclipse.microprofile.metrics.Counter;
 import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.Tag;
-import org.hamcrest.Matchers;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
@@ -49,13 +47,13 @@ import org.junit.runner.RunWith;
 public class CounterFieldTagBeanTest {
 
     private final static String COUNTER_NAME = MetricRegistry.name(CounterFieldTagBean.class, "counterName");
-    
+
     private final static Tag NUMBER_TWO_TAG = new Tag("number", "two");
     private final static Tag NUMBER_THREE_TAG = new Tag("number", "three");
-        
-    private final static Tag COLOUR_RED_TAG = new Tag("colour", "red"); 
-    private final static Tag COLOUR_BLUE_TAG = new Tag("colour", "blue"); 
-        
+
+    private final static Tag COLOUR_RED_TAG = new Tag("colour", "red");
+    private final static Tag COLOUR_BLUE_TAG = new Tag("colour", "blue");
+
     private static MetricID counterMID ;
     private static MetricID counterTwoMID;
     private static MetricID counterThreeMID;
@@ -82,18 +80,18 @@ public class CounterFieldTagBeanTest {
          * Running a managed arquillian container will result
          * with the MetricID being created in a client process
          * that does not contain the MPConfig impl.
-         * 
-         * This will cause client instantiated MetricIDs to 
+         *
+         * This will cause client instantiated MetricIDs to
          * throw an exception. (i.e the global MetricIDs)
          */
         counterMID = new MetricID(COUNTER_NAME);
         counterTwoMID = new MetricID(COUNTER_NAME, NUMBER_TWO_TAG, COLOUR_RED_TAG);
         counterThreeMID = new MetricID(COUNTER_NAME, NUMBER_THREE_TAG, COLOUR_BLUE_TAG);
     }
-    
+
     @Test
     @InSequence(1)
-    public void counterTagFieldsRegistered() {      
+    public void counterTagFieldsRegistered() {
         assertThat("Counter is not registered correctly", registry.getCounter(counterMID), notNullValue());
         assertThat("Counter is not registered correctly", registry.getCounter(counterTwoMID), notNullValue());
         assertThat("Counter is not registered correctly", registry.getCounter(counterThreeMID), notNullValue());
@@ -114,13 +112,13 @@ public class CounterFieldTagBeanTest {
         // Call the increment method and assert the counter is up-to-date
         long value = Math.round(Math.random() * Long.MAX_VALUE);
         bean.incrementOne(value);
-        
+
         long valueTwo = Math.round(Math.random() * Long.MAX_VALUE);
         bean.incrementTwo(valueTwo);
-        
+
         long valueThree = Math.round(Math.random() * Long.MAX_VALUE);
         bean.incrementThree(valueThree);
-        
+
         assertThat("Counter value is incorrect", counterOne.getCount(), is(equalTo(value)));
         assertThat("Counter value is incorrect", counterTwo.getCount(), is(equalTo(valueTwo)));
         assertThat("Counter value is incorrect", counterThree.getCount(), is(equalTo(valueThree)));

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/tags/GaugeTagMethodBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/tags/GaugeTagMethodBeanTest.java
@@ -22,8 +22,8 @@
 package org.eclipse.microprofile.metrics.tck.tags;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
 import javax.inject.Inject;
@@ -91,15 +91,16 @@ public class GaugeTagMethodBeanTest {
     @Test
     @InSequence(1)
     public void gaugeTagCalledWithDefaultValue() {
-        assertThat("Gauge is not registered correctly", registry.getGauges(), hasKey(gaugeOneMID));
-        assertThat("Gauge is not registered correctly", registry.getGauges(), hasKey(gaugeTwoMID));
-        
-        @SuppressWarnings("unchecked")
-        Gauge<Long> gaugeOne = registry.getGauges().get(gaugeOneMID);
 
         @SuppressWarnings("unchecked")
-        Gauge<Long> gaugeTwo = registry.getGauges().get(gaugeTwoMID);
-        
+        Gauge<Long> gaugeOne = (Gauge<Long>) registry.getGauge(gaugeOneMID);
+
+        @SuppressWarnings("unchecked")
+        Gauge<Long> gaugeTwo = (Gauge<Long>) registry.getGauge(gaugeTwoMID);
+
+        assertThat("Gauge is not registered correctly", gaugeOne, notNullValue());
+        assertThat("Gauge is not registered correctly", gaugeTwo, notNullValue());
+
         // Make sure that the gauge has the expected value
         assertThat("Gauge value is incorrect", gaugeOne.getValue(), is(equalTo(0L)));
         assertThat("Gauge value is incorrect", gaugeTwo.getValue(), is(equalTo(0L)));
@@ -108,14 +109,12 @@ public class GaugeTagMethodBeanTest {
     @Test
     @InSequence(2)
     public void callGaugeTagAfterSetterCall() {
-        assertThat("Gauge is not registered correctly", registry.getGauges(), hasKey(gaugeOneMID));
-        assertThat("Gauge is not registered correctly", registry.getGauges(), hasKey(gaugeTwoMID));
-        
         @SuppressWarnings("unchecked")
-        Gauge<Long> gaugeOne = registry.getGauges().get(gaugeOneMID);
-
+        Gauge<Long> gaugeOne = (Gauge<Long>) registry.getGauge(gaugeOneMID);
         @SuppressWarnings("unchecked")
-        Gauge<Long> gaugeTwo = registry.getGauges().get(gaugeTwoMID);
+        Gauge<Long> gaugeTwo = (Gauge<Long>) registry.getGauge(gaugeTwoMID);
+        assertThat("Gauge is not registered correctly", gaugeOne, notNullValue());
+        assertThat("Gauge is not registered correctly", gaugeTwo, notNullValue());
 
         // Call the setter method and assert the gauge is up-to-date
         long value = Math.round(Math.random() * Long.MAX_VALUE);

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/tags/HistogramTagFieldBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/tags/HistogramTagFieldBeanTest.java
@@ -22,8 +22,8 @@
 package org.eclipse.microprofile.metrics.tck.tags;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
 import javax.inject.Inject;
@@ -87,18 +87,18 @@ public class HistogramTagFieldBeanTest {
     @Test
     @InSequence(1)
     public void histogramTagFieldRegistered() {
-        assertThat("Histogram is not registered correctly", registry.getHistograms(), hasKey(histogramOneMID));
-        assertThat("Histogram is not registered correctly", registry.getHistograms(), hasKey(histogramTwoMID));
+        assertThat("Histogram is not registered correctly", registry.getHistogram(histogramOneMID), notNullValue());
+        assertThat("Histogram is not registered correctly", registry.getHistogram(histogramTwoMID), notNullValue());
     }
     
     @Test
     @InSequence(2)
     public void updateHistogramTagField() {
-        assertThat("Histogram is not registered correctly", registry.getHistograms(), hasKey(histogramOneMID));
-        assertThat("Histogram is not registered correctly", registry.getHistograms(), hasKey(histogramTwoMID));
+        Histogram histogramOne = registry.getHistogram(histogramOneMID);
+        Histogram histogramTwo = registry.getHistogram(histogramTwoMID);
+        assertThat("Histogram is not registered correctly", histogramOne, notNullValue());
+        assertThat("Histogram is not registered correctly", histogramTwo, notNullValue());
         
-        Histogram histogramOne = registry.getHistograms().get(histogramOneMID);
-        Histogram histogramTwo = registry.getHistograms().get(histogramTwoMID);
         
         // Call the update method and assert the histogram is up-to-date
         long value = Math.round(Math.random() * Long.MAX_VALUE);

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/tags/MeteredTagMethodBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/tags/MeteredTagMethodBeanTest.java
@@ -21,7 +21,7 @@
  **********************************************************************/
 package org.eclipse.microprofile.metrics.tck.tags;
 
-import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
 import javax.inject.Inject;
@@ -85,7 +85,7 @@ public class MeteredTagMethodBeanTest {
     @Test
     @InSequence(1)
     public void meteredTagMethodRegistered() {
-        assertThat("Meter is not registered correctly", registry.getMeters(), hasKey(meterOneMID));
-        assertThat("Meter is not registered correctly", registry.getMeters(), hasKey(meterTwoMID));
+        assertThat("Meter is not registered correctly", registry.getMeter(meterOneMID), notNullValue());
+        assertThat("Meter is not registered correctly", registry.getMeter(meterTwoMID), notNullValue());
     }
 }

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/tags/SimplerTimerTagFieldBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/tags/SimplerTimerTagFieldBeanTest.java
@@ -23,7 +23,7 @@ package org.eclipse.microprofile.metrics.tck.tags;
 
 import javax.inject.Inject;
 
-import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.notNullValue;
 
 import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
@@ -85,7 +85,7 @@ public class SimplerTimerTagFieldBeanTest {
     
     @Test
     public void simpleTimersTagFieldRegistered() {
-        assertThat("SimpleTimer is not registered correctly", registry.getSimpleTimers(), hasKey(simpleTimerOneMID));
-        assertThat("SimpleTimer is not registered correctly", registry.getSimpleTimers(), hasKey(simpleTimerTwoMID));
+        assertThat("SimpleTimer is not registered correctly", registry.getSimpleTimer(simpleTimerOneMID), notNullValue());
+        assertThat("SimpleTimer is not registered correctly", registry.getSimpleTimer(simpleTimerTwoMID), notNullValue());
     }
 }

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/tags/TagsTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/tags/TagsTest.java
@@ -24,6 +24,7 @@ package org.eclipse.microprofile.metrics.tck.tags;
 
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasValue;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
 import javax.inject.Inject;
@@ -90,7 +91,7 @@ public class TagsTest {
         MetricID counterMID = new MetricID(counterName, tagColourTwo);
         
         //check the metric is registered
-        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(counterMID));
+        assertThat("Counter is not registered correctly", registry.getCounter(counterMID), notNullValue());
     }
     
     @Test
@@ -112,9 +113,9 @@ public class TagsTest {
         MetricID counterBlueMID = new MetricID(counterName, tagEarth,tagBlue);
         
         //check multi-dimensional metrics are registered
-        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(counterColourMID));
-        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(counterRedMID));
-        assertThat("Counter is not registered correctly", registry.getCounters(), hasKey(counterBlueMID));
+        assertThat("Counter is not registered correctly", registry.getCounter(counterColourMID), notNullValue());
+        assertThat("Counter is not registered correctly", registry.getCounter(counterRedMID), notNullValue());
+        assertThat("Counter is not registered correctly", registry.getCounter(counterBlueMID), notNullValue());
     }
     
     @Test
@@ -136,9 +137,9 @@ public class TagsTest {
         MetricID meterBlueMID = new MetricID(meterName, tagEarth,tagBlue);
         
         //check multi-dimensional metrics are registered
-        assertThat("Meter is not registered correctly", registry.getMeters(), hasKey(meterColourMID));
-        assertThat("Meter is not registered correctly", registry.getMeters(), hasKey(meterRedMID));
-        assertThat("Meter is not registered correctly", registry.getMeters(), hasKey(meterBlueMID));
+        assertThat("Meter is not registered correctly", registry.getMeter(meterColourMID), notNullValue());
+        assertThat("Meter is not registered correctly", registry.getMeter(meterRedMID), notNullValue());
+        assertThat("Meter is not registered correctly", registry.getMeter(meterBlueMID), notNullValue());
     }
     
     @Test
@@ -160,9 +161,9 @@ public class TagsTest {
         MetricID timerBlueMID = new MetricID(timerName, tagEarth,tagBlue);
         
         //check multi-dimensional metrics are registered
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(timerColourMID));
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(timerRedMID));
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(timerBlueMID));
+        assertThat("Timer is not registered correctly", registry.getTimer(timerColourMID), notNullValue());
+        assertThat("Timer is not registered correctly", registry.getTimer(timerRedMID), notNullValue());
+        assertThat("Timer is not registered correctly", registry.getTimer(timerBlueMID), notNullValue());
     }
     
     @Test
@@ -184,9 +185,9 @@ public class TagsTest {
         MetricID histogramBlueMID = new MetricID(histogramName, tagEarth,tagBlue);
         
         //check multi-dimensional metrics are registered
-        assertThat("Histogram is not registered correctly", registry.getHistograms(), hasKey(histogramColourMID));
-        assertThat("Histogram is not registered correctly", registry.getHistograms(), hasKey(histogramRedMID));
-        assertThat("Histogram is not registered correctly", registry.getHistograms(), hasKey(histogramBlueMID));
+        assertThat("Histogram is not registered correctly", registry.getHistogram(histogramColourMID), notNullValue());
+        assertThat("Histogram is not registered correctly", registry.getHistogram(histogramRedMID), notNullValue());
+        assertThat("Histogram is not registered correctly", registry.getHistogram(histogramBlueMID), notNullValue());
     }
     
     @Test
@@ -208,9 +209,9 @@ public class TagsTest {
         MetricID simpleTimerBlueMID = new MetricID(simpleTimerName, tagEarth,tagBlue);
         
         //check multi-dimensional metrics are registered
-        assertThat("SimpleTimer is not registered correctly", registry.getSimpleTimers(), hasKey(simpleTimerColourMID));
-        assertThat("SimpleTimer is not registered correctly", registry.getSimpleTimers(), hasKey(simpleTimerRedMID));
-        assertThat("SimpleTimer is not registered correctly", registry.getSimpleTimers(), hasKey(simpleTimerBlueMID));
+        assertThat("SimpleTimer is not registered correctly", registry.getSimpleTimer(simpleTimerColourMID), notNullValue());
+        assertThat("SimpleTimer is not registered correctly", registry.getSimpleTimer(simpleTimerRedMID), notNullValue());
+        assertThat("SimpleTimer is not registered correctly", registry.getSimpleTimer(simpleTimerBlueMID), notNullValue());
     }
     
     @Test
@@ -232,8 +233,8 @@ public class TagsTest {
         MetricID concurrentGaugeBlueMID = new MetricID(concurrentGaugeName, tagEarth,tagBlue);
         
         //check multi-dimensional metrics are registered
-        assertThat("ConcurrentGauge is not registered correctly", registry.getConcurrentGauges(), hasKey(concurrentGaugeColourMID));
-        assertThat("ConcurrentGauge is not registered correctly", registry.getConcurrentGauges(), hasKey(concurrentGaugeRedMID));
-        assertThat("ConcurrentGauge is not registered correctly", registry.getConcurrentGauges(), hasKey(concurrentGaugeBlueMID));
+        assertThat("ConcurrentGauge is not registered correctly", registry.getConcurrentGauge(concurrentGaugeColourMID), notNullValue());
+        assertThat("ConcurrentGauge is not registered correctly", registry.getConcurrentGauge(concurrentGaugeRedMID), notNullValue());
+        assertThat("ConcurrentGauge is not registered correctly", registry.getConcurrentGauge(concurrentGaugeBlueMID), notNullValue());
     }
 }

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/tags/TimedTagMethodBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/tags/TimedTagMethodBeanTest.java
@@ -21,7 +21,7 @@
  **********************************************************************/
 package org.eclipse.microprofile.metrics.tck.tags;
 
-import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
 import javax.inject.Inject;
@@ -85,8 +85,8 @@ public class TimedTagMethodBeanTest {
     @Test
     @InSequence(1)
     public void timedTagMethodRegistered() {
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(timerOneMID));
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(timerTwoMID));
+        assertThat("Timer is not registered correctly", registry.getTimer(timerOneMID), notNullValue());
+        assertThat("Timer is not registered correctly", registry.getTimer(timerTwoMID), notNullValue());
     }
 
 

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/tags/TimerTagFieldBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/tags/TimerTagFieldBeanTest.java
@@ -23,7 +23,7 @@ package org.eclipse.microprofile.metrics.tck.tags;
 
 import javax.inject.Inject;
 
-import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.notNullValue;
 
 import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
@@ -85,7 +85,7 @@ public class TimerTagFieldBeanTest {
     
     @Test
     public void timersTagFieldRegistered() {
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(timerOneMID));
-        assertThat("Timer is not registered correctly", registry.getTimers(), hasKey(timerTwoMID));
+        assertThat("Timer is not registered correctly", registry.getTimer(timerOneMID), notNullValue());
+        assertThat("Timer is not registered correctly", registry.getTimer(timerTwoMID), notNullValue());
     }
 }

--- a/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MetricAppBean.java
+++ b/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MetricAppBean.java
@@ -207,12 +207,11 @@ public class MetricAppBean {
     public void gaugeMe() {
 
         @SuppressWarnings("unchecked")
-        Gauge<Long> gauge = metrics.getGauges().get(new MetricID("metricTest.test1.gauge"));
+        Gauge<Long> gauge = (Gauge<Long>) metrics.getGauge(new MetricID("metricTest.test1.gauge"));
         if (gauge == null) {
             gauge = () -> {
                 return 19L;
             };
-
 
             Metadata metadata = Metadata.builder().withName("metricTest.test1.gauge")
                     .withType(MetricType.GAUGE).withUnit(MetricUnits.GIGABYTES).build();


### PR DESCRIPTION
In response to #543 this PR adds methods to `MetricRegistry` that allow to favour key based lookup over accessing a map first and resolving the target instance from the returned map. 

Having to use a map is considered an anti-pattern as in many cases the returned maps are either views or data structures computed on demand. This either taxes implementation complexity (views) or runtime resources (computed maps) unnecessarily and it is somewhat awkward to use as well.

This PR adds to `MetricRegistry`:
* a general key based `Metric` lookup: `Metric getMetric(MetricID metricID);`
* a generic single type key based lookup: `default <T extends Metric> T getMetric(MetricID metricID, Class<T> asType)`
* implements all existing single type getters as `default` method of the generic single type lookup method
* a name based lookup for `Metadata`: `Metadata getMetadata(String name);`
* a _get or register_ method for each type that accepts `MetricID` as key (e.g. `counter(MetricID)`)
* implements all existing name and name + tags variants as `default` methods of the one added accepting `MetricID`
* a _get_ (or `null`) method for each type that accepts `MetricID` as key (e.g. `getCounter(MetricID)`)
* a multi type filter lookup `SortedMap<MetricID, Metric> getMetrics(MetricFilter filter);`
* a generic single type filter lookup `default <T extends Metric> SortedMap<MetricID, T> getMetrics(Class<T> ofType, MetricFilter filter)`
* implements all existing `MetricFilter` methods as `default` methods using the generic single type filter lookup

Notably a `Gauge<?> gauge(MetricID metricID, Gauge<?> gauge);` method was added that allows to lookup or create a `Gauge` as an _atomic_ (thread-safe) operation of the registry.
No variant with `Metadata` was added for now. 

In addition the existing methods `getMetrics()` and `getMetadata()` were marked deprecated.

Tests have been adopted to use the new methods where preferable. This also confirmed that `getMetrics()` and `getMetadata()` should not exist. There are no longer used by the TCK.

The same is largely true for methods like `getCounters()` that were mostly used to do `getCounter(MethodID)` in form of `getCounters().get(MetricID)` and so forth.

`MetricRegistry` has been changed to an `interface` and `default` methods have been used to show how the API can benefit from the use without providing implementations for methods that should be implemented based on the internal data organisation. Mapping `String` name or `String` name and `Tag[]` to `MetricID` can only be done correct in one way. There is no value in duplicating this logic. 
From an implementation standpoint the same is true for all methods accepting a `MetricFilter`. As the implementation cannot know the logic of the provided filter there is little room for an implementation to optimise this wherefore it is unlikely that an implementation can do better than the `default` methods provided. As for the various ways of providing a `MetricID` the family of methods accepting a `MetricFilter` is more a convenience feature of the API for the user than an opportunity for an implementation to optimise. 
