### PR TITLE
More straight forward and uniform optionals for Metadata

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/metrics/DefaultMetadata.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/DefaultMetadata.java
@@ -87,21 +87,21 @@ public class DefaultMetadata implements Metadata {
 
     @Override
     public String getDisplayName() {
-        return getDisplayNameOptional().orElse(name);
+        return displayName().orElse(name);
     }
 
     @Override
-    public Optional<String> getDisplayNameOptional() {
+    public Optional<String> displayName() {
         return Optional.ofNullable(displayName);
     }
 
     @Override
     public String getDescription() {
-        return getDescriptionOptional().orElse("");
+        return description().orElse("");
     }
 
     @Override
-    public Optional<String> getDescriptionOptional() {
+    public Optional<String> description() {
         return Optional.ofNullable(description);
     }
 
@@ -117,11 +117,11 @@ public class DefaultMetadata implements Metadata {
 
     @Override
     public String getUnit() {
-        return getUnitOptional().orElse(MetricUnits.NONE);
+        return unit().orElse(MetricUnits.NONE);
     }
 
     @Override
-    public Optional<String> getUnitOptional() {
+    public Optional<String> unit() {
         return Optional.ofNullable(unit);
     }
 

--- a/api/src/main/java/org/eclipse/microprofile/metrics/DefaultMetadata.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/DefaultMetadata.java
@@ -140,7 +140,7 @@ public class DefaultMetadata implements Metadata {
                 Objects.equals(this.getDisplayName(), that.getDisplayName()) &&
                 Objects.equals(this.getDescription(), that.getDescription()) &&
                 Objects.equals(this.getUnit(), that.getUnit()) &&
-                Objects.equals(this.getTypeRaw(), that.getTypeRaw()) &&
+                Objects.equals(this.getTypeRaw(), that.getTypeRaw());
     }
 
     @Override

--- a/api/src/main/java/org/eclipse/microprofile/metrics/DefaultMetadata.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/DefaultMetadata.java
@@ -1,6 +1,6 @@
 /*
  **********************************************************************
- * Copyright (c) 2018, 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2019, 2020 Contributors to the Eclipse Foundation
  *               2018 Red Hat, Inc. and/or its affiliates
  *               and other contributors as indicated by the @author tags.
  *

--- a/api/src/main/java/org/eclipse/microprofile/metrics/DefaultMetadata.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/DefaultMetadata.java
@@ -87,11 +87,21 @@ public class DefaultMetadata implements Metadata {
 
     @Override
     public String getDisplayName() {
-        return Optional.ofNullable(displayName).orElse(name);
+        return getDisplayNameOptional().orElse(name);
     }
 
     @Override
-    public Optional<String> getDescription() {
+    public Optional<String> getDisplayNameOptional() {
+        return Optional.ofNullable(displayName);
+    }
+
+    @Override
+    public String getDescription() {
+        return getDescriptionOptional().orElse("");
+    }
+
+    @Override
+    public Optional<String> getDescriptionOptional() {
         return Optional.ofNullable(description);
     }
 
@@ -106,7 +116,12 @@ public class DefaultMetadata implements Metadata {
     }
 
     @Override
-    public Optional<String> getUnit() {
+    public String getUnit() {
+        return getUnitOptional().orElse(MetricUnits.NONE);
+    }
+
+    @Override
+    public Optional<String> getUnitOptional() {
         return Optional.ofNullable(unit);
     }
 
@@ -120,16 +135,12 @@ public class DefaultMetadata implements Metadata {
         }
         Metadata that = (Metadata) o;
 
-        //Retrieve the Optional value or set to the "defaults" if empty
-        String thatDescription = (that.getDescription().isPresent()) ? that.getDescription().get() : null;
-        String thatUnit = (that.getUnit().isPresent()) ? that.getUnit().get() : MetricUnits.NONE;
-
-        //Need to use this.getDisplayname() and this.getTypeRaw() for the Optional.orElse() logic
+        //Use getters to compare the effective values
         return Objects.equals(name, that.getName()) &&
                 Objects.equals(this.getDisplayName(), that.getDisplayName()) &&
-                Objects.equals(description, thatDescription) &&
-                Objects.equals(unit, thatUnit) &&
-                Objects.equals(this.getTypeRaw(), that.getTypeRaw());
+                Objects.equals(this.getDescription(), that.getDescription()) &&
+                Objects.equals(this.getUnit(), that.getUnit()) &&
+                Objects.equals(this.getTypeRaw(), that.getTypeRaw()) &&
     }
 
     @Override

--- a/api/src/main/java/org/eclipse/microprofile/metrics/Metadata.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/Metadata.java
@@ -68,7 +68,7 @@ public interface Metadata {
      */
     String getDisplayName();
 
-    Optional<String> getDisplayNameOptional();
+    Optional<String> displayName();
 
     /**
      * Returns the description of the metric if set, otherwise this method returns the empty {@link String}.
@@ -77,7 +77,7 @@ public interface Metadata {
      */
     String getDescription();
 
-    Optional<String> getDescriptionOptional();
+    Optional<String> description();
 
     /**
      * Returns the String representation of the {@link MetricType}.
@@ -101,7 +101,7 @@ public interface Metadata {
      */
     String getUnit();
 
-    Optional<String> getUnitOptional();
+    Optional<String> unit();
 
     /**
      * Returns a new builder

--- a/api/src/main/java/org/eclipse/microprofile/metrics/Metadata.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/Metadata.java
@@ -68,12 +68,16 @@ public interface Metadata {
      */
     String getDisplayName();
 
+    Optional<String> getDisplayNameOptional();
+
     /**
-     * Returns the description of the metric.
+     * Returns the description of the metric if set, otherwise this method returns the empty {@link String}.
      *
      * @return the description
      */
-    Optional<String> getDescription();
+    String getDescription();
+
+    Optional<String> getDescriptionOptional();
 
     /**
      * Returns the String representation of the {@link MetricType}.
@@ -84,13 +88,20 @@ public interface Metadata {
     String getType();
 
     /**
-     * Returns the {@link MetricType} of the metric
+     * Returns the {@link MetricType} of the metric if set, otherwise it returns {@link MetricType#INVALID}
      *
      * @return the {@link MetricType}
      */
     MetricType getTypeRaw();
 
-    Optional<String> getUnit();
+    /**
+     * Returns the unit of this metric if set, otherwise this method returns {@link MetricUnits#NONE}
+     *
+     * @return the unit
+     */
+    String getUnit();
+
+    Optional<String> getUnitOptional();
 
     /**
      * Returns a new builder

--- a/api/src/main/java/org/eclipse/microprofile/metrics/Metadata.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/Metadata.java
@@ -1,6 +1,6 @@
 /*
  **********************************************************************
- * Copyright (c) 2017, 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017, 2018, 2020 Contributors to the Eclipse Foundation
  *               2017, 2018 Red Hat, Inc. and/or its affiliates
  *               and other contributors as indicated by the @author tags.
  *
@@ -50,7 +50,7 @@ import java.util.Optional;
  * </li>
  * </ul>
  *
- * @author hrupp, Raymond Lam
+ * @author hrupp, Raymond Lam, Jan Bernitt
  */
 public interface Metadata {
 

--- a/api/src/main/java/org/eclipse/microprofile/metrics/MetadataBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/MetadataBuilder.java
@@ -27,6 +27,9 @@ import java.util.Objects;
 
 /**
  * The {@link Metadata} builder.
+ *
+ * All values are considered "not present" by default.
+ * Name must be set before {@link #build()} is called.
  */
 public class MetadataBuilder {
 
@@ -58,18 +61,21 @@ public class MetadataBuilder {
      * @param name the name
      * @return the builder instance
      * @throws NullPointerException when name is null
+     * @throws IllegalArgumentException when name is empty
      */
     public MetadataBuilder withName(String name) {
         this.name = Objects.requireNonNull(name, "name is required");
+        if ("".equals(name)) {
+            throw new IllegalArgumentException("Name must not be empty");
+        }
         return this;
     }
 
     /**
-     * Sets the displayName. Does not accept null.
+     * Sets the displayName.
      *
-     * @param displayName the displayName
+     * @param displayName the displayName, empty string is considered as "not present" (null)
      * @return the builder instance
-     * @throws NullPointerException when displayName is null
      */
     public MetadataBuilder withDisplayName(String displayName) {
         this.displayName = "".equals(displayName) ? null : displayName;
@@ -77,11 +83,10 @@ public class MetadataBuilder {
     }
 
     /**
-     * Sets the description. Does not accept null.
+     * Sets the description.
      *
-     * @param description the name
+     * @param description the name, empty string is considered as "not present" (null)
      * @return the builder instance
-     * @throws NullPointerException when description is null
      */
     public MetadataBuilder withDescription(String description) {
         this.description = "".equals(description) ? null : description;
@@ -89,11 +94,10 @@ public class MetadataBuilder {
     }
 
     /**
-     * Sets the type. Does not accept null.
+     * Sets the type.
      *
-     * @param type the type
+     * @param type the type, {@link MetricType#INVALID} is considered as "not present" (null)
      * @return the builder instance
-     * @throws NullPointerException when type is null
      */
     public MetadataBuilder withType(MetricType type) {
         this.type = MetricType.INVALID == type ? null : type;
@@ -101,11 +105,10 @@ public class MetadataBuilder {
     }
 
     /**
-     * Sets the unit. Does not accept null.
+     * Sets the unit.
      *
-     * @param unit the unit
+     * @param unit the unit, {@link MetricUnits#NONE} is considered as "not present" (null)
      * @return the builder instance
-     * @throws NullPointerException when unit is null
      */
     public MetadataBuilder withUnit(String unit) {
         this.unit = MetricUnits.NONE.equals(unit) ? null : unit;

--- a/api/src/main/java/org/eclipse/microprofile/metrics/MetadataBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/MetadataBuilder.java
@@ -43,9 +43,9 @@ public class MetadataBuilder {
     MetadataBuilder(Metadata metadata) {
         this.name = metadata.getName();
         this.type = metadata.getTypeRaw();
-        metadata.getDescriptionOptional().ifPresent(this::withDescription);
-        metadata.getUnitOptional().ifPresent(this::withUnit);
-        metadata.getDisplayNameOptional().ifPresent(this::withDisplayName);
+        metadata.description().ifPresent(this::withDescription);
+        metadata.unit().ifPresent(this::withUnit);
+        metadata.displayName().ifPresent(this::withDisplayName);
     }
 
     public MetadataBuilder() {

--- a/api/src/main/java/org/eclipse/microprofile/metrics/MetadataBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/MetadataBuilder.java
@@ -72,7 +72,7 @@ public class MetadataBuilder {
      * @throws NullPointerException when displayName is null
      */
     public MetadataBuilder withDisplayName(String displayName) {
-        this.displayName = displayName;
+        this.displayName = "".equals(displayName) ? null : displayName;
         return this;
     }
 
@@ -84,7 +84,7 @@ public class MetadataBuilder {
      * @throws NullPointerException when description is null
      */
     public MetadataBuilder withDescription(String description) {
-        this.description = description;
+        this.description = "".equals(description) ? null : description;
         return this;
     }
 
@@ -96,7 +96,7 @@ public class MetadataBuilder {
      * @throws NullPointerException when type is null
      */
     public MetadataBuilder withType(MetricType type) {
-        this.type = type;
+        this.type = MetricType.INVALID == type ? null : type;
         return this;
     }
 
@@ -108,7 +108,7 @@ public class MetadataBuilder {
      * @throws NullPointerException when unit is null
      */
     public MetadataBuilder withUnit(String unit) {
-        this.unit = unit;
+        this.unit = MetricUnits.NONE.equals(unit) ? null : unit;
         return this;
     }
 

--- a/api/src/main/java/org/eclipse/microprofile/metrics/MetadataBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/MetadataBuilder.java
@@ -46,10 +46,9 @@ public class MetadataBuilder {
     MetadataBuilder(Metadata metadata) {
         this.name = metadata.getName();
         this.type = metadata.getTypeRaw();
-        this.displayName = metadata.getDisplayName();
-        metadata.getDescription().ifPresent(this::withDescription);
-        metadata.getUnit().ifPresent(this::withUnit);
-
+        metadata.getDescriptionOptional().ifPresent(this::withDescription);
+        metadata.getUnitOptional().ifPresent(this::withUnit);
+        metadata.getDisplayNameOptional().ifPresent(this::withDisplayName);
     }
 
     public MetadataBuilder() {
@@ -76,17 +75,6 @@ public class MetadataBuilder {
      * @throws NullPointerException when displayName is null
      */
     public MetadataBuilder withDisplayName(String displayName) {
-        this.displayName = Objects.requireNonNull(displayName, "displayName is required");
-        return this;
-    }
-
-    /**
-     * Sets the displayName. Does accept null.
-     *
-     * @param displayName the displayName
-     * @return the builder instance
-     */
-    public MetadataBuilder withOptionalDisplayName(String displayName) {
         this.displayName = displayName;
         return this;
     }
@@ -99,17 +87,6 @@ public class MetadataBuilder {
      * @throws NullPointerException when description is null
      */
     public MetadataBuilder withDescription(String description) {
-        this.description = Objects.requireNonNull(description, "description is required");
-        return this;
-    }
-
-    /**
-     * Sets the description. Does accept null.
-     *
-     * @param description the name
-     * @return the builder instance
-     */
-    public MetadataBuilder withOptionalDescription(String description) {
         this.description = description;
         return this;
     }
@@ -122,18 +99,7 @@ public class MetadataBuilder {
      * @throws NullPointerException when type is null
      */
     public MetadataBuilder withType(MetricType type) {
-        this.type = Objects.requireNonNull(type, "type is required");
-        return this;
-    }
-
-    /**
-     * Sets the type. Does accept null.
-     *
-     * @param type the type
-     * @return the builder instance
-     */
-    public MetadataBuilder withOptionalType(MetricType type) {
-        this.type = type;
+        this.type = type == null ? MetricType.INVALID : type;
         return this;
     }
 
@@ -145,18 +111,7 @@ public class MetadataBuilder {
      * @throws NullPointerException when unit is null
      */
     public MetadataBuilder withUnit(String unit) {
-        this.unit = Objects.requireNonNull(unit, "unit is required");
-        return this;
-    }
-
-    /**
-     * Sets the unit. Does accept null.
-     *
-     * @param unit the unit
-     * @return the builder instance
-     */
-    public MetadataBuilder withOptionalUnit(String unit) {
-        this.unit = unit;
+        this.unit = unit == null ? MetricUnits.NONE : unit;
         return this;
     }
 

--- a/api/src/main/java/org/eclipse/microprofile/metrics/MetadataBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/MetadataBuilder.java
@@ -1,6 +1,6 @@
 /*
  **********************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2020 Contributors to the Eclipse Foundation
  *               2018 Red Hat, Inc. and/or its affiliates
  *               and other contributors as indicated by the @author tags.
  *

--- a/api/src/main/java/org/eclipse/microprofile/metrics/MetadataBuilder.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/MetadataBuilder.java
@@ -27,9 +27,6 @@ import java.util.Objects;
 
 /**
  * The {@link Metadata} builder.
- * This builder has a default value:
- * {@link MetadataBuilder#type} as {@link MetricType#INVALID}
- * {@link MetadataBuilder#unit} as {@link MetricUnits#NONE}
  */
 public class MetadataBuilder {
 
@@ -39,9 +36,9 @@ public class MetadataBuilder {
 
     private String description;
 
-    private MetricType type = MetricType.INVALID;
+    private MetricType type;
 
-    private String unit = MetricUnits.NONE;
+    private String unit;
 
     MetadataBuilder(Metadata metadata) {
         this.name = metadata.getName();
@@ -99,7 +96,7 @@ public class MetadataBuilder {
      * @throws NullPointerException when type is null
      */
     public MetadataBuilder withType(MetricType type) {
-        this.type = type == null ? MetricType.INVALID : type;
+        this.type = type;
         return this;
     }
 
@@ -111,7 +108,7 @@ public class MetadataBuilder {
      * @throws NullPointerException when unit is null
      */
     public MetadataBuilder withUnit(String unit) {
-        this.unit = unit == null ? MetricUnits.NONE : unit;
+        this.unit = unit;
         return this;
     }
 

--- a/spec/src/main/asciidoc/changelog.adoc
+++ b/spec/src/main/asciidoc/changelog.adoc
@@ -58,6 +58,7 @@ Changes marked with icon:bolt[role="red"] are breaking changes relative to previ
 ** Timer class updated  (https://github.com/eclipse/microprofile-metrics/issues/524[#524])
 *** Changed `Timer.update(long duration, java.util.concurrent.TimeUnit)` to `Timer.update(java.time.Duration duration)`
 *** Added `Timer.getElapsedTime()` which returns `java.time.Duration`
+** Removed `MetadataBuilder.withOptional*` methods, the remaining `with*` methods do accept `null` value (considered not present) except `withName` which does not accept `null` or `""`
 
 === Functional Changes
 ** Simple Timer metrics now track the highest and lowest recorded timing duration of the previous completed minute (https://github.com/eclipse/microprofile-metrics/issues/523[#523])
@@ -82,7 +83,6 @@ A full list of changes may be found on the link:https://github.com/eclipse/micro
 ** Added `withOptional*` methods to the `MetadataBuilder`, they don't fail when null values are passed to them (https://github.com/eclipse/microprofile-metrics/issues/464[#464])
 ** Added the `MetricID.getTagsAsArray()` method to the API. (https://github.com/eclipse/microprofile-metrics/issues/457[#457])
 ** Added the method `MetricType.fromClassName` (https://github.com/eclipse/microprofile-metrics/issues/455[#455])
-** Removed `MetadataBuilder.withOptional*` methods, the remaining `with*` methods do accept `null` value (considered not present) except `withName` which does not accept `null` or `""`
 
 === Functional Changes
 ** Introduced a new base metric derived from RESTful stats into the base scope.

--- a/spec/src/main/asciidoc/changelog.adoc
+++ b/spec/src/main/asciidoc/changelog.adoc
@@ -82,6 +82,7 @@ A full list of changes may be found on the link:https://github.com/eclipse/micro
 ** Added `withOptional*` methods to the `MetadataBuilder`, they don't fail when null values are passed to them (https://github.com/eclipse/microprofile-metrics/issues/464[#464])
 ** Added the `MetricID.getTagsAsArray()` method to the API. (https://github.com/eclipse/microprofile-metrics/issues/457[#457])
 ** Added the method `MetricType.fromClassName` (https://github.com/eclipse/microprofile-metrics/issues/455[#455])
+** Removed `MetadataBuilder.withOptional*` methods, the remaining `with*` methods do accept `null` value (considered not present) except `withName` which does not accept `null` or `""`
 
 === Functional Changes
 ** Introduced a new base metric derived from RESTful stats into the base scope.

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/cdi/stereotype/StereotypeCountedClassBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/cdi/stereotype/StereotypeCountedClassBeanTest.java
@@ -77,14 +77,14 @@ public class StereotypeCountedClassBeanTest {
         MetricID constructorMetricId = new MetricID(constructorMetricName);
         assertNotNull(metricRegistry.getCounter(constructorMetricId));
         Metadata constructorMetadata = metricRegistry.getMetadata(constructorMetricName);
-        assertEquals("description", constructorMetadata.getDescription().orElse(null));
+        assertEquals("description", constructorMetadata.description().orElse(null));
         assertEquals("displayName", constructorMetadata.getDisplayName());
 
         String methodMetricName = "org.eclipse.microprofile.metrics.tck.cdi.stereotype.bloop.foo";
         MetricID methodMetricId = new MetricID(methodMetricName);
         assertNotNull(metricRegistry.getCounter(methodMetricId));
         Metadata methodMetadata = metricRegistry.getMetadata(methodMetricName);
-        assertEquals("description", methodMetadata.getDescription().orElse(null));
+        assertEquals("description", methodMetadata.description().orElse(null));
         assertEquals("displayName", methodMetadata.getDisplayName());
 
         beanWithSpecifiedMetadata.foo();


### PR DESCRIPTION
This is a suggestion to make `Metadata` more predictable when it comes to difference between values being `null` (not present) and set to their defaults explicitly.

`Metadata` methods returning _plain_ `String` or `MetricType` never return `null`, 
* display name defaults to name, 
* unit defaults to `MetricUnits.NONE` 
* description defaults to `""` 
* type defaults to `MetricType.INVALID`

This default is always applied in last possible moment when getter reads the field value.
Until then any value including `null` may be passed to builder `with`-methods. `null` simple makes values not present and triggers the defaults unless the value is accessed via one of the `Optional`-returning methods which give access to the underlying value in the sense that they allow to distinguish between a value that is not set (and returns its default) and a value that is set to any value that isn't the default.

The builder sets its field to `null` if the default value is passed to the `with` method so that any default means the field in `null` and will fallback to its default when accessed via plain getter and that any default will be treated as `not present`.

Reason this changes are suggested is that current state of `Metadata` and the builder is very confusing and hard to predict and different `Metadata` objects (with regards to their _is present_ behaviour) can easily created by accident. Something that should be a simple and straight forward  data record has a complexity to it that has no real benefit. Making sure plain methods never return `null` can be done without this complexity as this PR wants to show.

I also avoided use of `default` methods but naturally the fallback logic as demanded by the javadoc could be implemented as such making all _plain_ methods default methods that use the `-Optional` methods as done by the `DefaultMetadata` implementation. 