### PR TITLE
Some corrections for spec inconsistencies and REST data patterns

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/metrics/MetricUnits.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/MetricUnits.java
@@ -40,7 +40,7 @@ public final class MetricUnits {
     public static final String BITS = "bits";
     /** 1000 {@link #BITS} */
     public static final String KILOBITS = "kilobits";
-    /** 1000 {@link #KIBIBITS} */
+    /** 1000 {@link #KILOBITS} */
     public static final String MEGABITS = "megabits";
     /** 1000 {@link #MEGABITS} */
     public static final String GIGABITS = "gigabits";

--- a/spec/src/main/asciidoc/rest-endpoints.adoc
+++ b/spec/src/main/asciidoc/rest-endpoints.adoc
@@ -251,7 +251,7 @@ The JSON node is named `<metric-name>`. The JSON leafs are named `<key>[';'<tag-
 ----
 {
   "daily_value_changes": {
-    "count":'2,
+    "count": 2,
     "min": -1624,
     "max": 26,
     "mean": -799.0,

--- a/spec/src/main/asciidoc/rest-endpoints.adoc
+++ b/spec/src/main/asciidoc/rest-endpoints.adoc
@@ -43,19 +43,19 @@ For example:
 [source, json]
 ----
 {
- "carsCounter;colour=red" : 0,
- "carsCounter;colour=blue;car=sedan" : 0,
+ "carsCounter;colour=red": 0,
+ "carsCounter;car=sedan;colour=blue": 0,
  "carsMeter": {
-    "count;colour=red" : 0,
-    "meanRate;colour=red" : 0,
-    "oneMinRate;colour=red" : 0,
-    "fiveMinRate;colour=red" : 0,
-    "fifteenMinRate;colour=red" : 0,
-    "count;colour=blue" : 0,
-    "meanRate;colour=blue" : 0,
-    "oneMinRate;colour=blue" : 0,
-    "fiveMinRate;colour=blue" : 0,
-    "fifteenMinRate;colour=blue" : 0
+    "count;colour=red": 0,
+    "meanRate;colour=red": 0,
+    "oneMinRate;colour=red": 0,
+    "fiveMinRate;colour=red": 0,
+    "fifteenMinRate;colour=red": 0,
+    "count;colour=blue": 0,
+    "meanRate;colour=blue": 0,
+    "oneMinRate;colour=blue": 0,
+    "fiveMinRate;colour=blue": 0,
+    "fifteenMinRate;colour=blue": 0
  }
 }
 ----
@@ -84,11 +84,11 @@ API-objects MAY include one or more metrics as in
 [source, json]
 ----
 {
-  "thread.count" : 33,
-  "thread.max.count" : 47,
-  "memory.maxHeap" : 3817863211,
-  "memory.usedHeap" : 16859081,
-  "memory.committedHeap" : 64703546
+  "thread.count": 33,
+  "thread.max.count": 47,
+  "memory.maxHeap": 3817863211,
+  "memory.usedHeap": 16859081,
+  "memory.committedHeap": 64703546
 }
 ----
 
@@ -110,19 +110,20 @@ In case `/metrics` is requested, then the data for the scopes are wrapped in the
     "hitCount": 45
   },
   "base": {
-     "thread.count" : 33,
-     "thread.max.count" : 47
+     "thread.count": 33,
+     "thread.max.count": 47
   },
   "vendor": {...}
 }
 ----
 
-If there is a scope that contains no metrics, then it can be either present with an empty object 
+If there is a scope that contains no metrics, then it can be either present with an empty object
 as its value, or it can be omitted completely.
-                                        
+
 ==== Gauge JSON Format
 
 The value of the gauge must be equivalent to a call to the instance Gauge's `getValue()`.
+The JSON leaf is named `<metric-name>[';'<tag-name>'='<tag-value>]+` with tags in alphabetical order.
 
 .Example Gauge JSON GET Response
 [source, json]
@@ -130,13 +131,14 @@ The value of the gauge must be equivalent to a call to the instance Gauge's `get
 {
   "responsePercentage": 48.45632,
   "responsePercentage;servlet=two": 26.23654,
-  "responsePercentage;store=webshop;servlet=three": 29.24554
+  "responsePercentage;servlet=three;store=webshop": 29.24554
 }
 ----
 
 ==== Counter JSON Format
 
 The value of the counter must be equivalent to a call to the instance Counter's `getCount()`.
+The JSON leaf is named `<metric-name>[';'<tag-name>'='<tag-value>]+` with tags in alphabetical order.
 
 .Example Counter JSON GET Response
 [source, json]
@@ -144,13 +146,14 @@ The value of the counter must be equivalent to a call to the instance Counter's 
 {
   "hitCount": 45,
   "hitCount;servlet=two": 3,
-  "hitCount;store=webshop;servlet=three": 4
+  "hitCount;servlet=three;store=webshop": 4
 }
 ----
 
 ==== Concurrent Gauge JSON Format
 
 `ConcurrentGauge` is a complex metric type comprised of multiple key/values. The format is specified by the table below.
+The JSON node is named `<metric-name>`. The JSON leafs are named `<key>[';'<tag-name>'='<tag-value>]+` with tags in alphabetical order and keys according to below table.
 
 .JSON mapping for a ConcurrentGauge metric
 [cols="1,4"]
@@ -181,6 +184,7 @@ The value of the counter must be equivalent to a call to the instance Counter's 
 ==== Meter JSON Format
 
 `Meter` is a complex metric type comprised of multiple key/values. The format is specified by the table below.
+The JSON node is named `<metric-name>`. The JSON leafs are named `<key>[';'<tag-name>'='<tag-value>]+` with tags in alphabetical order and keys according to below table.
 
 .JSON mapping for a Meter metric
 [cols="1,4"]
@@ -222,6 +226,7 @@ The value of the counter must be equivalent to a call to the instance Counter's 
 ==== Histogram JSON Format
 
 `Histogram` is a complex metric type comprised of multiple key/values. The format is specified by the table below.
+The JSON node is named `<metric-name>`. The JSON leafs are named `<key>[';'<tag-name>'='<tag-value>]+` with tags in alphabetical order and keys according to below table.
 
 .JSON mapping for a Histogram metric
 [cols="1,4"]
@@ -246,28 +251,28 @@ The value of the counter must be equivalent to a call to the instance Counter's 
 ----
 {
   "daily_value_changes": {
-    "count":2,
-    "min":-1624,
-    "max":26,
-    "mean":-799.0,
-    "stddev":825.0,
-    "p50":26.0,
-    "p75":26.0,
-    "p95":26.0,
-    "p98":26.0,
-    "p99":26.0,
-    "p999":26.0,
-    "count;servlet=two":2,
-    "min;servlet=two":-1624,
-    "max;servlet=two":26,
-    "mean;servlet=two":-799.0,
-    "stddev;servlet=two":825.0,
-    "p50;servlet=two":26.0,
-    "p75;servlet=two":26.0,
-    "p95;servlet=two":26.0,
-    "p98;servlet=two":26.0,
-    "p99;servlet=two":26.0,
-    "p999;servlet=two":26.0
+    "count":'2,
+    "min": -1624,
+    "max": 26,
+    "mean": -799.0,
+    "stddev": 825.0,
+    "p50": 26.0,
+    "p75": 26.0,
+    "p95": 26.0,
+    "p98": 26.0,
+    "p99": 26.0,
+    "p999": 26.0,
+    "count;servlet=two": 2,
+    "min;servlet=two": -1624,
+    "max;servlet=two": 26,
+    "mean;servlet=two": -799.0,
+    "stddev;servlet=two": 825.0,
+    "p50;servlet=two": 26.0,
+    "p75;servlet=two": 26.0,
+    "p95;servlet=two": 26.0,
+    "p98;servlet=two": 26.0,
+    "p99;servlet=two": 26.0,
+    "p999;servlet=two": 26.0
   }
 }
 ----
@@ -276,6 +281,7 @@ The value of the counter must be equivalent to a call to the instance Counter's 
 ==== Timer JSON Format
 
 `Timer` is a complex metric type comprised of multiple key/values. The format is specified by the table below.
+The JSON node is named `<metric-name>`. The JSON leafs are named `<key>[';'<tag-name>'='<tag-value>]+` with tags in alphabetical order and keys according to below table.
 
 .JSON mapping for a Timer metric
 [cols="1,4"]
@@ -305,35 +311,35 @@ The value of the counter must be equivalent to a call to the instance Counter's 
 {
   "responseTime": {
     "count": 29382,
-    "meanRate":12.185627192860734,
+    "meanRate": 12.185627192860734,
     "oneMinRate": 12.563,
     "fiveMinRate": 12.364,
     "fifteenMinRate": 12.126,
-    "min":169916,
-    "max":5608694,
-    "mean":415041.00024926325,
-    "stddev":652907.9633011606,
-    "p50":293324.0,
-    "p75":344914.0,
-    "p95":543647.0,
-    "p98":2706543.0,
-    "p99":5608694.0,
-    "p999":5608694.0,
+    "min": 169916,
+    "max": 5608694,
+    "mean": 415041.00024926325,
+    "stddev": 652907.9633011606,
+    "p50": 293324.0,
+    "p75": 344914.0,
+    "p95": 543647.0,
+    "p98": 2706543.0,
+    "p99": 5608694.0,
+    "p999": 5608694.0,
     "count;servlet=two": 29382,
-    "meanRate;servlet=two":12.185627192860734,
+    "meanRate;servlet=two": 12.185627192860734,
     "oneMinRate;servlet=two": 12.563,
     "fiveMinRate;servlet=two": 12.364,
     "fifteenMinRate;servlet=two": 12.126,
-    "min;servlet=two":169916,
-    "max;servlet=two":5608694,
-    "mean;servlet=two":415041.00024926325,
-    "stddev;servlet=two":652907.9633011606,
-    "p50;servlet=two":293324.0,
-    "p75;servlet=two":344914.0,
-    "p95;servlet=two":543647.0,
-    "p98;servlet=two":2706543.0,
-    "p99;servlet=two":5608694.0,
-    "p999;servlet=two":5608694.0
+    "min;servlet=two": 169916,
+    "max;servlet=two": 5608694,
+    "mean;servlet=two": 415041.00024926325,
+    "stddev;servlet=two": 652907.9633011606,
+    "p50;servlet=two": 293324.0,
+    "p75;servlet=two": 344914.0,
+    "p95;servlet=two": 543647.0,
+    "p98;servlet=two": 2706543.0,
+    "p99;servlet=two": 5608694.0,
+    "p999;servlet=two": 5608694.0
   }
 }
 ----
@@ -341,6 +347,7 @@ The value of the counter must be equivalent to a call to the instance Counter's 
 ==== Simple Timer JSON Format
 
 `Simple Timer` is a complex metric type comprised of multiple key/values. The format is specified by the table below.
+The JSON node is named `<metric-name>`. The JSON leafs are named `<key>[';'<tag-name>'='<tag-value>]+` with tags in alphabetical order and keys according to below table.
 
 .JSON mapping for a Simple Timer metric
 [cols="1,4"]
@@ -366,7 +373,7 @@ The value of the counter must be equivalent to a call to the instance Counter's 
 
 
 Metadata is exposed in a tree-like fashion with sub-trees for the sub-resources mentioned previously.
-Tags from metrics associated with the metric name are also included. The 'tags' attribute is an array of nested arrays which hold tags from different metrics that are associated with the metadata.
+Tags from metrics associated with the metric name are also included. The 'tags' attribute is an array of nested arrays which hold tags from different metrics that are associated with the metadata. Tags in each inner array are in alphabetical order.
 
 Example:
 
@@ -407,8 +414,8 @@ If `GET /metrics/base` exposes multiple values like this:
 ----
 {
   "fooVal;store=webshop": 12345,
-  "barVal;store=webshop;component=backend": 42,
-  "barVal;store=webshop;component=frontend": 63
+  "barVal;component=backend;store=webshop": 42,
+  "barVal;component=frontend;store=webshop": 63
 }
 ----
 
@@ -434,12 +441,12 @@ then `OPTIONS /metrics/base` exposes:
     "type": "gauge",
     "tags": [
       [
-        "store=webshop",
-        "component=backend"
+        "component=backend",
+        "store=webshop"
       ],
       [
-        "store=webshop",
-        "component=frontend"
+        "component=frontend",
+        "store=webshop"
       ]
     ]
   }
@@ -467,11 +474,10 @@ The above json example would look like this in OpenMetrics format
 base_fooVal_seconds{store="webshop"} 12.345  <2>
 # TYPE base_barVal_bytes gauge
 base_barVal_bytes{component="backend", store="webshop"} 42000 <2>
-# TYPE base_barVal_bytes gauge
 base_barVal_bytes{component="frontend", store="webshop"} 63000 <2>
 ----
 <1> The description goes into the HELP line
-<2> Metric names gets the base unit of the family appended with `_` and defined labels. Values are scaled accordingly. See <<OpenMetrics_units>>
+<2> Metric names gets the base unit of the family appended with `_` and defined labels. Values are scaled accordingly. See <<OpenMetrics_units>>. The `TYPE` only occurs once.
 
 ==== Translation rules for metric names
 
@@ -541,6 +547,7 @@ Families and OpenMetrics base units are:
 ==== Gauge OpenMetrics Text Format
 
 The value of the gauge must be the value of `getValue()` with appropriate naming/scaling based on  <<OpenMetrics_units>>
+The OpenMetrics name is composed `<scope>'_'<metric-name>'_'[<unit>'_']`.
 
 .Example OpenMetrics text format for a Gauge in dollars.
 [source, ruby]
@@ -556,6 +563,7 @@ The value of the counter must be the value of `getCount()`.
 The exposed metric name must have a  `_total` suffix.
 The suffix is not appended if the (translated) original metric name already ends in `_total`.
 Counters do not have a suffix for the unit.
+The OpenMetrics name is composed `<scope>'_'<metric-name>'_'<suffix>.
 
 .Example OpenMetrics text format for a Counter.
 [source, ruby]
@@ -580,6 +588,7 @@ application_visitors_total 80
 |===
 
 Concurrent gauges do not have a suffix for the unit.
+The OpenMetrics name is composed `<scope>'_'<metric-name>'_'<suffix>.
 
 .Example OpenMetrics text format for a Concurrent Gauge
 [source, ruby]
@@ -612,6 +621,8 @@ The `# HELP` description line is only required for the `total` value as shown be
 | `fifteen_min_rate_per_second`   | Gauge   | `getFifteenMinuteRate()`            | PER_SECOND
 |===
 
+The OpenMetrics name is composed `<scope>'_'<metric-name>'_'<suffix>.
+
 .Example OpenMetrics text format for a Meter
 [source, ruby]
 ----
@@ -634,6 +645,8 @@ application_requests_fifteen_min_rate_per_second 12.126
 `Histogram` is a complex metric type comprised of multiple key/values. Each key will require a suffix to be appended to the metric name with appropriate naming/scaling based on <<OpenMetrics_units>>.  The format is specified by the table below.
 
 The `# HELP` description line is only required for the `summary` value as shown below.
+The OpenMetrics name is composed `<scope>'_'<metric-name>'_'<suffix>` where `<suffix>` can consist of a fixed part and a unit or just a unit.
+The `quantile` OpenMetrics label is merged with with the metric's tags.
 
 .OpenMetrics text mapping for a Histogram metric
 [cols="2,1,2,1"]
@@ -685,6 +698,8 @@ application_file_sizes_bytes{quantile="0.999"} 31716
 `Timer` is a complex metric type comprised of multiple key/values. Each key will require a suffix to be appended to the metric name. The format is specified by the table below.
 
 The `# HELP` description line is only required for the `summary` value as shown below.
+The OpenMetrics name is composed `<scope>'_'<metric-name>'_'<suffix>`.
+The `quantile` OpenMetrics label is merged with with the metric's tags.
 
 .OpenMetrics text mapping for a Timer metric
 [cols="2,1,2,1"]
@@ -746,6 +761,7 @@ application_response_time_seconds{quantile="0.999"} 0.005608694
 ==== Simple Timer OpenMetrics Text Format
 
 `Simple Timer` is a complex metric type comprised of multiple key/values. Each key will require a suffix to be appended to the metric name. The format is specified by the table below.
+The OpenMetrics name is composed `<scope>'_'<metric-name>'_'<suffix>`.
 
 .OpenMetrics text mapping for a SimpleTimer metric
 [cols="2,1,2,1"]


### PR DESCRIPTION
Some corrections for inconsistencies in the specification:

* `MEGABITS` are 1000 `KILOBITS`
* tags are given in alphabetical order in all examples for REST API
* JSON format uniformly uses no space before the `:` and a space after the colon of a object member
* OpenMetrics `TYPE` is only given once for each OpenMetrics name in the example(s)

Secondly I added patterns to each metric type for JSON and OpenMetrics format that explains in a different way how the overall OpenMetrics name is composed or how the data is made into a JSON tree and member names.