### PR TITLE
Fixes GaugeInjectionBeanTest setup

### DIFF
--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/cdi/GaugeInjectionBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/cdi/GaugeInjectionBeanTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
+import javax.enterprise.inject.spi.CDI;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.metrics.Gauge;
@@ -46,7 +47,6 @@ public class GaugeInjectionBeanTest {
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
-    @Inject
     private static GaugeInjectionBean bean;
 
     @Inject
@@ -55,6 +55,7 @@ public class GaugeInjectionBeanTest {
 
     @BeforeClass
     public static void instantiateApplicationScopedBean() {
+        bean = CDI.current().select(GaugeInjectionBean.class).get();
         // Let's trigger the instantiation of the application scoped bean
         // explicitly
         // as only a proxy gets injected otherwise

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/cdi/GaugeInjectionBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/cdi/GaugeInjectionBeanTest.java
@@ -30,7 +30,7 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -47,13 +47,13 @@ public class GaugeInjectionBeanTest {
     }
 
     @Inject
-    private GaugeInjectionBean bean;
+    private static GaugeInjectionBean bean;
 
     @Inject
     @Metric(absolute = true, name = "org.eclipse.microprofile.metrics.tck.cdi.GaugeInjectionBean.gaugeInjection")
     private Gauge<Long> gauge;
 
-    @Before
+    @BeforeClass
     public void instantiateApplicationScopedBean() {
         // Let's trigger the instantiation of the application scoped bean
         // explicitly

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/cdi/GaugeInjectionBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/cdi/GaugeInjectionBeanTest.java
@@ -54,7 +54,7 @@ public class GaugeInjectionBeanTest {
     private Gauge<Long> gauge;
 
     @BeforeClass
-    public void instantiateApplicationScopedBean() {
+    public static void instantiateApplicationScopedBean() {
         // Let's trigger the instantiation of the application scoped bean
         // explicitly
         // as only a proxy gets injected otherwise

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/cdi/GaugeInjectionBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/cdi/GaugeInjectionBeanTest.java
@@ -19,7 +19,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
-import javax.enterprise.inject.spi.CDI;
 import javax.inject.Inject;
 
 import org.eclipse.microprofile.metrics.Gauge;
@@ -31,7 +30,6 @@ import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -47,15 +45,16 @@ public class GaugeInjectionBeanTest {
                 .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
     }
 
-    private static GaugeInjectionBean bean;
+    @Inject
+    private GaugeInjectionBean bean;
 
     @Inject
     @Metric(absolute = true, name = "org.eclipse.microprofile.metrics.tck.cdi.GaugeInjectionBean.gaugeInjection")
     private Gauge<Long> gauge;
 
-    @BeforeClass
-    public static void instantiateApplicationScopedBean() {
-        bean = CDI.current().select(GaugeInjectionBean.class).get();
+    @Test
+    @InSequence(1)
+    public void instantiateApplicationScopedBean() {
         // Let's trigger the instantiation of the application scoped bean
         // explicitly
         // as only a proxy gets injected otherwise
@@ -63,14 +62,14 @@ public class GaugeInjectionBeanTest {
     }
 
     @Test
-    @InSequence(1)
+    @InSequence(2)
     public void gaugeCalledWithDefaultValue() {
         // Make sure that the gauge has the expected value
         assertThat("Gauge value is incorrect", gauge.getValue(), is(equalTo(0L)));
     }
 
     @Test
-    @InSequence(2)
+    @InSequence(3)
     public void callGaugeAfterSetterCall(
             @Metric(absolute = true, name = "org.eclipse.microprofile.metrics.tck.cdi.GaugeInjectionBean.gaugeInjection") Gauge<Long> gauge) {
         // Call the setter method and assert the gauge is up-to-date


### PR DESCRIPTION
The idea of using `@Before` to make sure the gauge gets registered before the test is running is flawed in the sense that the test is only successful if the gauge is successfully injected into the instance of the test class. This happens before `@Test` and `@Before` run so at that point the gauge does not exist should the `gauge` field be injected first. Or maybe even if it is injected after `bean` it might not exist due to proxies. 

~~I have not tested the fix of using `@BeforeClass` but I'd suspect this should force the usage of `bean` before the test class instance is injected and thereby making sure the gauge exists so it is successfully injected into the test class instance.~~

~~Another idea to fix this is to~~ use a empty test method an annotate it with `@InSequence(1)` and make the real tests 2 and 3.

Signed-off-by: Jan Bernitt <jaanbernitt@gmail.com>