### PR TITLE
Make sure TCKs are CDI-version agnostic

### DIFF
--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/inheritance/InheritedSimplyTimedMethodBean.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/inheritance/InheritedSimplyTimedMethodBean.java
@@ -25,6 +25,9 @@ package org.eclipse.microprofile.metrics.tck.inheritance;
 
 import org.eclipse.microprofile.metrics.annotation.SimplyTimed;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class InheritedSimplyTimedMethodBean extends VisibilitySimplyTimedMethodBean {
 
     @SimplyTimed

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/inheritance/InheritedTimedMethodBean.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/inheritance/InheritedTimedMethodBean.java
@@ -17,6 +17,9 @@ package org.eclipse.microprofile.metrics.tck.inheritance;
 
 import org.eclipse.microprofile.metrics.annotation.Timed;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class InheritedTimedMethodBean extends VisibilityTimedMethodBean {
 
     @Timed

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/inheritance/VisibilitySimplyTimedMethodBean.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/inheritance/VisibilitySimplyTimedMethodBean.java
@@ -25,6 +25,9 @@ package org.eclipse.microprofile.metrics.tck.inheritance;
 
 import org.eclipse.microprofile.metrics.annotation.SimplyTimed;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class VisibilitySimplyTimedMethodBean {
 
     @SimplyTimed

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/inheritance/VisibilityTimedMethodBean.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/inheritance/VisibilityTimedMethodBean.java
@@ -17,6 +17,9 @@ package org.eclipse.microprofile.metrics.tck.inheritance;
 
 import org.eclipse.microprofile.metrics.annotation.Timed;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class VisibilityTimedMethodBean {
 
     @Timed

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/ConcreteExtendedTimedBean.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/ConcreteExtendedTimedBean.java
@@ -15,6 +15,9 @@
  */
 package org.eclipse.microprofile.metrics.tck.metrics;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class ConcreteExtendedTimedBean extends AbstractTimedBean {
 
     public void anotherTimedMethod() {

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/ConcreteTimedBean.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/ConcreteTimedBean.java
@@ -17,6 +17,9 @@ package org.eclipse.microprofile.metrics.tck.metrics;
 
 import org.eclipse.microprofile.metrics.annotation.Timed;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 @Timed
 public class ConcreteTimedBean extends AbstractGenericBean {
 

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/ConcurrentGaugedClassBean.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/ConcurrentGaugedClassBean.java
@@ -40,6 +40,9 @@ package org.eclipse.microprofile.metrics.tck.metrics;
 
 import org.eclipse.microprofile.metrics.annotation.ConcurrentGauge;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 @ConcurrentGauge(name = "cGaugedClass")
 public class ConcurrentGaugedClassBean {
 

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/ConcurrentGaugedConstructorBean.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/ConcurrentGaugedConstructorBean.java
@@ -17,6 +17,9 @@ package org.eclipse.microprofile.metrics.tck.metrics;
 
 import org.eclipse.microprofile.metrics.annotation.ConcurrentGauge;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class ConcurrentGaugedConstructorBean {
 
     @ConcurrentGauge(name = "cGaugedConstructor")

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/ConcurrentGaugedMethodBean.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/ConcurrentGaugedMethodBean.java
@@ -19,6 +19,9 @@ import java.util.concurrent.Callable;
 
 import org.eclipse.microprofile.metrics.annotation.ConcurrentGauge;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class ConcurrentGaugedMethodBean<T> {
 
     @ConcurrentGauge(name = "cGaugedMethod", absolute = true)

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/CountedClassBean.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/CountedClassBean.java
@@ -17,6 +17,9 @@ package org.eclipse.microprofile.metrics.tck.metrics;
 
 import org.eclipse.microprofile.metrics.annotation.Counted;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 @Counted(name = "countedClass")
 public class CountedClassBean {
 

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/CountedMethodBean.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/CountedMethodBean.java
@@ -19,6 +19,9 @@ import java.util.concurrent.Callable;
 
 import org.eclipse.microprofile.metrics.annotation.Counted;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class CountedMethodBean<T> {
 
     @Counted(name = "countedMethod", absolute = true)

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/CountedMethodTagBean.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/CountedMethodTagBean.java
@@ -23,6 +23,9 @@ package org.eclipse.microprofile.metrics.tck.metrics;
 
 import org.eclipse.microprofile.metrics.annotation.Counted;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class CountedMethodTagBean {
 
     @Counted(name = "countedMethod", absolute = true, tags = {"number=one"})

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/CounterFieldBean.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/CounterFieldBean.java
@@ -18,8 +18,10 @@ package org.eclipse.microprofile.metrics.tck.metrics;
 import org.eclipse.microprofile.metrics.Counter;
 import org.eclipse.microprofile.metrics.annotation.Metric;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 
+@Dependent
 public class CounterFieldBean {
 
     @Inject

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/DefaultNameMetricMethodBean.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/DefaultNameMetricMethodBean.java
@@ -19,6 +19,9 @@ import org.eclipse.microprofile.metrics.annotation.Counted;
 import org.eclipse.microprofile.metrics.annotation.Metered;
 import org.eclipse.microprofile.metrics.annotation.Timed;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class DefaultNameMetricMethodBean {
 
     @Counted

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/HistogramFieldBean.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/HistogramFieldBean.java
@@ -18,8 +18,10 @@ package org.eclipse.microprofile.metrics.tck.metrics;
 import org.eclipse.microprofile.metrics.Histogram;
 import org.eclipse.microprofile.metrics.annotation.Metric;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 
+@Dependent
 public class HistogramFieldBean {
 
     @Inject

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/MeteredClassBean.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/MeteredClassBean.java
@@ -17,6 +17,9 @@ package org.eclipse.microprofile.metrics.tck.metrics;
 
 import org.eclipse.microprofile.metrics.annotation.Metered;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 @Metered(name = "meteredClass")
 public class MeteredClassBean {
 

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/MeteredConstructorBean.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/MeteredConstructorBean.java
@@ -17,6 +17,9 @@ package org.eclipse.microprofile.metrics.tck.metrics;
 
 import org.eclipse.microprofile.metrics.annotation.Metered;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class MeteredConstructorBean {
 
     @Metered(name = "meteredConstructor", absolute = true)

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/MeteredMethodBean1.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/MeteredMethodBean1.java
@@ -17,6 +17,9 @@ package org.eclipse.microprofile.metrics.tck.metrics;
 
 import org.eclipse.microprofile.metrics.annotation.Metered;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class MeteredMethodBean1 {
 
     @Metered(name = "meteredMethod")

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/MeteredMethodBean2.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/MeteredMethodBean2.java
@@ -17,6 +17,9 @@ package org.eclipse.microprofile.metrics.tck.metrics;
 
 import org.eclipse.microprofile.metrics.annotation.Metered;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class MeteredMethodBean2 {
 
     @Metered(name = "meteredMethod")

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/MultipleMetricsConstructorBean.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/MultipleMetricsConstructorBean.java
@@ -19,6 +19,9 @@ import org.eclipse.microprofile.metrics.annotation.Counted;
 import org.eclipse.microprofile.metrics.annotation.Metered;
 import org.eclipse.microprofile.metrics.annotation.Timed;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class MultipleMetricsConstructorBean {
 
     @Counted(name = "counter")

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/OverloadedTimedMethodBean.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/OverloadedTimedMethodBean.java
@@ -19,6 +19,9 @@ import java.util.List;
 
 import org.eclipse.microprofile.metrics.annotation.Timed;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class OverloadedTimedMethodBean {
 
     @Timed(name = "overloadedTimedMethodWithNoArguments")

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/SimpleTimerFieldBean.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/SimpleTimerFieldBean.java
@@ -26,8 +26,10 @@ package org.eclipse.microprofile.metrics.tck.metrics;
 import org.eclipse.microprofile.metrics.SimpleTimer;
 import org.eclipse.microprofile.metrics.annotation.Metric;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 
+@Dependent
 public class SimpleTimerFieldBean {
 
     @Inject

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/SimplyTimedConstructorBean.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/SimplyTimedConstructorBean.java
@@ -25,6 +25,9 @@ package org.eclipse.microprofile.metrics.tck.metrics;
 
 import org.eclipse.microprofile.metrics.annotation.SimplyTimed;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class SimplyTimedConstructorBean {
 
     @SimplyTimed(name = "simplyTimedConstructor")

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/SimplyTimedMethodBean1.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/SimplyTimedMethodBean1.java
@@ -25,6 +25,9 @@ package org.eclipse.microprofile.metrics.tck.metrics;
 
 import org.eclipse.microprofile.metrics.annotation.SimplyTimed;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class SimplyTimedMethodBean1 {
 
     @SimplyTimed(name = "simplyTimedMethod")

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/SimplyTimedMethodBean2.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/SimplyTimedMethodBean2.java
@@ -25,6 +25,9 @@ package org.eclipse.microprofile.metrics.tck.metrics;
 
 import org.eclipse.microprofile.metrics.annotation.SimplyTimed;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class SimplyTimedMethodBean2 {
 
     @SimplyTimed(name = "simplyTimedMethod")

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/SimplyTimedMethodBean3.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/SimplyTimedMethodBean3.java
@@ -25,6 +25,9 @@ package org.eclipse.microprofile.metrics.tck.metrics;
 
 import org.eclipse.microprofile.metrics.annotation.SimplyTimed;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class SimplyTimedMethodBean3 {
 
     @SimplyTimed(name = "simplyTimedMethod")

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/TimedConstructorBean.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/TimedConstructorBean.java
@@ -17,6 +17,9 @@ package org.eclipse.microprofile.metrics.tck.metrics;
 
 import org.eclipse.microprofile.metrics.annotation.Timed;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class TimedConstructorBean {
 
     @Timed(name = "timedConstructor")

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/TimedMethodBean1.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/TimedMethodBean1.java
@@ -17,6 +17,9 @@ package org.eclipse.microprofile.metrics.tck.metrics;
 
 import org.eclipse.microprofile.metrics.annotation.Timed;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class TimedMethodBean1 {
 
     @Timed(name = "timedMethod")

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/TimedMethodBean2.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/TimedMethodBean2.java
@@ -17,6 +17,9 @@ package org.eclipse.microprofile.metrics.tck.metrics;
 
 import org.eclipse.microprofile.metrics.annotation.Timed;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class TimedMethodBean2 {
 
     @Timed(name = "timedMethod")

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/TimedMethodBean3.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/TimedMethodBean3.java
@@ -17,6 +17,9 @@ package org.eclipse.microprofile.metrics.tck.metrics;
 
 import org.eclipse.microprofile.metrics.annotation.Timed;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class TimedMethodBean3 {
 
     @Timed(name = "timedMethod")

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/TimerFieldBean.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/TimerFieldBean.java
@@ -18,8 +18,10 @@ package org.eclipse.microprofile.metrics.tck.metrics;
 import org.eclipse.microprofile.metrics.Timer;
 import org.eclipse.microprofile.metrics.annotation.Metric;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 
+@Dependent
 public class TimerFieldBean {
 
     @Inject

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/tags/CounterFieldTagBean.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/tags/CounterFieldTagBean.java
@@ -24,8 +24,10 @@ package org.eclipse.microprofile.metrics.tck.tags;
 import org.eclipse.microprofile.metrics.Counter;
 import org.eclipse.microprofile.metrics.annotation.Metric;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 
+@Dependent
 public class CounterFieldTagBean {
 
     @Inject

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/tags/HistogramTagFieldBean.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/tags/HistogramTagFieldBean.java
@@ -24,8 +24,10 @@ package org.eclipse.microprofile.metrics.tck.tags;
 import org.eclipse.microprofile.metrics.Histogram;
 import org.eclipse.microprofile.metrics.annotation.Metric;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 
+@Dependent
 public class HistogramTagFieldBean {
 
     @Inject

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/tags/MeteredTagMethodBean.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/tags/MeteredTagMethodBean.java
@@ -23,6 +23,9 @@ package org.eclipse.microprofile.metrics.tck.tags;
 
 import org.eclipse.microprofile.metrics.annotation.Metered;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class MeteredTagMethodBean {
 
     @Metered(name = "meteredMethod", tags = {"number=one"})

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/tags/SimpleTimerTagFieldBean.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/tags/SimpleTimerTagFieldBean.java
@@ -24,8 +24,10 @@ package org.eclipse.microprofile.metrics.tck.tags;
 import org.eclipse.microprofile.metrics.SimpleTimer;
 import org.eclipse.microprofile.metrics.annotation.Metric;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 
+@Dependent
 public class SimpleTimerTagFieldBean {
 
     @Inject

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/tags/SimplyTimedTagMethodBean.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/tags/SimplyTimedTagMethodBean.java
@@ -23,6 +23,9 @@ package org.eclipse.microprofile.metrics.tck.tags;
 
 import org.eclipse.microprofile.metrics.annotation.SimplyTimed;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class SimplyTimedTagMethodBean {
 
     @SimplyTimed(name = "simplyTimedMethod", tags = {"number=one"})

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/tags/TimedTagMethodBean.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/tags/TimedTagMethodBean.java
@@ -23,6 +23,9 @@ package org.eclipse.microprofile.metrics.tck.tags;
 
 import org.eclipse.microprofile.metrics.annotation.Timed;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class TimedTagMethodBean {
 
     @Timed(name = "timedMethod", tags = {"number=one"})

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/tags/TimerTagFieldBean.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/tags/TimerTagFieldBean.java
@@ -24,8 +24,10 @@ package org.eclipse.microprofile.metrics.tck.tags;
 import org.eclipse.microprofile.metrics.Timer;
 import org.eclipse.microprofile.metrics.annotation.Metric;
 
+import jakarta.enterprise.context.Dependent;
 import jakarta.inject.Inject;
 
+@Dependent
 public class TimerTagFieldBean {
 
     @Inject

--- a/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/multipleinstances/DependentScopedBean.java
+++ b/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/multipleinstances/DependentScopedBean.java
@@ -26,6 +26,9 @@ import org.eclipse.microprofile.metrics.annotation.Counted;
 import org.eclipse.microprofile.metrics.annotation.Metered;
 import org.eclipse.microprofile.metrics.annotation.Timed;
 
+import jakarta.enterprise.context.Dependent;
+
+@Dependent
 public class DependentScopedBean {
 
     @Counted(name = "counter", absolute = true)


### PR DESCRIPTION
Fixes #665 

These were the tests that started failing for me once I tried with CDI 4 (or rather the beans used in them). The rest works just fine as-is, so I didn't touch it.

To reiterate myself - this doesn't change the TCK behavior in any way. It simply makes it CDI-version agnostic so that the TCK works with CDI 3 and CDI 4 implementations. It will ease transition for any early adopters and will eliminate future fraction when actual migration to EE 10 happens. See linked issue for more information.

This change was tested with SR impl customized to run the TCKs on Weld 5 container and the tests passed.

Note that I looked into `tck/api` and `tck/rest` and tested those. The `tck/optional` I only scanned but didn't manage to test but there is basically two tests and all the beans are annotated so that should work just fine gong forward.