### PR TITLE
Upgrade REST assured dependency to address Java 16 TCK failures

### DIFF
--- a/tck/rest/pom.xml
+++ b/tck/rest/pom.xml
@@ -30,7 +30,7 @@
 
     <properties>
         <!-- TODO should come from parent pom -->
-        <version.rest-assured>2.4.0</version.rest-assured>
+        <version.rest-assured>4.3.0</version.rest-assured>
         <version.junit>4.12</version.junit>
         <version.jackson>2.8.6</version.jackson>
 
@@ -54,7 +54,7 @@
     <dependencies>
 
         <dependency>
-            <groupId>com.jayway.restassured</groupId>
+            <groupId>io.rest-assured</groupId>
             <artifactId>rest-assured</artifactId>
             <version>${version.rest-assured}</version>
             <scope>compile</scope>

--- a/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MpMetricTest.java
+++ b/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MpMetricTest.java
@@ -22,8 +22,8 @@
 
 package org.eclipse.microprofile.metrics.test;
 
-import static com.jayway.restassured.RestAssured.given;
-import static com.jayway.restassured.RestAssured.when;
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.Matchers.hasKey;
@@ -36,10 +36,10 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
-import com.jayway.restassured.response.Header;
-import com.jayway.restassured.RestAssured;
-import com.jayway.restassured.path.json.JsonPath;
-import com.jayway.restassured.response.Response;
+import io.restassured.RestAssured;
+import io.restassured.http.Header;
+import io.restassured.path.json.JsonPath;
+import io.restassured.response.Response;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;

--- a/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/ReusableMetricsTest.java
+++ b/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/ReusableMetricsTest.java
@@ -25,10 +25,10 @@
 package org.eclipse.microprofile.metrics.test;
 
 import static org.hamcrest.Matchers.equalTo;
-import static com.jayway.restassured.RestAssured.given;
+import static io.restassured.RestAssured.given;
 
-import com.jayway.restassured.RestAssured;
-import com.jayway.restassured.response.Header;
+import io.restassured.RestAssured;
+import io.restassured.http.Header;
 import java.net.MalformedURLException;
 import java.net.URL;
 import javax.inject.Inject;


### PR DESCRIPTION
With Java 16, the TCKs will encounter issues when using the rest assured library. 
e.g.
```
org.eclipse.microprofile.metrics.test.MpMetricTest:java.lang.ExceptionInInitializerError: null
at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:357)
at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
at java.base/java.lang.reflect.Method.checkCanSetAccessible(Method.java:199)
at java.base/java.lang.reflect.AccessibleObject.setAccessible(AccessibleObject.java:130)
at org.codehaus.groovy.reflection.CachedClass$3$1.run(CachedClass.java:86)
```
See : https://github.com/OpenLiberty/open-liberty/issues/16162

This PR upgrades the rest-assured dependency to address these test failures.