### PR TITLE
fix adoc spec link

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -24,7 +24,7 @@ export Monitoring data ("Telemetry") to management agents and also a unified
 Java API, that all (application) programmers can use to expose their telemetry
 data.
 
-* For the current specification see the link:spec/src/main/asciidoc/metrics_spec.adoc[Metrics Spec] document. For the specification at a given release or milestone, download link:https://github.com/eclipse/microprofile-metrics/releases[the PDF from the GitHub releases page].
+* For the current specification see the link:spec/src/main/asciidoc/microprofile-metrics-spec.asciidoc[Metrics Spec] document. For the specification at a given release or milestone, download link:https://github.com/eclipse/microprofile-metrics/releases[the PDF from the GitHub releases page].
 * To chat or ask questions about the spec, join the discussion on Gitter: image:https://badges.gitter.im/eclipse/microprofile-metrics.svg[link=https://gitter.im/eclipse/microprofile-metrics]
 * For announcements, visit the link:++https://groups.google.com/forum/#!forum/microprofile++[Microprofile Google Group] and filter by link:++https://groups.google.com/forum/#!tags/microprofile/metrics++[the metrics tag] to focus on topics related to this specification.
 


### PR DESCRIPTION
spec file has been renamed previously