### PR TITLE
initial spec updates for MP Metrics 5.0

### DIFF
--- a/spec/src/main/asciidoc/app-programming-model.adoc
+++ b/spec/src/main/asciidoc/app-programming-model.adoc
@@ -44,10 +44,6 @@ public int getQueueSize() {
 }
 ----
 
-- NOTE: The programming API was inspired by Dropwizard Metrics 3.2.3 API, with some changes.
-It is expected that many existing DropWizard Metrics based applications can easily be
-ported over by switching the package names.
-
 - NOTE: There are no hard limits on the number of metrics, but it is often not a good practice to 
 create a huge number of metrics, because the downstream time series databases
 that need to store the metrics may not deal well with this amount of data.
@@ -68,22 +64,13 @@ and throw an `IllegalArgumentException` if such duplicate exists
 * The implementation must flag and reject metrics upon registration if the metadata information being registered is not equivalent to the metadata information that has already been registered under the given metric name (if it already exists).
 ** All metrics of a given metric name must be associated with the same metadata information
 ** The implementation must throw an `IllegalArgumentException` when the metric is rejected.
-* The implementation must throw an `IllegalStateException` if an annotated metric is invoked, but the metric no longer exists in the MetricRegistry. This applies to the following annotations : @Timed, @SimplyTimed, @Counted, @ConcurrentGauge, @Metered
+* The implementation must throw an `IllegalStateException` if an annotated metric is invoked, but the metric no longer exists in the MetricRegistry. This applies to the following annotations : @Timed, @Counted
 * The implementation must make sure that metric registries are thread-safe, in other words, concurrent calls to methods of `MetricRegistry` must not leave the registry in an inconsistent state.
 
 
 === Base Package
 
 All Java-Classes are in the top-level package `org.eclipse.microprofile.metrics` or one of its sub-packages.
-
-[TIP]
-====
-The `org.eclipse.microprofile.metrics` package was influenced by the Drop Wizard Metrics project release 3.2.3.
-
-Implementors can consult this project for implementation ideas.
-
-See <<appendix#references>> for more information.
-====
 
 [[api-annotations]]
 === Annotations
@@ -101,14 +88,6 @@ Both the Java Interceptors and CDI specifications set restrictions about the typ
 That implies only _managed beans_ whose bean types are _proxyable_ can be instrumented using the Metrics annotations.
 ====
 
-[TIP]
-====
-The `org.eclipse.microprofile.metrics.annotation` package was influenced by the CDI extension for Dropwizard Metric project release 1.4.0.
-
-Implementors can consult this project for implementation ideas.
-
-See <<appendix#references>> for more information.
-====
 The following Annotations exist, see below for common fields:
 
 [cols="1,1,3,2"]
@@ -116,12 +95,9 @@ The following Annotations exist, see below for common fields:
 |Annotation | Applies to |  Description | Default Unit
 
 |@Counted | M, C, T | Denotes a counter, which counts the invocations of the annotated object. | MetricUnits.NONE
-|@ConcurrentGauge | M, C, T | Denotes a gauge which counts the parallel invocations of the annotated object. | MetricUnits.NONE
 |@Gauge   | M | Denotes a gauge, which samples the value of the annotated object.  | _no default_, must be supplied by the user
-|@Metered | M, C, T  | Denotes a meter, which tracks the frequency of invocations of the annotated object. | MetricUnits.PER_SECOND
 |@Metric  | F, P | An annotation that contains the metadata information when requesting a metric to be injected. | MetricUnits.NONE
 |@Timed   | M, C, T | Denotes a timer, which tracks duration of the annotated object. | MetricUnits.NANOSECONDS
-|@SimplyTimed   | M, C, T | Denotes a simple timer, which tracks duration and invocations of the annotated object. | MetricUnits.NANOSECONDS
 |===
 (C=Constructor, F=Field, M=Method, P=Parameter, T=Type)
 
@@ -256,7 +232,6 @@ The implementation must support the following annotation targets:
   * `TYPE`
 
 NOTE: This annotation has changed in MicroProfile Metrics 2.0: Counters now always increase monotonically upon invocation.
-The old behaviour pre 2.0 can now be achieved with `@ConcurrentGauge`.
 
 If the metric no longer exists in the `MetricRegistry` when the annotated element is invoked then an `IllegalStateException` will be thrown.
 
@@ -305,66 +280,6 @@ public class CounterBean {
 }
 ----
 
-[[ConcurrentGaugeDef]]
-==== @ConcurrentGauge
-An annotation for marking a method, constructor, or type as a parallel invocation counted.
-The semantics is such that upon entering a marked item, the parallel count is increased by one and upon
-exit again decreased by one. The purpose of this annotation is to gauge the number of parallel
-invocations of the marked methods or constructors.
-
-The implementation must support the following annotation targets:
-
-  * `CONSTRUCTOR`
-  * `METHOD`
-  * `TYPE`
-
-If the metric no longer exists in the `MetricRegistry` when the annotated element is invoked then an `IllegalStateException` will be thrown.
-
-The following lists the behavior for each annotation target.
-
-===== CONSTRUCTOR
-
-When a constructor is annotated, the implementation must register gauges, representing the current,
-previous minute maximum, and previous minute minimum values for the constructor using the <<annotated-naming-convention>>.
-
-.Example of an annotated constructor
-[source, java]
-----
-@ConcurrentGauge
-public CounterBean() {
-}
-----
-
-===== METHOD
-
-When a non-private method is annotated, the implementation must register gauges, representing the current,
-previous minute maximum, and previous minute minimum values for the method using the <<annotated-naming-convention>>.
-
-.Example of an annotated method
-[source, java]
-----
-@ConcurrentGauge
-public void run() {
-}
-----
-
-===== TYPE
-When a type/class is annotated, the implementation must register gauges, representing the current,
-previous minute maximum, and previous minute minimum values for each of the constructors and non-private methods
-using the <<annotated-naming-convention>>.
-
-.Example of an annotated type/class
-[source, java]
-----
-@ConcurrentGauge
-public class CounterBean {
-
-  public void countMethod1() {}
-  public void countMethod2() {}
-
-}
-----
-
 ==== @Gauge
 An annotation for marking a method as a gauge. No default `MetricUnit` is supplied, so the `unit` must always be specified explicitly.
 
@@ -385,113 +300,6 @@ When a non-private method is annotated, the implementation must register a gauge
 @Gauge(unit = MetricUnits.NONE)
 public long getValue() {
   return value;
-}
-----
-
-
-==== @Metered
-An annotation for marking a constructor or method as metered. The meter counts the invocations
-of the constructor or method and tracks how frequently they are called.
-
-The implementation must support the following annotation targets:
-
-  * `CONSTRUCTOR`
-  * `METHOD`
-  * `TYPE`
-
-If the metric no longer exists in the `MetricRegistry` when the annotated element is invoked then an `IllegalStateException` will be thrown.
-
-The following lists the behavior for each annotation target.
-
-===== CONSTRUCTOR
-
-When a constructor is annotated, the implementation must register a meter for the constructor using the <<annotated-naming-convention>>. The meter is marked each time the constructor is invoked.
-
-.Example of an annotated constructor
-[source, java]
-----
-@Metered
-public MeteredBean() {
-}
-----
-
-===== METHOD
-
-When a non-private method is annotated, the implementation must register a meter for the method using the <<annotated-naming-convention>>. The meter is marked each time the method is invoked.
-
-.Example of an annotated method
-[source, java]
-----
-@Metered
-public void run() {
-}
-----
-
-===== TYPE
-When a type/class is annotated, the implementation must register a meter for each of the constructors and non-private methods using the <<annotated-naming-convention>>. The meters are marked each time the corresponding constructor/method is invoked.
-
-.Example of an annotated type/class
-[source, java]
-----
-@Metered
-public class MeteredBean {
-
-  public void meteredMethod1() {}
-  public void meteredMethod2() {}
-
-}
-----
-
-==== @SimplyTimed
-An annotation for marking a constructor or method of an annotated object as simply timed.
-The metric of type SimpleTimer tracks the count of invocations of the annotated object and tracks how long it took the invocations to complete.
-
-The implementation must support the following annotation targets:
-
-  * `CONSTRUCTOR`
-  * `METHOD`
-  * `TYPE`
-
-If the metric no longer exists in the `MetricRegistry` when the annotated element is invoked then an `IllegalStateException` will be thrown.
-
-The following lists the behavior for each annotation target.
-
-===== CONSTRUCTOR
-
-When a constructor is annotated, the implementation must register a simple timer for the constructor using the <<annotated-naming-convention>>. Each time the constructor is invoked, the execution will be timed.
-
-.Example of an annotated constructor
-[source, java]
-----
-@SimplyTimed
-public SimplyTimedBean() {
-}
-----
-
-===== METHOD
-
-When a non-private method is annotated, the implementation must register a simple timer for the method using the <<annotated-naming-convention>>. Each time the method is invoked, the execution will be timed.
-
-.Example of an annotated method
-[source, java]
-----
-@SimplyTimed
-public void run() {
-}
-----
-
-===== TYPE
-When a type/class is annotated, the implementation must register a simple timer for each of the constructors and non-private methods using the <<annotated-naming-convention>>. Each time a constructor/method is invoked, the execution will be timed with the corresponding simple timer.
-
-.Example of an annotated type/class
-[source, java]
-----
-@SimplyTimed
-public class SimplyTimedBean {
-
-  public void simplyTimedMethod1() {}
-  public void simplyTimedMethod2() {}
-
 }
 ----
 
@@ -610,29 +418,14 @@ lots of annotations in the code. The two approaches can also be combined if nece
 |`counter(String name, Tag... tags)` | Counter with given name and tags
 |`counter(Metadata metadata)` | Counter from given `Metadata` object
 |`counter(Metadata metadata, Tag... tags)` | Counter from given `Metadata` object with given tags
-|`concurrentGauge(String name)` | Concurrent gauge with given name and no tags
-|`concurrentGauge(String name, Tag... tags)` | Concurrent gauge with given name and tags
-|`concurrentGauge(Metadata metadata)` | Concurrent gauge from given `Metadata` object
-|`concurrentGauge(Metadata metadata, Tag... tags)` | Concurrent gauge from given `Metadata` object with given tags
 |`histogram(String name)` | Histogram with given name and no tags
 |`histogram(String name, Tag... tags)` | Histogram with given name and tags
 |`histogram(Metadata metadata)` | Histogram from given `Metadata` object
 |`histogram(Metadata metadata, Tag... tags)` | Histogram from given `Metadata` object with given tags
-|`meter(String name)` | Meter with given name and no tags
-|`meter(String name, Tag... tags)` | Meter with given name and tags
-|`meter(Metadata metadata)` | Meter from given `Metadata` object 
-|`meter(Metadata metadata, Tag... tags)` | Meter from given `Metadata` object with given tags
 |`timer(String name)` | Timer with given name and no tags
 |`timer(String name, Tag... tags)` | Timer with given name and tags
 |`timer(Metadata metadata)` | Timer from given `Metadata` object
 |`timer(Metadata metadata, Tag... tags)` | Timer from given `Metadata` object with given tags
-|`simpleTimer(String name)` | SimpleTimer with given name and no tags
-|`simpleTimer(String name, Tag... tags)` | SimpleTimer with given name and tags
-|`simpleTimer(Metadata metadata)` | SimpleTimer from given `Metadata` object
-|`simpleTimer(Metadata metadata, Tag... tags)` | SimpleTimer from given `Metadata` object with given tags
-|`register(String name, T metric)` | Registers the given metric instance under the given name 
-|`register(Metadata metadata, T metric)` | Registers the given metric instance using the given metadata object
-|`register(Metadata metadata, T metric, Tag... tags)` | Registers the given metric instance using the given metadata object and given tags
 |===
 
 All metrics in the table above, except the variants of `register`, exhibit the _get-or-create_ semantics, 
@@ -671,10 +464,11 @@ it is still possible to dynamically remove metrics from metric registries at run
 === Metric Registries
 
 The `MetricRegistry` is used to maintain a collection of metrics along with their <<pgm-metadata,metadata>>.
-There is one shared singleton of the `MetricRegistry` per scope (_application_, _base_, and _vendor_).
-When metrics are registered using annotations, the metrics are registered in the _application_ `MetricRegistry` (and thus the _application_ scope).
+There is one shared singleton of the `MetricRegistry` per pre-defined scope (_application_, _base_, and _vendor_).
+There is also one shared singleton of the `MetricRegistry` per custom scope.
+When metrics are registered using annotations and no scope is provided, the metrics are registered in the _application_ `MetricRegistry` (and thus the _application_ scope).
 
-When injected, the `@RegistryType` is used as a qualifier to selectively inject either the `APPLICATION`, `BASE`, or `VENDOR` registry.
+When injected, the `@RegistryType` is used as a qualifier to selectively inject one of the `APPLICATION`, `BASE`, `VENDOR` or custom registries.
 If no qualifier is used, the default `MetricRegistry` returned is the `APPLICATION` registry.
 
 Implementations may choose to use a Factory class to produce the injectable `MetricRegistry` bean via CDI. See <<appendix#metric-registry-factory>>. Note: The factory would be an internal class and not exposed to the application.
@@ -724,6 +518,19 @@ The implementation must produce the _vendor_ `MetricRegistry` when the `Registry
 @RegistryType(type=MetricRegistry.Type.VENDOR)
 MetricRegistry vendorRegistry;
 ----
+
+==== Custom Metric Registries
+The implementation must produce the `MetricRegistry` corresponding to the custom-named registry when the `RegistryType` is a custom value. If the custom-named MetricRegistry does not yet exist the implementation must create a `MetricRegistry` with the specified name.
+
+.Example of the application injecting a custom-named registry
+[source, java]
+----
+@Inject
+@RegistryType(type="motorguide")
+MetricRegistry motorGuideRegistry;
+----
+
+
 
 [[pgm-metadata]]
 ==== Metadata

--- a/spec/src/main/asciidoc/architecture.adoc
+++ b/spec/src/main/asciidoc/architecture.adoc
@@ -54,12 +54,12 @@ Section <<required-metrics#required-metrics>> lists the required metrics. This l
 These are listed here as they are dependent on the underlying JVM and not the server and thus fit better in _base_ scope
 than the _vendor_ one.
 
-The optional REST metrics are listed as base metrics as they are expected to be portable between different implementations. If the implementation provides REST metrics, it is up to the implementation to decide how to enable the REST metrics.
+The implementation must tag base metrics with `scope=base`.
 
-Required base metrics are exposed under `/metrics/base`.
+Required base metrics are exposed under `/metrics?scope=base`.
 
 The `base` scope is used for, and only for, any metrics that are defined in MicroProfile specifications. 
-Metrics in the base scope are intended to be portable between different MicroProfile-compatible runtimes.
+Metrics in the base scope are intended to be portable between different MicroProfile-compatible runtimes at the same version.
 
 ===== Application metrics
 
@@ -69,14 +69,23 @@ can expose the same metrics on a different compliant server without change.
 
 Details of this Java API are described in <<app-programming-model#app-programming-model>>.
 
-Application specific metrics are exposed under `/metrics/application`.
+The implementation must automatically tag application metrics with `scope=application`, except where the metric already has a `scope` tag. 
 
+Metrics with application scope are exposed under `/metrics?scope=application`.
+
+Applications may also define their own scope names by tagging metrics with another 
+`scope` (other than `base`, `vendor`, `application`). Metrics with custom scopes are exposed 
+under `/metrics?scope=scope_name` where scope_name is defined by the application. Scope names must match the regex `[a-zA-Z_][a-zA-Z0-9_]*`. If an illegal character is used, the implementation must
+throw an `IllegalArgumentException`.
+
+Metrics with application-defined scopes are exposed under `/metrics?scope=scope_name`
 
 ===== Vendor specific Metrics
 
 It is possible for MicroProfile server implementors to supply their specific metrics data on top
 of the basic set of required metrics.
-Vendor specific metrics are exposed under `/metrics/vendor`.
+
+Vendor specific metrics are exposed under `/metrics?scope=vendor`.
 
 Examples for vendor specific data could be metrics like:
 
@@ -89,10 +98,12 @@ the same application framework.
 Vendor specific metrics are not supposed to be portable between different implementations
 of MicroProfile servers, even if they are compliant with the same version of this specification.
 
+Vendors are encouraged to use metric names consistent with the https://opentelemetry.io/docs/reference/specification/metrics/semantic_conventions/[Open Telemetry Metrics Semantic Conventions] where applicable.
+
 [[metric_tags]]
 ==== Tags
 
-Tags (or labels) play an important role in modern microservices and microservice scheduling systems (like e.g. Kubernetes).
+Tags (also known as labels) play an important role in modern microservices and microservice scheduling systems (like e.g. Kubernetes).
 Application code can run on any node and can be re-scheduled to a different node at any time. Each container in such
 an environment gets its own ID; when the container is stopped and a new one started for the same image, it will get a
 different id. The classical mapping of host/node and application runtime on it, therefore no longer works.
@@ -159,17 +170,9 @@ The Metadata:
 * unit: a fixed set of string units
 * type:
 ** counter: a monotonically increasing numeric value (e.g. total number of requests received).
-** concurrent gauge: an incrementally increasing or decreasing numeric value (e.g. number of parallel invocations of a method).
-+
-This type exposes three values: current count, highest count within the previous completed full minute and lowest count within the
-previous completed full minute.
-+
-Full minute is the minute from second 0 to just before second 0 on the next minute ( eg. from [10:46:00-10:46:59.99999999] ).
 ** gauge: a metric that is sampled to obtain its value (e.g. cpu temperature or disk usage).
-** meter: a metric which tracks mean throughput and one-, five-, and fifteen-minute exponentially-weighted moving average throughput.
 ** histogram: a metric which calculates the distribution of a value.
-** timer: a metric which aggregates timing durations and provides duration statistics, plus throughput statistics.
-** simple timer: a lightweight alternative to the timer metric that only tracks the elapsed time duration, invocation counts, highest recorded time duration within the previous completed full minute and lowest recorded time duration within the previous completed full minute. The simple timer may be preferrable over the timer when used with Prometheus as the statistical calculations can be deferred to Prometheus using the simple timer's available values.
+** timer: a metric which aggregates timing durations and provides duration statistics.
 * description (optional): A human readable description of the metric.
 * displayName (optional): A human readable name of the metric for display purposes if the metric name is not
 human readable. This could e.g. be the case when the metric name is a uuid.
@@ -187,7 +190,7 @@ an overall view if the same metric has different metadata.
 
 === Metric Registry
 The `MetricRegistry` stores the metrics and metadata information.
-There is one `MetricRegistry` instance for each of the scopes listed in <<scopes>>.
+There is one `MetricRegistry` instance for each of the predefined scopes listed in <<scopes>>.
 
 Metrics can be added to or retrieved from the registry either using the `@Metric` annotation
 (see <<app-programming-model#api-annotations, Metrics Annotations>>) or using the `MetricRegistry` object directly.
@@ -236,9 +239,8 @@ In these cases, where multiple bean instances exist, only one instance of the co
 to that metric will be combined from all related invocations regardless of the bean instance where the invocation happens. 
 For example, calls to a method annotated with `@Counted` will increase the value of the same counter no matter which bean 
 instance is the one where the counted method is being invoked.
-Concurrent gauges will watch the number of parallel invocations of a method even if the invocations are on different instances.
 
-The only exception from this are gauges (not concurrent gauges), which don't support multiple instances of the underlying bean to be created,
+The only exception from this are gauges, which don't support multiple instances of the underlying bean to be created,
 because in that case it would not be clear which instance should be used for obtaining the gauge value. For this reason,
 gauges should only be used with beans that create only one instance, in CDI terms this means `@ApplicationScoped` and `@Singleton` beans.
 The implementation may employ validation checks that throw an error eagerly when it is detected that there is a `@Gauge` on a bean
@@ -277,11 +279,11 @@ The API MUST NOT return a 500 Internal Server Error code to represent a non-exis
 | Endpoint | Request Type | Supported Formats | Description
 
 | `/metrics` | GET | JSON, OpenMetrics | Returns all registered metrics
-| `/metrics/<scope>` | GET | JSON, OpenMetrics | Returns metrics registered for the respective scope. Scopes are listed in <<metrics-setup>>
-| `/metrics/<scope>/<metric_name>` | GET | JSON, OpenMetrics | Returns the metric that matches the metric name for the respective scope
+| `/metrics?scope=<scope_name>` | GET | JSON, OpenMetrics | Returns metrics registered for the respective scope. Scopes are listed in <<metrics-setup>>
+| `/metrics?scope=<scope_name>&name=<metric_name>` | GET | JSON, OpenMetrics | Returns metrics that match the metric name for the respective scope
 | `/metrics` | OPTIONS | JSON | Returns all registered metrics' metadata
-| `/metrics/<scope>` | OPTIONS | JSON | Returns metrics' metadata registered for the respective scope. Scopes are listed in <<metrics-setup>>
-| `/metrics/<scope>/<metric_name>` | OPTIONS | JSON | Returns the metric's metadata that matches the metric name for the respective scope
+| `/metrics?scope=<scope_name>` | OPTIONS | JSON | Returns metrics' metadata registered for the respective scope. Scopes are listed in <<metrics-setup>>
+| `/metrics/scope=<scope_name>&name=<metric_name>` | OPTIONS | JSON | Returns the metric's metadata that matches the metric name for the respective scope
 |===
 
 NOTE: The implementation must return a 406 response code if the request's HTTP Accept header for an OPTIONS request
@@ -295,7 +297,7 @@ how such application servers should behave if they want to support MicroProfile 
 Metrics from all applications and scopes should be available under a single REST endpoint ending with `/metrics` similarly as
 in case of single-application deployments (microservices).
 
-To help distinguish between metrics pertaining to each deployed application, a tag named `_app` should be appended to each metric. 
+To help distinguish between metrics pertaining to each deployed application, a tag named `_app` should be added to each metric. 
 
 The value of the `_app` tag should be passed by the application server to the application via a MicroProfile Config property named `mp.metrics.appName`.
 It should be possible to override this value by bundling the file `META-INF/microprofile-config.properties` within the application archive

--- a/spec/src/main/asciidoc/changelog.adoc
+++ b/spec/src/main/asciidoc/changelog.adoc
@@ -22,6 +22,52 @@
 = Release Notes
 
 
+[[release_notes_5_0]]
+== Changes in 5.0
+
+=== Breaking changes
+
+=== API/SPI Changes
+* Updated Timer class
+** Removed `getFifteenMinuteRate()` method
+** Removed `getFiveMinuteRate()` method
+** Removed `getMeanMinuteRate()` method
+** Removed `getOneMinuteRate()` method
+
+* Updated MetricRegistry class
+** Removed `register(String name, T metric)` method
+** Removed `register(Metadata metadata, T metric)` method
+** Removed `register(Metadata metadata, T metric, Tag... tags)` method
+** Removed `concurrentGauge(String name)` method
+** Removed `concurrentGauge(String name, Tag... tags)` method
+** Removed `concurrentGauge(MetricID metricID)` method
+** Removed `concurrentGauge(Metadata metadata)` method
+** Removed `concurrentGauge(Metadata metadata, Tag... tags)` method
+** Removed `meter(String name)` method
+** Removed `meter(String name, Tag... tags)` method
+** Removed `meter(MetricID metricID)` method
+** Removed `meter(Metadata metadata)` method
+** Removed `meter(Metadata metadata, Tag... tags)` method
+** Removed `simpleTimer(String name)` method
+** Removed `simpleTimer(String name, Tag... tags)` method
+** Removed `simpleTimer(MetricID metricID)` method
+** Removed `simpleTimer(Metadata metadata)` method
+** Removed `simpleTimer(Metadata metadata, Tag... tags)` method
+** Removed `getConcurrentGauge(MetricID metricID)` method
+** Removed `getConcurrentGauges()` method
+** Removed `getConcurrentGauges(MetricFilter filter)` method
+** Removed `getMeter(MetricID metricID)` method
+** Removed `getMeters()` method
+** Removed `getMeters(MetricFilter filter)` method
+** Removed `getSimpleTimer(MetricID metricID)` method
+** Removed `getSimpleTimers()` method
+** Removed `getSimpleTimers(MetricFilter filter)` method
+
+* Updated MetricType class
+** Removed `CONCURRENT_GAUGE("concurrent gauge", ConcurrentGauge.class)` enum
+** Removed `METERED("meter", Meter.class)` enum
+** Removed `SIMPLE_TIMER("simple timer", SimpleTimer.class)` enum
+
 [[release_notes_4_0]]
 == Changes in 4.0
 

--- a/spec/src/main/asciidoc/intro.adoc
+++ b/spec/src/main/asciidoc/intro.adoc
@@ -27,12 +27,12 @@ endpoints and metrics for each process adhering to the Eclipse MicroProfile stan
 This proposal does not talk about health checks. There is a separate specification for
 https://github.com/eclipse/microprofile-health[Health Checks].
 
-=== Future Direction
-
-Over the last few months the group involved in metrics has been investigating https://micrometer.io/[Micrometer].
-This investigation will lead to changes to MP Metrics for releases in 2021.
-What exactly will change in the specification and what level of compatibility will be maintained between MP Metrics 3.0 and 4.x releases hasn't been determined.
-The intent will be to shift towards Micrometer as a solution suited to providing metrics for Site Reliability tooling.
+In the previous release we mentioned our intent to investigate https://micrometer.io/[Micrometer]. 
+This has led to key changes in this specification, and the corresponding API, to allow for a variety
+of possible implementations. As examples, it should be possible to implement this specification
+using metrics libraries from Micrometer or Open https://opentelemetry.io/[Open Telemetry]. The modifications to the API, since
+the previous release, have been made in consideration of maintaining backwards compatibility, as much
+as possible, but while removing parts of the API that limited the ability to plug in new implementations.
 
 === Motivation
 

--- a/spec/src/main/asciidoc/intro.adoc
+++ b/spec/src/main/asciidoc/intro.adoc
@@ -30,7 +30,7 @@ https://github.com/eclipse/microprofile-health[Health Checks].
 In the previous release we mentioned our intent to investigate https://micrometer.io/[Micrometer]. 
 This has led to key changes in this specification, and the corresponding API, to allow for a variety
 of possible implementations. As examples, it should be possible to implement this specification
-using metrics libraries from Micrometer or Open https://opentelemetry.io/[Open Telemetry]. The modifications to the API, since
+using metrics libraries from Micrometer or https://opentelemetry.io/[Open Telemetry]. The modifications to the API, since
 the previous release, have been made in consideration of maintaining backwards compatibility, as much
 as possible, but while removing parts of the API that limited the ability to plug in new implementations.
 

--- a/spec/src/main/asciidoc/rest-endpoints.adoc
+++ b/spec/src/main/asciidoc/rest-endpoints.adoc
@@ -45,17 +45,21 @@ For example:
 {
  "carsCounter;colour=red": 0,
  "carsCounter;car=sedan;colour=blue": 0,
- "carsMeter": {
-    "count;colour=red": 0,
-    "meanRate;colour=red": 0,
-    "oneMinRate;colour=red": 0,
-    "fiveMinRate;colour=red": 0,
-    "fifteenMinRate;colour=red": 0,
-    "count;colour=blue": 0,
-    "meanRate;colour=blue": 0,
-    "oneMinRate;colour=blue": 0,
-    "fiveMinRate;colour=blue": 0,
-    "fifteenMinRate;colour=blue": 0
+ "carsSpeed": {
+    "count;colour=red": 324,
+    "percentile;colour=red;_p=50": 110,
+    "percentile;colour=red;_p=75": 122,
+    "percentile;colour=red;_p=95": 135,
+    "percentile;colour=red;_p=98": 138,
+    "percentile;colour=red;_p=99": 141,
+    "percentile;colour=red;_p=99.9": 155,
+    "count;colour=blue": 199,
+    "percentile;colour=blue;_p=50": 105,
+    "percentile;colour=blue;_p=75": 118,
+    "percentile;colour=blue;_p=95": 133,
+    "percentile;colour=blue;_p=98": 139,
+    "percentile;colour=blue;_p=99": 140,
+    "percentile;colour=blue;_p=99.9": 152        
  }
 }
 ----
@@ -113,7 +117,10 @@ In case `/metrics` is requested, then the data for the scopes are wrapped in the
      "thread.count": 33,
      "thread.max.count": 47
   },
-  "vendor": {...}
+  "vendor": {...},
+  "someCustomScope": {
+    "myCounter": 22
+  }
 }
 ----
 
@@ -150,79 +157,6 @@ The JSON leaf is named `<metric-name>[';'<tag-name>'='<tag-value>]+` with tags i
 }
 ----
 
-==== Concurrent Gauge JSON Format
-
-`ConcurrentGauge` is a complex metric type comprised of multiple key/values. The format is specified by the table below.
-The JSON node is named `<metric-name>`. The JSON leaves are named `<key>[';'<tag-name>'='<tag-value>]+` with tags in alphabetical order and keys according to below table.
-
-.JSON mapping for a ConcurrentGauge metric
-[cols="1,4"]
-|===
-| JSON Key | Value (Equivalent ConcurrentGauge method)
-
-| `current` | `getValue()`
-| `min` | `getMin()`
-| `max` | `getMax()`
-|===
-
-.Example ConcurrentGauge JSON GET Response
-[source, json]
-----
-{
-  "callCount": {
-      "current" : 48,
-      "min": 4,
-      "max": 50,
-      "current;component=backend" : 23,
-      "min;component=backend": 1,
-      "max;component=backend": 29
-  }
-}
-----
-
-
-==== Meter JSON Format
-
-`Meter` is a complex metric type comprised of multiple key/values. The format is specified by the table below.
-The JSON node is named `<metric-name>`. The JSON leafs are named `<key>[';'<tag-name>'='<tag-value>]+` with tags in alphabetical order and keys according to below table.
-
-.JSON mapping for a Meter metric
-[cols="1,4"]
-|===
-| JSON Key | Value (Equivalent Meter method)
-
-| `count` | `getCount()`
-| `meanRate` | `getMeanRate()`
-| `oneMinRate` | `getOneMinuteRate()`
-| `fiveMinRate` | `getFiveMinuteRate()`
-| `fifteenMinRate` | `getFifteenMinuteRate()`
-|===
-
-.Example Meter JSON GET Response
-[source, json]
-----
-{
-  "requests": {
-    "count": 29382,
-    "meanRate": 12.223,
-    "oneMinRate": 12.563,
-    "fiveMinRate": 12.364,
-    "fifteenMinRate": 12.126,
-    "count;servlet=one": 29382,
-    "meanRate;servlet=one": 12.223,
-    "oneMinRate;servlet=one": 12.563,
-    "fiveMinRate;servlet=one": 12.364,
-    "fifteenMinRate;servlet=one": 12.126,
-    "count;servlet=two": 29382,
-    "meanRate;servlet=two": 12.223,
-    "oneMinRate;servlet=two": 12.563,
-    "fiveMinRate;servlet=two": 12.364,
-    "fifteenMinRate;servlet=two": 12.126
-  }
-}
-----
-
-
 ==== Histogram JSON Format
 
 `Histogram` is a complex metric type comprised of multiple key/values. The format is specified by the table below.
@@ -237,8 +171,6 @@ The JSON node is named `<metric-name>`. The JSON leaves are named `<key>[';'<tag
 | `sum` | `getSum()`
 | `min` | `getSnapshot().getMin()`
 | `max` | `getSnapshot().getMax()`
-| `mean` | `getSnapshot().getMean()`
-| `stddev` | `getSnapshot().getStdDev()`
 | `p50` | `getSnapshot().getMedian()`
 | `p75` | `getSnapshot().get75thPercentile()`
 | `p95` | `getSnapshot().get95thPercentile()`
@@ -256,8 +188,6 @@ The JSON node is named `<metric-name>`. The JSON leaves are named `<key>[';'<tag
     "sum": -1598,
     "min": -1624,
     "max": 26,
-    "mean": -799.0,
-    "stddev": 825.0,
     "p50": 26.0,
     "p75": 26.0,
     "p95": 26.0,
@@ -268,8 +198,6 @@ The JSON node is named `<metric-name>`. The JSON leaves are named `<key>[';'<tag
     "sum;servlet=two": -1598,
     "min;servlet=two": -1624,
     "max;servlet=two": 26,
-    "mean;servlet=two": -799.0,
-    "stddev;servlet=two": 825.0,
     "p50;servlet=two": 26.0,
     "p75;servlet=two": 26.0,
     "p95;servlet=two": 26.0,
@@ -293,14 +221,8 @@ The JSON node is named `<metric-name>`. The JSON leaves are named `<key>[';'<tag
 
 | `count` | `getCount()`
 | `elapsedTime` | `getElapsedTime()`
-| `meanRate` | `getMeanRate()`
-| `oneMinRate` | `getOneMinuteRate()`
-| `fiveMinRate` | `getFiveMinuteRate()`
-| `fifteenMinRate` | `getFifteenMinuteRate()`
 | `min` | `getSnapshot().getMin()`
 | `max` | `getSnapshot().getMax()`
-| `mean` | `getSnapshot().getMean()`
-| `stddev` | `getSnapshot().getStdDev()`
 | `p50` | `getSnapshot().getMedian()`
 | `p75` | `getSnapshot().get75thPercentile()`
 | `p95` | `getSnapshot().get95thPercentile()`
@@ -316,14 +238,8 @@ The JSON node is named `<metric-name>`. The JSON leaves are named `<key>[';'<tag
   "responseTime": {
     "count": 29382,
     "elapsedTime": 25608694,
-    "meanRate": 12.185627192860734,
-    "oneMinRate": 12.563,
-    "fiveMinRate": 12.364,
-    "fifteenMinRate": 12.126,
     "min": 169916,
     "max": 5608694,
-    "mean": 415041.00024926325,
-    "stddev": 652907.9633011606,
     "p50": 293324.0,
     "p75": 344914.0,
     "p95": 543647.0,
@@ -332,14 +248,8 @@ The JSON node is named `<metric-name>`. The JSON leaves are named `<key>[';'<tag
     "p999": 5608694.0,
     "count;servlet=two": 29382,
     "elapsedTime;servlet=two": 25608694,
-    "meanRate;servlet=two":12.185627192860734,
-    "oneMinRate;servlet=two": 12.563,
-    "fiveMinRate;servlet=two": 12.364,
-    "fifteenMinRate;servlet=two": 12.126,
     "min;servlet=two": 169916,
     "max;servlet=two": 5608694,
-    "mean;servlet=two": 415041.00024926325,
-    "stddev;servlet=two": 652907.9633011606,
     "p50;servlet=two": 293324.0,
     "p75;servlet=two": 344914.0,
     "p95;servlet=two": 543647.0,
@@ -349,37 +259,6 @@ The JSON node is named `<metric-name>`. The JSON leaves are named `<key>[';'<tag
   }
 }
 ----
-
-==== Simple Timer JSON Format
-
-`Simple Timer` is a complex metric type comprised of multiple key/values. The format is specified by the table below.
-The JSON node is named `<metric-name>`. The JSON leaves are named `<key>[';'<tag-name>'='<tag-value>]+` with tags in alphabetical order and keys according to below table.
-
-.JSON mapping for a Simple Timer metric
-[cols="1,4"]
-|===
-| JSON Key | Value (Equivalent SimpleTimer method)
-
-| `count`                 | `getCount()`
-| `elapsedTime`           | `getElapsedTime()`
-| `maxTimeDuration`       | `getMaxTimeDuration()`
-| `minTimeDuration`       | `getMinTimeDuration()`
-|===
-
-.Example Simple Timer JSON GET Response
-[source, json]
-----
-{
-  "simple_responseTime": {
-    "count": 1,
-    "elapsedTime": 12300000000,
-    "maxTimeDuration": 3231000000,   //(1)
-    "minTimeDuration": 25600000      //(1)
-  }
-}
-----
-
-<1> The `minTimeDuration` and `maxTimeDuration` will display a `null` value if no values were recorded.
 
 ==== Metadata
 
@@ -498,7 +377,7 @@ Characters allowed are `[a-zA-Z0-9_]` (Ascii alphabet, numbers and underscore). 
 follow the pattern `[a-zA-Z_][a-zA-Z0-9_]*`.
 
 * Characters that do not fall in above category are translated to underscore (`_`).
-* Scope is always specified at the start of the metric name.
+* Scope is stored as a tag (eg. scope=base or scope=vendor or scope=app or scope=bananas)
 * Scope and name are separated by underscore (`_`).
 * Double underscore is translated to single underscore
 * The unit is appended to the name, separated by underscore. See <<OpenMetrics_units>>
@@ -585,73 +464,6 @@ The OpenMetrics name is composed `<scope>_<metric-name>_<suffix>`.
 application_visitors_total 80
 ----
 
-==== Concurrent Gauge OpenMetrics Text Format
-
-`ConcurrentGauge` is a complex metric type comprised of multiple key/values. Each key will require a suffix to be appended to the metric name. The format is specified by the table below.
-
-.OpenMetrics text mapping for a ConcurrentGauge metric
-[cols="2,1,2,1"]
-|===
-| Suffix{label}   | TYPE    | Value (Meter method)     | Units
-
-| `current`       | Gauge   | `getCount()`             | N/A
-| `min`           | Gauge   | `getMin()`               | N/A
-| `max`           | Gauge   | `getMax()`               | N/A
-|===
-
-Concurrent gauges do not have a suffix for the unit.
-The OpenMetrics name is composed `<scope>_<metric-name>_<suffix>`.
-
-.Example OpenMetrics text format for a Concurrent Gauge
-[source, ruby]
-----
-# TYPE application_method_a_invocations_current gauge
-# HELP application_method_a_invocations_current The number of parallel invocations of methodA() #<1>
-application_method_a_invocations_current 80
-# TYPE application_method_a_invocations_min gauge
-application_method_a_invocations_min 20
-# TYPE application_method_a_invocations_max gauge
-application_method_a_invocations_max 100
-----
-<1> Note help is only emitted for the metric related to `getCount()`, but not for _min and _max.
-
-==== Meter OpenMetrics Text Format
-
-`Meter` is a complex metric type comprised of multiple key/values. Each key will require a suffix to be appended to the metric name. The format is specified by the table below.
-
-The `# HELP` description line is only required for the `total` value as shown below.
-
-.OpenMetrics text mapping for a Meter metric
-[cols="2,1,2,1"]
-|===
-| Suffix{label}                   | TYPE    | Value (Meter method)                | Units
-
-| `total`                         | Counter | `getCount()`                        | N/A
-| `rate_per_second`               | Gauge   | `getMeanRate()`                     | PER_SECOND
-| `one_min_rate_per_second`       | Gauge   | `getOneMinuteRate()`                | PER_SECOND
-| `five_min_rate_per_second`      | Gauge   | `getFiveMinuteRate()`               | PER_SECOND
-| `fifteen_min_rate_per_second`   | Gauge   | `getFifteenMinuteRate()`            | PER_SECOND
-|===
-
-The OpenMetrics name is composed `<scope>_<metric-name>_<suffix>`.
-
-.Example OpenMetrics text format for a Meter
-[source, ruby]
-----
-# TYPE application_requests_total counter
-# HELP application_requests_total Tracks the number of requests to the server
-application_requests_total 29382
-# TYPE application_requests_rate_per_second gauge
-application_requests_rate_per_second 12.223
-# TYPE application_requests_one_min_rate_per_second gauge
-application_requests_one_min_rate_per_second 12.563
-# TYPE application_requests_five_min_rate_per_second gauge
-application_requests_five_min_rate_per_second 12.364
-# TYPE application_requests_fifteen_min_rate_per_second gauge
-application_requests_fifteen_min_rate_per_second 12.126
-----
-
-
 ==== Histogram OpenMetrics Text Format
 
 `Histogram` is a complex metric type comprised of multiple key/values. Each key will require a suffix to be appended to the metric name with appropriate naming/scaling based on <<OpenMetrics_units>>.  The format is specified by the table below.
@@ -668,7 +480,6 @@ The `quantile` OpenMetrics label is merged with the metric's tags.
 | `min_<units>`                   | Gauge   | `getSnapshot().getMin()`            | <units>^1^
 | `max_<units>`                   | Gauge   | `getSnapshot().getMax()`            | <units>^1^
 | `mean_<units>`                  | Gauge   | `getSnapshot().getMean()`           | <units>^1^
-| `stddev_<units>`                | Gauge   | `getSnapshot().getStdDev()`         | <units>^1^
 | `<units>_count`^2^              | Summary | `getCount()`                        | N/A
 | `<units>_sum`^2^                | Summary | `getSum()`                          | <units>^1^
 | `<units>{quantile="0.5"}`^2^    | Summary | `getSnapshot().getMedian()`         | <units>^1^
@@ -720,14 +531,9 @@ The `quantile` OpenMetrics label is merged with the metric's tags.
 |===
 | Suffix{label}                   | TYPE    | Value (Timer method)                | Units
 
-| `rate_per_second`               | Gauge   | `getMeanRate()`                     | PER_SECOND
-| `one_min_rate_per_second`       | Gauge   | `getOneMinuteRate()`                | PER_SECOND
-| `five_min_rate_per_second`      | Gauge   | `getFiveMinuteRate()`               | PER_SECOND
-| `fifteen_min_rate_per_second`   | Gauge   | `getFifteenMinuteRate()`            | PER_SECOND
 | `min_seconds`                   | Gauge   | `getSnapshot().getMin()`            | SECONDS^1^
 | `max_seconds`                   | Gauge   | `getSnapshot().getMax()`            | SECONDS^1^
 | `mean_seconds`                  | Gauge   | `getSnapshot().getMean()`           | SECONDS^1^
-| `stddev_seconds`                | Gauge   | `getSnapshot().getStdDev()`         | SECONDS^1^
 | `seconds_count`^2^              | Summary | `getCount()`                        | N/A
 | `seconds_sum`^2^                | Summary | `getElapsedTime()`                  | SECONDS^1^
 | `seconds{quantile="0.5"}`^2^    | Summary | `getSnapshot().getMedian()`         | SECONDS^1^
@@ -773,42 +579,6 @@ application_response_time_seconds{quantile="0.99"} 0.005608694
 application_response_time_seconds{quantile="0.999"} 0.005608694
 ----
 
-
-==== Simple Timer OpenMetrics Text Format
-
-`Simple Timer` is a complex metric type comprised of multiple key/values. Each key will require a suffix to be appended to the metric name. The format is specified by the table below.
-The OpenMetrics name is composed `<scope>_<metric-name>_<suffix>`.
-
-
-.OpenMetrics text mapping for a SimpleTimer metric
-[cols="2,1,2,1"]
-|===
-| Suffix{label}                   | TYPE    | Value (SimpleTimer method)                | Units
-| `total`                         | Counter | `getCount()`                              | N/A
-| `elapsedTime_seconds`           | Gauge   | `getElapsedTime()`                        | SECONDS^1^
-| `maxTimeDuration_seconds`       | Gauge   | `getMaxTimeDuration()`                    | SECONDS^1^
-| `minTimeDuration_seconds`       | Gauge   | `getMinTimeDuration()`                    | SECONDS^1^
-|===
-
-^1^ The implementation is expected to convert the result returned by the `SimpleTimer` into seconds
-
-.Example OpenMetrics text format for a SimpleTimer
-[source, ruby]
-----
-# TYPE application_response_time_total counter
-# HELP application_response_time_total The number of calls to this REST endpoint #(1)
-application_response_time_total 12
-# TYPE application_response_time_elapsedTime_seconds gauge
-application_response_time_elapsedTime_seconds  12.30000000
-# TYPE application_response_time_maxTimeDuration_seconds gauge
-application_response_time_maxTimeDuration_seconds  3.231000000 #(2)
-# TYPE application_response_time_minTimeDuration_seconds gauge
-application_response_time_minTimeDuration_seconds  0.0256 #(2)
-----
-
-<1> Note help is only emitted for the metric related to `getCount()`, but not for elapsedTime.
-
-<2> The `minTimeDuration` and `maxTimeDuration` will display a `NaN` value if no values were recorded.
 
 === Security
 


### PR DESCRIPTION
Signed-off-by: Don Bourne <dbourne@ca.ibm.com>

- removed references to `@ConcurrentGauge`
- removed references to `@SimplyTimed`
- removed references to `@Metered`
---
- removed references to MetricRegisty.concurrentGauge
- removed references to MetricRegistry.simpleTimer
- removed references to MetricRegistry.meter
 ---
- removed references to MetricRegistry.register methods allowing Metric implementations to be registered
- removed reference to CDI extension from Dropwizard as potential implementation
---
- added custom scopes / custom MetricRegistrys
- changed metrics/base to metrics?scope=base
- changed metrics/vendor to metrics?scope=vendor
- changed metrics/application to metrics?scope=application
- added requirement that scope be added to all metrics as a tag
---
- added recommendation to follow Open Telemetry semantic conventions for vendor metric names
- removed throughput stats from Timer
- removed mean and stddev from Timer and Histogram
---
- replaced Future Direction with description of what we're trying to make it easy to implement with popular metrics libraries
---
- added initial API changes for 5.0 to breaking changes

