### PR TITLE
Upgrade REST assured dependency to address Java 16 TCK failures

### DIFF
--- a/tck/rest/pom.xml
+++ b/tck/rest/pom.xml
@@ -30,7 +30,7 @@
 
     <properties>
         <!-- TODO should come from parent pom -->
-        <version.rest-assured>3.0.0</version.rest-assured>
+        <version.rest-assured>4.3.0</version.rest-assured>
         <version.junit>4.12</version.junit>
         <version.jackson>2.8.6</version.jackson>
 


### PR DESCRIPTION
With Java 16, the TCKs will encounter issues when using the rest assured library. 
e.g.
```
org.eclipse.microprofile.metrics.test.MpMetricTest:java.lang.ExceptionInInitializerError: null
at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:357)
at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
at java.base/java.lang.reflect.Method.checkCanSetAccessible(Method.java:199)
at java.base/java.lang.reflect.AccessibleObject.setAccessible(AccessibleObject.java:130)
at org.codehaus.groovy.reflection.CachedClass$3$1.run(CachedClass.java:86)
```
See : https://github.com/OpenLiberty/open-liberty/issues/16162

This PR upgrades the rest-assured dependency to address these test failures.