### PR TITLE
Remove existing MetricRegistry's retrieve/register gauge() methods and introduce new ones that make use of Functions

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/metrics/MetricRegistry.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/MetricRegistry.java
@@ -31,7 +31,7 @@ import java.util.Map;
 import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.function.Supplier;
-import java.util.function.ToDoubleFunction;
+import java.util.function.Function;
 
 /**
  * The registry that stores metrics and their metadata.
@@ -300,69 +300,72 @@ public interface MetricRegistry {
     ConcurrentGauge concurrentGauge(Metadata metadata, Tag... tags);
 
     /**
-     * Return the {@link Gauge} of type Double registered under the {@link MetricID} with this
+     * Return the {@link Gauge} of type {@link java.lang.Number Number} registered under the {@link MetricID} with this
      * name and with the provided {@link Tag}s; or create and register this gauge if none is registered.
      *
      * If a {@link Gauge} was created, a {@link Metadata} object will be registered with the name
      * and type. If a {@link Metadata} object is already registered with this metric name then that
      * {@link Metadata} will be used.
      *
-     * The created {@link Gauge} will apply a @link java.util.function.ToDoubleFunction ToDoubleFunction}
-     * to the provided object to resolve a Long value.
+     * The created {@link Gauge} will apply a {@link java.util.function.Function Function}
+     * to the provided object to resolve a {@link java.lang.Number Number} value.
      *
      * @param <T>    The Type of the Object of which the function <code>func</code> is applied to
+     * @param <R>    A {@link java.lang.Number Number}
      * @param name   The name of the Gauge metric
-     * @param object The object that the {@link java.util.function.ToDoubleFunction ToDoubleFunction} <code>func</code> will be applied to
-     * @param func   The {@link java.util.function.ToDoubleFunction ToDoubleFunction} that will be applied to <code>object</code>
+     * @param object The object that the {@link java.util.function.Function Function} <code>func</code> will be applied to
+     * @param func   The {@link java.util.function.Function Function} that will be applied to <code>object</code>
      * @param tags   The tags of the metric
      * @return a new or pre-existing {@link Gauge}
      *
      * @since 3.0
      */
-    <T> Gauge<Double> gauge(String name, T object, ToDoubleFunction<T> func, Tag... tags);
+    <T, R extends Number> Gauge<R> gauge(String name, T object, Function<T, R> func, Tag... tags);
 
     /**
-     * Return the {@link Gauge} of type Double registered under the {@link MetricID}; or create
+     * Return the {@link Gauge} of type {@link java.lang.Number Number} registered under the {@link MetricID}; or create
      * and register this gauge if none is registered.
      *
      * If a {@link Gauge} was created, a {@link Metadata} object will be registered with the name
      * and type. If a {@link Metadata} object is already registered with this metric name then that
      * {@link Metadata} will be used.
      *
-     * The created {@link Gauge} will apply a @link java.util.function.ToDoubleFunction ToDoubleFunction}
-     * to the provided object to resolve a Long value.
+     * The created {@link Gauge} will apply a {@link java.util.function.Function Function}
+     * to the provided object to resolve a {@link java.lang.Number Number} value.
      *
      * @param <T>      The Type of the Object of which the function <code>func</code> is applied to
+     * @param <R>      A {@link java.lang.Number Number}
      * @param metricID The MetricID of the Gauge metric
-     * @param object   The object that the {@link java.util.function.ToDoubleFunction ToDoubleFunction} <code>func</code> will be applied to
-     * @param func     The {@link java.util.function.ToDoubleFunction ToDoubleFunction} that will be applied to <code>object</code>
+     * @param object   The object that the {@link java.util.function.Function Function} <code>func</code> will be applied to
+     * @param func     The {@link java.util.function.Function Function} that will be applied to <code>object</code>
      * @return a new or pre-existing {@link Gauge}
      *
      * @since 3.0
      */
-    <T> Gauge<Double> gauge(MetricID metricID, T object, ToDoubleFunction<T> func);
+    <T, R extends Number> Gauge<R> gauge(MetricID metricID, T object, Function<T, R> func);
 
     /**
-     * Return the {@link Gauge} of type Double registered under the {@link MetricID} with the @{link Metadata}'s
+     * Return the {@link Gauge} of type {@link java.lang.Number Number} registered under the {@link MetricID} with the @{link Metadata}'s
      * name and with the provided {@link Tag}s; or create and register this gauge if none is registered.
      *
      * If a {@link Gauge} was created, a {@link Metadata} object will be registered with the name
      * and type. If a {@link Metadata} object is already registered with this metric name then that
      * {@link Metadata} will be used.
      *
-     * The created {@link Gauge} will apply a @link java.util.function.ToDoubleFunction ToDoubleFunction}
-     * to the provided object to resolve a Long value.
+     * The created {@link Gauge} will apply a {@link java.util.function.Function Function}
+     * to the provided object to resolve a {@link java.lang.Number Number} value.
      *
      * @param <T>      The Type of the Object of which the function <code>func</code> is applied to
+     * @param <R>      A {@link java.lang.Number Number}
      * @param metadata The Metadata of the Gauge
-     * @param object   The object that the {@link java.util.function.ToDoubleFunction ToDoubleFunction} <code>func</code> will be applied to
-     * @param func     The {@link java.util.function.ToDoubleFunction ToDoubleFunction} that will be applied to <code>object</code>
+     * @param object   The object that the {@link java.util.function.Function Function} <code>func</code> will be applied to
+     * @param func     The {@link java.util.function.Function Function} that will be applied to <code>object</code>
      * @param tags     The tags of the metric
      * @return a new or pre-existing {@link Gauge}
      *
      * @since 3.0
      */
-    <T> Gauge<Double> gauge(Metadata metadata, T object, ToDoubleFunction<T> func, Tag... tags);
+    <T, R extends Number> Gauge<R> gauge(Metadata metadata, T object, Function<T, R> func, Tag... tags);
 
     /**
      * Return the {@link Gauge} registered under the {@link MetricID} with this
@@ -425,6 +428,7 @@ public interface MetricRegistry {
      * @since 3.0
      */
     <T extends Number> Gauge<T> gauge(Metadata metadata, Supplier<T> supplier, Tag... tags);
+
 
     /**
      * Return the {@link Histogram} registered under the {@link MetricID} with this name and with no tags;

--- a/api/src/main/java/org/eclipse/microprofile/metrics/MetricRegistry.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/MetricRegistry.java
@@ -300,7 +300,7 @@ public interface MetricRegistry {
     ConcurrentGauge concurrentGauge(Metadata metadata, Tag... tags);
 
     /**
-     * Return the {@link Gauge} of type Long registered under the {@link MetricID} with this
+     * Return the {@link Gauge} of type Double registered under the {@link MetricID} with this
      * name and with the provided {@link Tag}s; or create and register this gauge if none is registered.
      *
      * If a {@link Gauge} was created, a {@link Metadata} object will be registered with the name
@@ -319,10 +319,10 @@ public interface MetricRegistry {
      *
      * @since 3.0
      */
-    <T> Gauge<Long> gauge(String name, T object, ToDoubleFunction<T> func, Tag... tags);
+    <T> Gauge<Double> gauge(String name, T object, ToDoubleFunction<T> func, Tag... tags);
 
     /**
-     * Return the {@link Gauge} of type Long registered under the {@link MetricID}; or create
+     * Return the {@link Gauge} of type Double registered under the {@link MetricID}; or create
      * and register this gauge if none is registered.
      *
      * If a {@link Gauge} was created, a {@link Metadata} object will be registered with the name
@@ -340,10 +340,10 @@ public interface MetricRegistry {
      *
      * @since 3.0
      */
-    <T> Gauge<Long> gauge(MetricID metricID, T object, ToDoubleFunction<T> func);
+    <T> Gauge<Double> gauge(MetricID metricID, T object, ToDoubleFunction<T> func);
 
     /**
-     * Return the {@link Gauge} of type Long registered under the {@link MetricID} with the @{link Metadata}'s
+     * Return the {@link Gauge} of type Double registered under the {@link MetricID} with the @{link Metadata}'s
      * name and with the provided {@link Tag}s; or create and register this gauge if none is registered.
      *
      * If a {@link Gauge} was created, a {@link Metadata} object will be registered with the name
@@ -362,7 +362,7 @@ public interface MetricRegistry {
      *
      * @since 3.0
      */
-    <T> Gauge<Long> gauge(Metadata metadata, T object, ToDoubleFunction<T> func, Tag... tags);
+    <T> Gauge<Double> gauge(Metadata metadata, T object, ToDoubleFunction<T> func, Tag... tags);
 
     /**
      * Return the {@link Gauge} registered under the {@link MetricID} with this
@@ -375,7 +375,7 @@ public interface MetricRegistry {
      * The created {@link Gauge} will return the value that the {@link java.util.function.Supplier Supplier}
      * will provide.
      *
-     * @param <T>      The type that {@link Gauge} metric will return
+     * @param <T>      A {@link java.lang.Number Number}
      * @param name     The name of the Gauge
      * @param supplier The {@link java.util.function.Supplier Supplier} function that will return the value for the Gauge metric
      * @param tags     The tags of the metric
@@ -383,7 +383,7 @@ public interface MetricRegistry {
      *
      * @since 3.0
      */
-    <T> Gauge<T> gauge(String name, Supplier<T> supplier, Tag... tags);
+    <T extends Number> Gauge<T> gauge(String name, Supplier<T> supplier, Tag... tags);
 
     /**
      * Return the {@link Gauge} registered under the {@link MetricID}; or create
@@ -396,14 +396,14 @@ public interface MetricRegistry {
      * The created {@link Gauge} will return the value that the {@link java.util.function.Supplier Supplier}
      * will provide.
      *
-     * @param <T>      The type that {@link Gauge} metric will return
+     * @param <T>      A {@link java.lang.Number Number}
      * @param metricID The {@link MetricID}
      * @param supplier The {@link java.util.function.Supplier Supplier} function that will return the value for the Gauge metric
      * @return a new or pre-existing {@link Gauge}
      *
      * @since 3.0
      */
-    <T> Gauge<T> gauge(MetricID metricID, Supplier<T> supplier);
+    <T extends Number> Gauge<T> gauge(MetricID metricID, Supplier<T> supplier);
 
     /**
      * Return the {@link Gauge} registered under the {@link MetricID} with the @{link Metadata}'s
@@ -416,7 +416,7 @@ public interface MetricRegistry {
      * The created {@link Gauge} will return the value that the {@link java.util.function.Supplier Supplier}
      * will provide.
      *
-     * @param <T>      The type that {@link Gauge} metric will return
+     * @param <T>      A {@link java.lang.Number Number}
      * @param metadata The metadata of the gauge
      * @param supplier The {@link java.util.function.Supplier Supplier} function that will return the value for the Gauge metric
      * @param tags     The tags of the metric
@@ -424,7 +424,7 @@ public interface MetricRegistry {
      *
      * @since 3.0
      */
-    <T> Gauge<T> gauge(Metadata metadata, Supplier<T> supplier, Tag... tags);
+    <T extends Number> Gauge<T> gauge(Metadata metadata, Supplier<T> supplier, Tag... tags);
 
     /**
      * Return the {@link Histogram} registered under the {@link MetricID} with this name and with no tags;

--- a/api/src/main/java/org/eclipse/microprofile/metrics/MetricRegistry.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/MetricRegistry.java
@@ -30,6 +30,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.SortedSet;
+import java.util.function.Supplier;
+import java.util.function.ToDoubleFunction;
 
 /**
  * The registry that stores metrics and their metadata.
@@ -298,52 +300,131 @@ public interface MetricRegistry {
     ConcurrentGauge concurrentGauge(Metadata metadata, Tag... tags);
 
     /**
-     * Return the {@link Gauge} registered under the {@link MetricID} with this name and with no tags;
-     * or create and register this gauge if none is registered.
+     * Return the {@link Gauge} of type Long registered under the {@link MetricID} with this
+     * name and with the provided {@link Tag}s; or create and register this gauge if none is registered.
      *
      * If a {@link Gauge} was created, a {@link Metadata} object will be registered with the name
      * and type. If a {@link Metadata} object is already registered with this metric name then that
      * {@link Metadata} will be used.
      *
-     * @param name the name of the metric
-     * @param gauge the {@link Gauge} to use if none is registered already
-     * @return the pre-existing or provided {@link Gauge}
+     * The created {@link Gauge} will apply a @link java.util.function.ToDoubleFunction ToDoubleFunction}
+     * to the provided object to resolve a Long value.
+     *
+     * @param <T>    The Type of the Object of which the function <code>func</code> is applied to
+     * @param name   The name of the Gauge metric
+     * @param object The object that the {@link java.util.function.ToDoubleFunction ToDoubleFunction} <code>func</code> will be applied to
+     * @param func   The {@link java.util.function.ToDoubleFunction ToDoubleFunction} that will be applied to <code>object</code>
+     * @param tags   The tags of the metric
+     * @return a new or pre-existing {@link Gauge}
      *
      * @since 3.0
      */
-    Gauge<?> gauge(String name, Gauge<?> gauge);
+    <T> Gauge<Long> gauge(String name, T object, ToDoubleFunction<T> func, Tag... tags);
 
     /**
-     * Return the {@link Gauge} registered under the {@link MetricID} with this name and with the
-     * provided {@link Tag}s; or create and register this gauge if none is registered.
+     * Return the {@link Gauge} of type Long registered under the {@link MetricID}; or create
+     * and register this gauge if none is registered.
      *
      * If a {@link Gauge} was created, a {@link Metadata} object will be registered with the name
      * and type. If a {@link Metadata} object is already registered with this metric name then that
      * {@link Metadata} will be used.
      *
-     * @param name the name of the metric
-     * @param gauge the {@link Gauge} to use if none is registered already
-     * @return the pre-existing or provided {@link Gauge}
+     * The created {@link Gauge} will apply a @link java.util.function.ToDoubleFunction ToDoubleFunction}
+     * to the provided object to resolve a Long value.
+     *
+     * @param <T>      The Type of the Object of which the function <code>func</code> is applied to
+     * @param metricID The MetricID of the Gauge metric
+     * @param object   The object that the {@link java.util.function.ToDoubleFunction ToDoubleFunction} <code>func</code> will be applied to
+     * @param func     The {@link java.util.function.ToDoubleFunction ToDoubleFunction} that will be applied to <code>object</code>
+     * @return a new or pre-existing {@link Gauge}
      *
      * @since 3.0
      */
-    Gauge<?> gauge(String name, Gauge<?> gauge, Tag...tags);
+    <T> Gauge<Long> gauge(MetricID metricID, T object, ToDoubleFunction<T> func);
 
     /**
-     * Return the {@link Gauge} registered under the {@link MetricID}; or create and register this
-     * gauge if none is registered.
+     * Return the {@link Gauge} of type Long registered under the {@link MetricID} with the @{link Metadata}'s
+     * name and with the provided {@link Tag}s; or create and register this gauge if none is registered.
      *
      * If a {@link Gauge} was created, a {@link Metadata} object will be registered with the name
      * and type. If a {@link Metadata} object is already registered with this metric name then that
      * {@link Metadata} will be used.
      *
-     * @param metricID the ID of the metric
-     * @param gauge the {@link Gauge} to use if none is registered already
-     * @return the pre-existing or provided {@link Gauge}
+     * The created {@link Gauge} will apply a @link java.util.function.ToDoubleFunction ToDoubleFunction}
+     * to the provided object to resolve a Long value.
+     *
+     * @param <T>      The Type of the Object of which the function <code>func</code> is applied to
+     * @param metadata The Metadata of the Gauge
+     * @param object   The object that the {@link java.util.function.ToDoubleFunction ToDoubleFunction} <code>func</code> will be applied to
+     * @param func     The {@link java.util.function.ToDoubleFunction ToDoubleFunction} that will be applied to <code>object</code>
+     * @param tags     The tags of the metric
+     * @return a new or pre-existing {@link Gauge}
      *
      * @since 3.0
      */
-    Gauge<?> gauge(MetricID metricID, Gauge<?> gauge);
+    <T> Gauge<Long> gauge(Metadata metadata, T object, ToDoubleFunction<T> func, Tag... tags);
+
+    /**
+     * Return the {@link Gauge} registered under the {@link MetricID} with this
+     * name and with the provided {@link Tag}s; or create and register this gauge if none is registered.
+     *
+     * If a {@link Gauge} was created, a {@link Metadata} object will be registered with the name
+     * and type. If a {@link Metadata} object is already registered with this metric name then that
+     * {@link Metadata} will be used.
+     *
+     * The created {@link Gauge} will return the value that the {@link java.util.function.Supplier Supplier}
+     * will provide.
+     *
+     * @param <T>      The type that {@link Gauge} metric will return
+     * @param name     The name of the Gauge
+     * @param supplier The {@link java.util.function.Supplier Supplier} function that will return the value for the Gauge metric
+     * @param tags     The tags of the metric
+     * @return a new or pre-existing {@link Gauge}
+     *
+     * @since 3.0
+     */
+    <T> Gauge<T> gauge(String name, Supplier<T> supplier, Tag... tags);
+
+    /**
+     * Return the {@link Gauge} registered under the {@link MetricID}; or create
+     * and register this gauge if none is registered.
+     *
+     * If a {@link Gauge} was created, a {@link Metadata} object will be registered with the name
+     * and type. If a {@link Metadata} object is already registered with this metric name then that
+     * {@link Metadata} will be used.
+     *
+     * The created {@link Gauge} will return the value that the {@link java.util.function.Supplier Supplier}
+     * will provide.
+     *
+     * @param <T>      The type that {@link Gauge} metric will return
+     * @param metricID The {@link MetricID}
+     * @param supplier The {@link java.util.function.Supplier Supplier} function that will return the value for the Gauge metric
+     * @return a new or pre-existing {@link Gauge}
+     *
+     * @since 3.0
+     */
+    <T> Gauge<T> gauge(MetricID metricID, Supplier<T> supplier);
+
+    /**
+     * Return the {@link Gauge} registered under the {@link MetricID} with the @{link Metadata}'s
+     * name and with the provided {@link Tag}s; or create and register this gauge if none is registered.
+     *
+     * If a {@link Gauge} was created, a {@link Metadata} object will be registered with the name
+     * and type. If a {@link Metadata} object is already registered with this metric name then that
+     * {@link Metadata} will be used.
+     *
+     * The created {@link Gauge} will return the value that the {@link java.util.function.Supplier Supplier}
+     * will provide.
+     *
+     * @param <T>      The type that {@link Gauge} metric will return
+     * @param metadata The metadata of the gauge
+     * @param supplier The {@link java.util.function.Supplier Supplier} function that will return the value for the Gauge metric
+     * @param tags     The tags of the metric
+     * @return a new or pre-existing {@link Gauge}
+     *
+     * @since 3.0
+     */
+    <T> Gauge<T> gauge(Metadata metadata, Supplier<T> supplier, Tag... tags);
 
     /**
      * Return the {@link Histogram} registered under the {@link MetricID} with this name and with no tags;

--- a/spec/src/main/asciidoc/changelog.adoc
+++ b/spec/src/main/asciidoc/changelog.adoc
@@ -36,9 +36,12 @@
 ** Added the `MetricRegistry.getType()` method
 ** Added the `MetricRegistry.counter(MetricID)` method
 ** Added the `MetricRegistry.concurrentGauge(MetricID)` method
-** Added the `MetricRegistry.gauge(MetricID, Gauge)` method
-** Added the `MetricRegistry.gauge(String, Gauge)` method
-** Added the `MetricRegistry.gauge(String, Gauge, Tag[])` method
+** Added the `MetricRegistry.gauge(String, Object, ToDoubleFunction, Tag[])` method
+** Added the `MetricRegistry.gauge(MetricID, Object, ToDoubleFunction)` method
+** Added the `MetricRegistry.gauge(Metadata, Object, ToDoubleFunction, Tag[])` method
+** Added the `MetricRegistry.gauge(String, Supplier, Tag[])` method
+** Added the `MetricRegistry.gauge(MetricID, Supplier)` method
+** Added the `MetricRegistry.gauge(Metadata), Supplier, Tag[])` method
 ** Added the `MetricRegistry.histogram(MetricID)` method
 ** Added the `MetricRegistry.meter(MetricID)` method
 ** Added the `MetricRegistry.timer(MetricID)` method

--- a/spec/src/main/asciidoc/changelog.adoc
+++ b/spec/src/main/asciidoc/changelog.adoc
@@ -36,9 +36,9 @@
 ** Added the `MetricRegistry.getType()` method
 ** Added the `MetricRegistry.counter(MetricID)` method
 ** Added the `MetricRegistry.concurrentGauge(MetricID)` method
-** Added the `MetricRegistry.gauge(String, Object, ToDoubleFunction, Tag[])` method
-** Added the `MetricRegistry.gauge(MetricID, Object, ToDoubleFunction)` method
-** Added the `MetricRegistry.gauge(Metadata, Object, ToDoubleFunction, Tag[])` method
+** Added the `MetricRegistry.gauge(String, Object, Function, Tag[])` method
+** Added the `MetricRegistry.gauge(MetricID, Object, Function)` method
+** Added the `MetricRegistry.gauge(Metadata, Object, Function, Tag[])` method
 ** Added the `MetricRegistry.gauge(String, Supplier, Tag[])` method
 ** Added the `MetricRegistry.gauge(MetricID, Supplier)` method
 ** Added the `MetricRegistry.gauge(Metadata), Supplier, Tag[])` method

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/GaugeTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/GaugeTest.java
@@ -57,9 +57,7 @@ public class GaugeTest {
         MetricID supplierGaugeMetricID = new MetricID("tck.gaugetest.supplierGaugeManual");
         MetricID toDoubleFunctiongaugeMetricID = new MetricID("tck.gaugetest.toDoubleFunctionGaugeManual");
         
-        Gauge<?> sGauge = metrics.getGauge(supplierGaugeMetricID);
-        
-        //Gauge that uses a ToDoubleFunction retrieves a Long value
+        Gauge<?> sGauge = metrics.getGauge(supplierGaugeMetricID);      
         Gauge<?> fGauge = metrics.getGauge(toDoubleFunctiongaugeMetricID);
         
         Assert.assertNull(sGauge);
@@ -71,12 +69,10 @@ public class GaugeTest {
         fGauge = metrics.getGauge(toDoubleFunctiongaugeMetricID);
         
         Assert.assertEquals(0, sGauge.getValue());
-        //Gauge that uses a ToDoubleFunction retrieves a Long value
-        Assert.assertEquals(1L, fGauge.getValue());
+        Assert.assertEquals(1.0, fGauge.getValue());
         
         Assert.assertEquals(2, sGauge.getValue());
-        //Gauge that uses a ToDoubleFunction retrieves a Long value
-        Assert.assertEquals(3L, fGauge.getValue());
+        Assert.assertEquals(3.0, fGauge.getValue());
     }
 
     public void gaugeMe() {

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/GaugeTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/GaugeTest.java
@@ -1,6 +1,6 @@
 /*
  **********************************************************************
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017, 2020 Contributors to the Eclipse Foundation
  *               2010-2013 Coda Hale, Yammer.com
  *
  * See the NOTICES file(s) distributed with this work for additional
@@ -54,19 +54,40 @@ public class GaugeTest {
 
     @Test
     public void testManualGauge() {
-        MetricID gaugeMetricID = new MetricID("tck.gaugetest.gaugemanual");
+        MetricID supplierGaugeMetricID = new MetricID("tck.gaugetest.supplierGaugeManual");
+        MetricID toDoubleFunctiongaugeMetricID = new MetricID("tck.gaugetest.toDoubleFunctionGaugeManual");
         
-        Gauge<?> gauge = metrics.getGauge(gaugeMetricID);
-        Assert.assertNull(gauge);
+        Gauge<?> sGauge = metrics.getGauge(supplierGaugeMetricID);
+        
+        //Gauge that uses a ToDoubleFunction retrieves a Long value
+        Gauge<?> fGauge = metrics.getGauge(toDoubleFunctiongaugeMetricID);
+        
+        Assert.assertNull(sGauge);
+        Assert.assertNull(fGauge);
+        
         gaugeMe();
-        gauge = metrics.getGauge(gaugeMetricID);
         
-        Assert.assertEquals(0, gauge.getValue());
-        Assert.assertEquals(1, gauge.getValue());
+        sGauge = metrics.getGauge(supplierGaugeMetricID);
+        fGauge = metrics.getGauge(toDoubleFunctiongaugeMetricID);
+        
+        Assert.assertEquals(0, sGauge.getValue());
+        //Gauge that uses a ToDoubleFunction retrieves a Long value
+        Assert.assertEquals(1L, fGauge.getValue());
+        
+        Assert.assertEquals(2, sGauge.getValue());
+        //Gauge that uses a ToDoubleFunction retrieves a Long value
+        Assert.assertEquals(3L, fGauge.getValue());
     }
 
     public void gaugeMe() {
-        metrics.gauge("tck.gaugetest.gaugemanual", value::getAndIncrement);
+        metrics.gauge("tck.gaugetest.supplierGaugeManual", value::getAndIncrement, null);
+        
+        metrics.gauge("tck.gaugetest.toDoubleFunctionGaugeManual", value , 
+                (atomicInteger) -> {
+                    AtomicInteger myAtomicInteger= (AtomicInteger) atomicInteger;
+                    return myAtomicInteger.getAndIncrement();
+                    }, null);
+
     }
 
 }

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/GaugeTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/GaugeTest.java
@@ -69,10 +69,10 @@ public class GaugeTest {
         fGauge = metrics.getGauge(toDoubleFunctiongaugeMetricID);
         
         Assert.assertEquals(0, sGauge.getValue());
-        Assert.assertEquals(1.0, fGauge.getValue());
+        Assert.assertEquals(1, fGauge.getValue());
         
         Assert.assertEquals(2, sGauge.getValue());
-        Assert.assertEquals(3.0, fGauge.getValue());
+        Assert.assertEquals(3, fGauge.getValue());
     }
 
     public void gaugeMe() {


### PR DESCRIPTION
See #592 

Was going to add the below methods without tag parameters but would cause ambiguity issues.
```

1. <T> Gauge<T> gauge(String name, Supplier<T> supplier);
2. <T> Gauge<T> gauge(Metadata metadata, Supplier<T> supplier);

3. <T> Gauge<Long> gauge(String name, T object, ToDoubleFunction<T> func;
4. <T> Gauge<Long> gauge(Metadata metadata, T object, ToDoubleFunction<T> func;

```

For example, wanting to calling `gauge("name", supplier, null)` is ambiguous with **3**
 and similarily calling `gauge(metadata, supplier, null)` is ambigious with **4**
Signed-off-by: David Chan <chdavid@ca.ibm.com>