### PR TITLE
Increase tolerance and time for testing rates for Meter and Timer TCK tests

### DIFF
--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/MeterTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/MeterTest.java
@@ -1,6 +1,6 @@
 /*
  **********************************************************************
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017, 2020 Contributors to the Eclipse Foundation
  *               2010-2013 Coda Hale, Yammer.com
  *
  * See the NOTICES file(s) distributed with this work for additional
@@ -81,7 +81,7 @@ public class MeterTest {
     public void testRates() throws Exception {
 
         int count = 100;
-        int markSeconds = 30;
+        int markSeconds = 60;
         int delaySeconds = 15;
         
         Meter meter = registry.meter("testMeterRatesLong");

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/TimerTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/TimerTest.java
@@ -1,6 +1,6 @@
 /*
  **********************************************************************
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017, 2020 Contributors to the Eclipse Foundation
  *               2010-2013 Coda Hale, Yammer.com
  *
  * See the NOTICES file(s) distributed with this work for additional
@@ -93,7 +93,7 @@ public class TimerTest {
     @InSequence(1)
     public void testRate() throws Exception {
 
-        int markSeconds = 30;
+        int markSeconds = 60;
         int delaySeconds = 15;
 
         Timer timer = registry.timer("testRate");

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/util/TestUtils.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/util/TestUtils.java
@@ -1,6 +1,6 @@
 /*
  **********************************************************************
- * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018, 2020 Contributors to the Eclipse Foundation
  *
  * See the NOTICES file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -25,7 +25,7 @@ import org.junit.Assert;
 
 public class TestUtils {
     
-    public static final double TOLERANCE = 0.025;
+    public static final double TOLERANCE = 0.15;
     
     // private constructor
     private TestUtils() {


### PR DESCRIPTION
Double the time.
Increase tolerance from 2.5% to 15%.
#619