### PR TITLE
Update Histogram/Timer's Snapshot

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/metrics/Snapshot.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/Snapshot.java
@@ -1,6 +1,6 @@
 /*
  **********************************************************************
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017, 2022 Contributors to the Eclipse Foundation
  *               2010-2013 Coda Hale, Yammer.com
  *
  * See the NOTICES file(s) distributed with this work for additional
@@ -39,79 +39,18 @@ public abstract class Snapshot {
     public abstract double getValue(double quantile);
 
     /**
-     * Returns the entire set of values in the snapshot.
-     *
-     * @return the entire set of values
-     */
-    public abstract long[] getValues();
-
-    /**
      * Returns the number of values in the snapshot.
      *
      * @return the number of values
      */
-    public abstract int size();
-
-    /**
-     * Returns the median value in the distribution.
-     *
-     * @return the median value
-     */
-    public double getMedian() {
-        return getValue(0.5);
-    }
-
-    /**
-     * Returns the value at the 75th percentile in the distribution.
-     *
-     * @return the value at the 75th percentile
-     */
-    public double get75thPercentile() {
-        return getValue(0.75);
-    }
-
-    /**
-     * Returns the value at the 95th percentile in the distribution.
-     *
-     * @return the value at the 95th percentile
-     */
-    public double get95thPercentile() {
-        return getValue(0.95);
-    }
-
-    /**
-     * Returns the value at the 98th percentile in the distribution.
-     *
-     * @return the value at the 98th percentile
-     */
-    public double get98thPercentile() {
-        return getValue(0.98);
-    }
-
-    /**
-     * Returns the value at the 99th percentile in the distribution.
-     *
-     * @return the value at the 99th percentile
-     */
-    public double get99thPercentile() {
-        return getValue(0.99);
-    }
-
-    /**
-     * Returns the value at the 99.9th percentile in the distribution.
-     *
-     * @return the value at the 99.9th percentile
-     */
-    public double get999thPercentile() {
-        return getValue(0.999);
-    }
+    public abstract long size();
 
     /**
      * Returns the highest value in the snapshot.
      *
      * @return the highest value
      */
-    public abstract long getMax();
+    public abstract double getMax();
 
     /**
      * Returns the arithmetic mean of the values in the snapshot.
@@ -121,18 +60,12 @@ public abstract class Snapshot {
     public abstract double getMean();
 
     /**
-     * Returns the lowest value in the snapshot.
+     * Returns an array of {@link PercentileValue} containing the percentiles and associated values of this
+     * {@link Snapshot} at the moment invocation.
      *
-     * @return the lowest value
+     * @return an array of {@link PercentileValue}
      */
-    public abstract long getMin();
-
-    /**
-     * Returns the standard deviation of the values in the snapshot.
-     *
-     * @return the standard value
-     */
-    public abstract double getStdDev();
+    public abstract PercentileValue[] percentileValues();
 
     /**
      * Writes the values of the snapshot to the given stream.
@@ -142,4 +75,48 @@ public abstract class Snapshot {
      */
     public abstract void dump(OutputStream output);
 
+    /**
+     * Represents a percentile and its value at the moment it was sampled from the Snapshot.
+     * 
+     * See {@link #percentileValue()}
+     */
+    public static class PercentileValue {
+        private final double percentile;
+        private final double value;
+
+        /**
+         * 
+         * @param percentile
+         *            percentile
+         * @param value
+         *            value of percentile
+         */
+        public PercentileValue(double percentile, double value) {
+            this.percentile = percentile;
+            this.value = value;
+        }
+
+        /**
+         * Returns percentile
+         * 
+         * @return double percentile
+         */
+        public double getPercentile() {
+            return this.percentile;
+        }
+
+        /**
+         * Returns value at percentile
+         * 
+         * @return double value at percentile
+         */
+        public double getValue() {
+            return this.value;
+        }
+
+        public String toString() {
+            return "[Percentile: " + (this.percentile * 100.0) + "% with Value: " + this.value + "]";
+        }
+
+    }
 }

--- a/api/src/main/java/org/eclipse/microprofile/metrics/Snapshot.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/Snapshot.java
@@ -30,15 +30,6 @@ import java.io.OutputStream;
 public abstract class Snapshot {
 
     /**
-     * Returns the value at the given quantile.
-     *
-     * @param quantile
-     *            a given quantile, in {@code [0..1]}
-     * @return the value in the distribution at {@code quantile}
-     */
-    public abstract double getValue(double quantile);
-
-    /**
      * Returns the number of values in the snapshot.
      *
      * @return the number of values

--- a/spec/src/main/asciidoc/rest-endpoints.adoc
+++ b/spec/src/main/asciidoc/rest-endpoints.adoc
@@ -428,11 +428,11 @@ distance_to_hole_meters_sum{_scope="golf_stats"} 1569.3785694223322 <3>
 
 | `<units>_max`                   | Gauge   | `getSnapshot().getMax()`            | <units>
 | `<units>{quantile="0.5"}`       | Summary | `getSnapshot().getMedian()`         | <units>
-| `<units>{quantile="0.75"}`      | Summary | `getSnapshot().get75thPercentile()` | <units>
-| `<units>{quantile="0.95"}`      | Summary | `getSnapshot().get95thPercentile()` | <units>
-| `<units>{quantile="0.98"}`      | Summary | `getSnapshot().get98thPercentile()` | <units>
-| `<units>{quantile="0.99"}`      | Summary | `getSnapshot().get99thPercentile()` | <units>
-| `<units>{quantile="0.999"}`     | Summary | `getSnapshot().get999thPercentile()`| <units>
+| `<units>{quantile="0.75"}`      | Summary | `getSnapshot().getValue(0.75)`      | <units>
+| `<units>{quantile="0.95"}`      | Summary | `getSnapshot().getValue(0.95)`      | <units>
+| `<units>{quantile="0.98"}`      | Summary | `getSnapshot().getValue(0.98)`      | <units>
+| `<units>{quantile="0.99"}`      | Summary | `getSnapshot().getValue(0.99)`      | <units>
+| `<units>{quantile="0.999"}`     | Summary | `getSnapshot().getValue(0.999)`     | <units>
 | `<units>_count`                 | Summary | `getCount()`                        | <units>
 | `<units>_sum`                   | Summary | `getSum()`                          | <units>
 |===
@@ -475,11 +475,11 @@ myClass_myMethod_seconds_max{_scope="vendor"} 0.05507899 <3>
 
 | `max_seconds`                   | Gauge   | `getSnapshot().getMax()`            | SECONDS^1^
 | `seconds{quantile="0.5"}`       | Summary | `getSnapshot().getMedian()`         | SECONDS^1^
-| `seconds{quantile="0.75"}`      | Summary | `getSnapshot().get75thPercentile()` | SECONDS^1^
-| `seconds{quantile="0.95"}`      | Summary | `getSnapshot().get95thPercentile()` | SECONDS^1^
-| `seconds{quantile="0.98"}`      | Summary | `getSnapshot().get98thPercentile()` | SECONDS^1^
-| `seconds{quantile="0.99"}`      | Summary | `getSnapshot().get99thPercentile()` | SECONDS^1^
-| `seconds{quantile="0.999"}`     | Summary | `getSnapshot().get999thPercentile()`| SECONDS^1^
+| `seconds{quantile="0.75"}`      | Summary | `getSnapshot().getValue(0.75)`      | SECONDS^1^
+| `seconds{quantile="0.95"}`      | Summary | `getSnapshot().getValue(0.95)`      | SECONDS^1^
+| `seconds{quantile="0.98"}`      | Summary | `getSnapshot().getValue(0.98)`      | SECONDS^1^
+| `seconds{quantile="0.99"}`      | Summary | `getSnapshot().getValue(0.99)`      | SECONDS^1^
+| `seconds{quantile="0.999"}`     | Summary | `getSnapshot().getValue(0.999)`     | SECONDS^1^
 | `seconds_count`                 | Summary | `getCount()`                        | SECONDS^1^
 | `seconds_sum`                   | Summary | `getElapsedTime()`                  | SECONDS^1^
 |===

--- a/spec/src/main/asciidoc/rest-endpoints.adoc
+++ b/spec/src/main/asciidoc/rest-endpoints.adoc
@@ -427,7 +427,7 @@ distance_to_hole_meters_sum{_scope="golf_stats"} 1569.3785694223322 <3>
 | Suffix{label}                   | TYPE    | Value (Histogram method)            | Units
 
 | `<units>_max`                   | Gauge   | `getSnapshot().getMax()`            | <units>
-| `<units>{quantile="0.5"}`       | Summary | `getSnapshot().getMedian()`         | <units>
+| `<units>{quantile="0.5"}`       | Summary | `getSnapshot().getValue(0.5)`       | <units>
 | `<units>{quantile="0.75"}`      | Summary | `getSnapshot().getValue(0.75)`      | <units>
 | `<units>{quantile="0.95"}`      | Summary | `getSnapshot().getValue(0.95)`      | <units>
 | `<units>{quantile="0.98"}`      | Summary | `getSnapshot().getValue(0.98)`      | <units>
@@ -474,7 +474,7 @@ myClass_myMethod_seconds_max{_scope="vendor"} 0.05507899 <3>
 | Suffix{label}                   | TYPE    | Value (Timer method)                | Units
 
 | `max_seconds`                   | Gauge   | `getSnapshot().getMax()`            | SECONDS^1^
-| `seconds{quantile="0.5"}`       | Summary | `getSnapshot().getMedian()`         | SECONDS^1^
+| `seconds{quantile="0.5"}`       | Summary | `getSnapshot().getValue(0.5)`       | SECONDS^1^
 | `seconds{quantile="0.75"}`      | Summary | `getSnapshot().getValue(0.75)`      | SECONDS^1^
 | `seconds{quantile="0.95"}`      | Summary | `getSnapshot().getValue(0.95)`      | SECONDS^1^
 | `seconds{quantile="0.98"}`      | Summary | `getSnapshot().getValue(0.98)`      | SECONDS^1^

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/HistogramFieldBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/HistogramFieldBeanTest.java
@@ -83,10 +83,11 @@ public class HistogramFieldBeanTest {
 
         // Call the update method and assert the histogram is up-to-date
         long value = Math.round(Math.random() * Long.MAX_VALUE);
+
         bean.update(value);
         assertThat("Histogram count is incorrect", histogram.getCount(), is(equalTo(1L)));
         assertThat("Histogram sum is incorrect", histogram.getSum(), is(equalTo(value)));
-        assertThat("Histogram size is incorrect", histogram.getSnapshot().size(), is(equalTo(1)));
-        assertThat("Histogram max value is incorrect", histogram.getSnapshot().getMax(), is(equalTo(value)));
+        assertThat("Histogram size is incorrect", histogram.getSnapshot().size(), is(equalTo(1L)));
+        assertThat("Histogram max value is incorrect", histogram.getSnapshot().getMax(), is(equalTo((double) value)));
     }
 }

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/HistogramFieldBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/HistogramFieldBeanTest.java
@@ -1,4 +1,5 @@
 /**
+ * Copyright (c) 2013, 2022 Contributors to the Eclipse Foundation
  * Copyright © 2013 Antonin Stefanutti (antonin.stefanutti@gmail.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -86,7 +87,6 @@ public class HistogramFieldBeanTest {
         assertThat("Histogram count is incorrect", histogram.getCount(), is(equalTo(1L)));
         assertThat("Histogram sum is incorrect", histogram.getSum(), is(equalTo(value)));
         assertThat("Histogram size is incorrect", histogram.getSnapshot().size(), is(equalTo(1)));
-        assertThat("Histogram min value is incorrect", histogram.getSnapshot().getMin(), is(equalTo(value)));
         assertThat("Histogram max value is incorrect", histogram.getSnapshot().getMax(), is(equalTo(value)));
     }
 }

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/HistogramTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/HistogramTest.java
@@ -1,6 +1,6 @@
 /*
  **********************************************************************
- * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ * Copyright (c) 2017, 2022 Contributors to the Eclipse Foundation
  *               2010-2013 Coda Hale, Yammer.com
  *
  * See the NOTICES file(s) distributed with this work for additional
@@ -26,11 +26,10 @@ package org.eclipse.microprofile.metrics.tck.metrics;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
-import java.util.Arrays;
-
 import org.eclipse.microprofile.metrics.Histogram;
 import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.Snapshot.PercentileValue;
 import org.eclipse.microprofile.metrics.tck.util.TestUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -131,43 +130,71 @@ public class HistogramTest {
     }
 
     @Test
-    public void testSnapshotValues() throws Exception {
-        Assert.assertArrayEquals(
-                "The histogramInt does not contain the expected values: " + Arrays.toString(SAMPLE_INT_DATA),
-                Arrays.stream(SAMPLE_INT_DATA).asLongStream().toArray(), histogramInt.getSnapshot().getValues());
-        Assert.assertArrayEquals(
-                "The histogramLong does not contain the expected values: " + Arrays.toString(SAMPLE_LONG_DATA),
-                SAMPLE_LONG_DATA, histogramLong.getSnapshot().getValues());
+    public void testSnapshotPercentileValuesPresent() throws Exception {
+
+        PercentileValue[] percentileValuesHistInt = histogramInt.getSnapshot().percentileValues();
+        // Check that there are 5 percentiles - [0.75,0.95,0.98,0.99,0.999]
+        Assert.assertTrue(percentileValuesHistInt.length == 5);
+
+        int countDown = 5;
+        for (PercentileValue pv : percentileValuesHistInt) {
+            double percentile = pv.getPercentile();
+            if (percentile == 0.75 ||
+                    percentile == 0.95 ||
+                    percentile == 0.98 ||
+                    percentile == 0.99 ||
+                    percentile == 0.999) {
+                countDown--;
+            }
+        }
+        Assert.assertTrue(countDown == 0);
+
+        PercentileValue[] percentileValuesHisLong = histogramLong.getSnapshot().percentileValues();
+        // Check that there are 5 percentiles - [0.75,0.95,0.98,0.99,0.999]
+        Assert.assertTrue(percentileValuesHisLong.length == 5);
+
+        countDown = 5;
+        for (PercentileValue pv : percentileValuesHisLong) {
+            double percentile = pv.getPercentile();
+            if (percentile == 0.75 ||
+                    percentile == 0.95 ||
+                    percentile == 0.98 ||
+                    percentile == 0.99 ||
+                    percentile == 0.999) {
+                countDown--;
+            }
+        }
+        Assert.assertTrue(countDown == 0);
     }
 
     @Test
     public void testSnapshot75thPercentile() throws Exception {
-        TestUtils.assertEqualsWithTolerance(75, histogramInt.getSnapshot().get75thPercentile());
-        TestUtils.assertEqualsWithTolerance(750, histogramLong.getSnapshot().get75thPercentile());
+        TestUtils.assertEqualsWithTolerance(75, histogramInt.getSnapshot().getValue(0.75));
+        TestUtils.assertEqualsWithTolerance(750, histogramLong.getSnapshot().getValue(0.75));
     }
 
     @Test
     public void testSnapshot95thPercentile() throws Exception {
-        TestUtils.assertEqualsWithTolerance(96, histogramInt.getSnapshot().get95thPercentile());
-        TestUtils.assertEqualsWithTolerance(960, histogramLong.getSnapshot().get95thPercentile());
+        TestUtils.assertEqualsWithTolerance(96, histogramInt.getSnapshot().getValue(0.95));
+        TestUtils.assertEqualsWithTolerance(960, histogramLong.getSnapshot().getValue(0.95));
     }
 
     @Test
     public void testSnapshot98thPercentile() throws Exception {
-        TestUtils.assertEqualsWithTolerance(98, histogramInt.getSnapshot().get98thPercentile());
-        TestUtils.assertEqualsWithTolerance(980, histogramLong.getSnapshot().get98thPercentile());
+        TestUtils.assertEqualsWithTolerance(98, histogramInt.getSnapshot().getValue(0.98));
+        TestUtils.assertEqualsWithTolerance(980, histogramLong.getSnapshot().getValue(0.98));
     }
 
     @Test
     public void testSnapshot99thPercentile() throws Exception {
-        TestUtils.assertEqualsWithTolerance(98, histogramInt.getSnapshot().get99thPercentile());
-        TestUtils.assertEqualsWithTolerance(980, histogramLong.getSnapshot().get99thPercentile());
+        TestUtils.assertEqualsWithTolerance(98, histogramInt.getSnapshot().getValue(0.98));
+        TestUtils.assertEqualsWithTolerance(980, histogramLong.getSnapshot().getValue(0.98));
     }
 
     @Test
     public void testSnapshot999thPercentile() throws Exception {
-        TestUtils.assertEqualsWithTolerance(99, histogramInt.getSnapshot().get999thPercentile());
-        TestUtils.assertEqualsWithTolerance(990, histogramLong.getSnapshot().get999thPercentile());
+        TestUtils.assertEqualsWithTolerance(99, histogramInt.getSnapshot().getValue(0.999));
+        TestUtils.assertEqualsWithTolerance(990, histogramLong.getSnapshot().getValue(0.999));
     }
 
     @Test
@@ -177,27 +204,9 @@ public class HistogramTest {
     }
 
     @Test
-    public void testSnapshotMin() throws Exception {
-        Assert.assertEquals(0, histogramInt.getSnapshot().getMin());
-        Assert.assertEquals(0, histogramLong.getSnapshot().getMin());
-    }
-
-    @Test
     public void testSnapshotMean() throws Exception {
         TestUtils.assertEqualsWithTolerance(50.6, histogramInt.getSnapshot().getMean());
         TestUtils.assertEqualsWithTolerance(506.3, histogramLong.getSnapshot().getMean());
-    }
-
-    @Test
-    public void testSnapshotMedian() throws Exception {
-        TestUtils.assertEqualsWithTolerance(48, histogramInt.getSnapshot().getMedian());
-        TestUtils.assertEqualsWithTolerance(480, histogramLong.getSnapshot().getMedian());
-    }
-
-    @Test
-    public void testSnapshotStdDev() throws Exception {
-        TestUtils.assertEqualsWithTolerance(29.4, histogramInt.getSnapshot().getStdDev());
-        TestUtils.assertEqualsWithTolerance(294.3, histogramLong.getSnapshot().getStdDev());
     }
 
     @Test

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/HistogramTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/HistogramTest.java
@@ -168,6 +168,12 @@ public class HistogramTest {
     }
 
     @Test
+    public void testSnapshot50thPercentile() throws Exception {
+        TestUtils.assertEqualsWithTolerance(48, histogramInt.getSnapshot().getValue(0.5));
+        TestUtils.assertEqualsWithTolerance(480, histogramLong.getSnapshot().getValue(0.5));
+    }
+
+    @Test
     public void testSnapshot75thPercentile() throws Exception {
         TestUtils.assertEqualsWithTolerance(75, histogramInt.getSnapshot().getValue(0.75));
         TestUtils.assertEqualsWithTolerance(750, histogramLong.getSnapshot().getValue(0.75));

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/HistogramTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/HistogramTest.java
@@ -138,7 +138,7 @@ public class HistogramTest {
     public void testSnapshotPercentileValuesPresent() throws Exception {
 
         PercentileValue[] percentileValuesHistInt = histogramInt.getSnapshot().percentileValues();
-        // Check that there are 5 percentiles - [0.75,0.95,0.98,0.99,0.999]
+        // Check that there are 6 percentiles - [0.75,0.95,0.98,0.99,0.999]
         Assert.assertTrue(percentileValuesHistInt.length == 6);
 
         int countDown = 6;
@@ -156,7 +156,7 @@ public class HistogramTest {
         Assert.assertTrue(countDown == 0);
 
         PercentileValue[] percentileValuesHisLong = histogramLong.getSnapshot().percentileValues();
-        // Check that there are 5 percentiles - [0.5,0.75,0.95,0.98,0.99,0.999]
+        // Check that there are 6 percentiles - [0.5,0.75,0.95,0.98,0.99,0.999]
         Assert.assertTrue(percentileValuesHisLong.length == 6);
 
         countDown = 6;

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/HistogramTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/HistogramTest.java
@@ -24,11 +24,13 @@
 package org.eclipse.microprofile.metrics.tck.metrics;
 
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
 import org.eclipse.microprofile.metrics.Histogram;
 import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.Snapshot;
 import org.eclipse.microprofile.metrics.Snapshot.PercentileValue;
 import org.eclipse.microprofile.metrics.tck.util.TestUtils;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -113,8 +115,11 @@ public class HistogramTest {
         assertThat("Histogram is not registered correctly", histogramInt, notNullValue());
         assertThat("Histogram is not registered correctly", histogramLong, notNullValue());
 
-        TestUtils.assertEqualsWithTolerance(48, histogramInt.getSnapshot().getValue(0.5));
-        TestUtils.assertEqualsWithTolerance(480, histogramLong.getSnapshot().getValue(0.5));
+        PercentileValue histogramIntPercentileValue = getPercentileValueAt(histogramInt, 0.5);
+        PercentileValue histogramLongPercentileValue = getPercentileValueAt(histogramLong, 0.5);
+
+        TestUtils.assertEqualsWithTolerance(48, histogramIntPercentileValue.getValue());
+        TestUtils.assertEqualsWithTolerance(480, histogramLongPercentileValue.getValue());
     }
 
     @Test
@@ -150,13 +155,14 @@ public class HistogramTest {
         Assert.assertTrue(countDown == 0);
 
         PercentileValue[] percentileValuesHisLong = histogramLong.getSnapshot().percentileValues();
-        // Check that there are 5 percentiles - [0.75,0.95,0.98,0.99,0.999]
+        // Check that there are 5 percentiles - [0.5,0.75,0.95,0.98,0.99,0.999]
         Assert.assertTrue(percentileValuesHisLong.length == 5);
 
-        countDown = 5;
+        countDown = 6;
         for (PercentileValue pv : percentileValuesHisLong) {
             double percentile = pv.getPercentile();
-            if (percentile == 0.75 ||
+            if (percentile == 0.5 ||
+                    percentile == 0.75 ||
                     percentile == 0.95 ||
                     percentile == 0.98 ||
                     percentile == 0.99 ||
@@ -169,38 +175,62 @@ public class HistogramTest {
 
     @Test
     public void testSnapshot50thPercentile() throws Exception {
-        TestUtils.assertEqualsWithTolerance(48, histogramInt.getSnapshot().getValue(0.5));
-        TestUtils.assertEqualsWithTolerance(480, histogramLong.getSnapshot().getValue(0.5));
+
+        PercentileValue histogramIntPercentileValue = getPercentileValueAt(histogramInt, 0.5);
+        PercentileValue histogramLongPercentileValue = getPercentileValueAt(histogramLong, 0.5);
+
+        TestUtils.assertEqualsWithTolerance(48, histogramIntPercentileValue.getValue());
+        TestUtils.assertEqualsWithTolerance(480, histogramLongPercentileValue.getValue());
     }
 
     @Test
     public void testSnapshot75thPercentile() throws Exception {
-        TestUtils.assertEqualsWithTolerance(75, histogramInt.getSnapshot().getValue(0.75));
-        TestUtils.assertEqualsWithTolerance(750, histogramLong.getSnapshot().getValue(0.75));
+
+        PercentileValue histogramIntPercentileValue = getPercentileValueAt(histogramInt, 0.5);
+        PercentileValue histogramLongPercentileValue = getPercentileValueAt(histogramLong, 0.5);
+
+        TestUtils.assertEqualsWithTolerance(75, histogramIntPercentileValue.getValue());
+        TestUtils.assertEqualsWithTolerance(750, histogramLongPercentileValue.getValue());
     }
 
     @Test
     public void testSnapshot95thPercentile() throws Exception {
-        TestUtils.assertEqualsWithTolerance(96, histogramInt.getSnapshot().getValue(0.95));
-        TestUtils.assertEqualsWithTolerance(960, histogramLong.getSnapshot().getValue(0.95));
+
+        PercentileValue histogramIntPercentileValue = getPercentileValueAt(histogramInt, 0.75);
+        PercentileValue histogramLongPercentileValue = getPercentileValueAt(histogramLong, 0.75);
+
+        TestUtils.assertEqualsWithTolerance(96, histogramIntPercentileValue.getValue());
+        TestUtils.assertEqualsWithTolerance(960, histogramLongPercentileValue.getValue());
     }
 
     @Test
     public void testSnapshot98thPercentile() throws Exception {
-        TestUtils.assertEqualsWithTolerance(98, histogramInt.getSnapshot().getValue(0.98));
-        TestUtils.assertEqualsWithTolerance(980, histogramLong.getSnapshot().getValue(0.98));
+
+        PercentileValue histogramIntPercentileValue = getPercentileValueAt(histogramInt, 0.98);
+        PercentileValue histogramLongPercentileValue = getPercentileValueAt(histogramLong, 0.98);
+
+        TestUtils.assertEqualsWithTolerance(98, histogramIntPercentileValue.getValue());
+        TestUtils.assertEqualsWithTolerance(980, histogramLongPercentileValue.getValue());
     }
 
     @Test
     public void testSnapshot99thPercentile() throws Exception {
-        TestUtils.assertEqualsWithTolerance(98, histogramInt.getSnapshot().getValue(0.98));
-        TestUtils.assertEqualsWithTolerance(980, histogramLong.getSnapshot().getValue(0.98));
+
+        PercentileValue histogramIntPercentileValue = getPercentileValueAt(histogramInt, 0.99);
+        PercentileValue histogramLongPercentileValue = getPercentileValueAt(histogramLong, 0.99);
+
+        TestUtils.assertEqualsWithTolerance(98, histogramIntPercentileValue.getValue());
+        TestUtils.assertEqualsWithTolerance(980, histogramLongPercentileValue.getValue());
     }
 
     @Test
     public void testSnapshot999thPercentile() throws Exception {
-        TestUtils.assertEqualsWithTolerance(99, histogramInt.getSnapshot().getValue(0.999));
-        TestUtils.assertEqualsWithTolerance(990, histogramLong.getSnapshot().getValue(0.999));
+
+        PercentileValue histogramIntPercentileValue = getPercentileValueAt(histogramInt, 0.999);
+        PercentileValue histogramLongPercentileValue = getPercentileValueAt(histogramLong, 0.999);
+
+        TestUtils.assertEqualsWithTolerance(99, histogramIntPercentileValue.getValue());
+        TestUtils.assertEqualsWithTolerance(990, histogramLongPercentileValue.getValue());
     }
 
     @Test
@@ -219,6 +249,20 @@ public class HistogramTest {
     public void testSnapshotSize() throws Exception {
         Assert.assertEquals(200, histogramInt.getSnapshot().size());
         Assert.assertEquals(200, histogramLong.getSnapshot().size());
+    }
+
+    private static PercentileValue getPercentileValueAt(Histogram histo, double percentile) {
+        Snapshot snapshot = histo.getSnapshot();
+
+        PercentileValue percentileValue = null;
+        for (PercentileValue pv : snapshot.percentileValues()) {
+            if (pv.getPercentile() == percentile) {
+                percentileValue = pv;
+                break;
+            }
+        }
+        assertNotNull(percentileValue);
+        return percentileValue;
     }
 
 }

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/HistogramTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/HistogramTest.java
@@ -139,12 +139,13 @@ public class HistogramTest {
 
         PercentileValue[] percentileValuesHistInt = histogramInt.getSnapshot().percentileValues();
         // Check that there are 5 percentiles - [0.75,0.95,0.98,0.99,0.999]
-        Assert.assertTrue(percentileValuesHistInt.length == 5);
+        Assert.assertTrue(percentileValuesHistInt.length == 6);
 
-        int countDown = 5;
+        int countDown = 6;
         for (PercentileValue pv : percentileValuesHistInt) {
             double percentile = pv.getPercentile();
-            if (percentile == 0.75 ||
+            if (percentile == 0.5 ||
+                    percentile == 0.75 ||
                     percentile == 0.95 ||
                     percentile == 0.98 ||
                     percentile == 0.99 ||
@@ -156,7 +157,7 @@ public class HistogramTest {
 
         PercentileValue[] percentileValuesHisLong = histogramLong.getSnapshot().percentileValues();
         // Check that there are 5 percentiles - [0.5,0.75,0.95,0.98,0.99,0.999]
-        Assert.assertTrue(percentileValuesHisLong.length == 5);
+        Assert.assertTrue(percentileValuesHisLong.length == 6);
 
         countDown = 6;
         for (PercentileValue pv : percentileValuesHisLong) {
@@ -186,8 +187,8 @@ public class HistogramTest {
     @Test
     public void testSnapshot75thPercentile() throws Exception {
 
-        PercentileValue histogramIntPercentileValue = getPercentileValueAt(histogramInt, 0.5);
-        PercentileValue histogramLongPercentileValue = getPercentileValueAt(histogramLong, 0.5);
+        PercentileValue histogramIntPercentileValue = getPercentileValueAt(histogramInt, 0.75);
+        PercentileValue histogramLongPercentileValue = getPercentileValueAt(histogramLong, 0.75);
 
         TestUtils.assertEqualsWithTolerance(75, histogramIntPercentileValue.getValue());
         TestUtils.assertEqualsWithTolerance(750, histogramLongPercentileValue.getValue());
@@ -196,8 +197,8 @@ public class HistogramTest {
     @Test
     public void testSnapshot95thPercentile() throws Exception {
 
-        PercentileValue histogramIntPercentileValue = getPercentileValueAt(histogramInt, 0.75);
-        PercentileValue histogramLongPercentileValue = getPercentileValueAt(histogramLong, 0.75);
+        PercentileValue histogramIntPercentileValue = getPercentileValueAt(histogramInt, 0.95);
+        PercentileValue histogramLongPercentileValue = getPercentileValueAt(histogramLong, 0.95);
 
         TestUtils.assertEqualsWithTolerance(96, histogramIntPercentileValue.getValue());
         TestUtils.assertEqualsWithTolerance(960, histogramLongPercentileValue.getValue());
@@ -235,8 +236,8 @@ public class HistogramTest {
 
     @Test
     public void testSnapshotMax() throws Exception {
-        Assert.assertEquals(99, histogramInt.getSnapshot().getMax());
-        Assert.assertEquals(990, histogramLong.getSnapshot().getMax());
+        Assert.assertEquals(99, histogramInt.getSnapshot().getMax(), 0.0);
+        Assert.assertEquals(990, histogramLong.getSnapshot().getMax(), 0.0);
     }
 
     @Test

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/TimerTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/TimerTest.java
@@ -30,6 +30,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.microprofile.metrics.MetricID;
 import org.eclipse.microprofile.metrics.MetricRegistry;
+import org.eclipse.microprofile.metrics.Snapshot;
 import org.eclipse.microprofile.metrics.Snapshot.PercentileValue;
 import org.eclipse.microprofile.metrics.Timer;
 import org.eclipse.microprofile.metrics.Timer.Context;
@@ -121,7 +122,9 @@ public class TimerTest {
         assertNotNull(timerLong);
         assertNotNull(timerTime);
 
-        TestUtils.assertEqualsWithTolerance(480, timerLong.getSnapshot().getValue(0.5));
+        PercentileValue globalTimerPercentileValue = getPercentileValueAt(globalTimer, 0.5);
+
+        TestUtils.assertEqualsWithTolerance(480, globalTimerPercentileValue.getValue());
     }
 
     @Test
@@ -151,13 +154,14 @@ public class TimerTest {
     public void testSnapshotPercentileValuesPresent() throws Exception {
 
         PercentileValue[] percentileValues = globalTimer.getSnapshot().percentileValues();
-        // Check that there are 5 percentiles - [0.75,0.95,0.98,0.99,0.999]
+        // Check that there are 5 percentiles - [0.5, 0.75,0.95,0.98,0.99,0.999]
         Assert.assertTrue(percentileValues.length == 5);
 
-        int countDown = 5;
+        int countDown = 6;
         for (PercentileValue pv : percentileValues) {
             double percentile = pv.getPercentile();
-            if (percentile == 0.75 ||
+            if (percentile == 0.5 ||
+                    percentile == 0.75 ||
                     percentile == 0.95 ||
                     percentile == 0.98 ||
                     percentile == 0.99 ||
@@ -171,32 +175,40 @@ public class TimerTest {
 
     @Test
     public void testSnapshot50thPercentile() throws Exception {
-        TestUtils.assertEqualsWithTolerance(480, globalTimer.getSnapshot().getValue(0.5));
+
+        PercentileValue globalTimerPercentileValue = getPercentileValueAt(globalTimer, 0.5);
+
+        TestUtils.assertEqualsWithTolerance(480, globalTimerPercentileValue.getValue());
     }
 
     @Test
     public void testSnapshot75thPercentile() throws Exception {
-        TestUtils.assertEqualsWithTolerance(750, globalTimer.getSnapshot().getValue(0.75));
+        PercentileValue globalTimerPercentileValue = getPercentileValueAt(globalTimer, 0.75);
+        TestUtils.assertEqualsWithTolerance(750, globalTimerPercentileValue.getValue());
     }
 
     @Test
     public void testSnapshot95thPercentile() throws Exception {
-        TestUtils.assertEqualsWithTolerance(960, globalTimer.getSnapshot().getValue(0.95));
+        PercentileValue globalTimerPercentileValue = getPercentileValueAt(globalTimer, 0.95);
+        TestUtils.assertEqualsWithTolerance(960, globalTimerPercentileValue.getValue());
     }
 
     @Test
     public void testSnapshot98thPercentile() throws Exception {
-        TestUtils.assertEqualsWithTolerance(980, globalTimer.getSnapshot().getValue(0.98));
+        PercentileValue globalTimerPercentileValue = getPercentileValueAt(globalTimer, 0.98);
+        TestUtils.assertEqualsWithTolerance(980, globalTimerPercentileValue.getValue());
     }
 
     @Test
     public void testSnapshot99thPercentile() throws Exception {
-        TestUtils.assertEqualsWithTolerance(980, globalTimer.getSnapshot().getValue(0.99));
+        PercentileValue globalTimerPercentileValue = getPercentileValueAt(globalTimer, 0.99);
+        TestUtils.assertEqualsWithTolerance(980, globalTimerPercentileValue.getValue());
     }
 
     @Test
     public void testSnapshot999thPercentile() throws Exception {
-        TestUtils.assertEqualsWithTolerance(990, globalTimer.getSnapshot().getValue(0.999));
+        PercentileValue globalTimerPercentileValue = getPercentileValueAt(globalTimer, 0.999);
+        TestUtils.assertEqualsWithTolerance(990, globalTimerPercentileValue.getValue());
     }
 
     @Test
@@ -212,5 +224,19 @@ public class TimerTest {
     @Test
     public void testSnapshotSize() throws Exception {
         Assert.assertEquals(200, globalTimer.getSnapshot().size());
+    }
+
+    private static PercentileValue getPercentileValueAt(Timer timer, double percentile) {
+        Snapshot snapshot = timer.getSnapshot();
+
+        PercentileValue percentileValue = null;
+        for (PercentileValue pv : snapshot.percentileValues()) {
+            if (pv.getPercentile() == percentile) {
+                percentileValue = pv;
+                break;
+            }
+        }
+        assertNotNull(percentileValue);
+        return percentileValue;
     }
 }

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/TimerTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/TimerTest.java
@@ -170,6 +170,11 @@ public class TimerTest {
     }
 
     @Test
+    public void testSnapshot50thPercentile() throws Exception {
+        TestUtils.assertEqualsWithTolerance(480, globalTimer.getSnapshot().getValue(0.5));
+    }
+
+    @Test
     public void testSnapshot75thPercentile() throws Exception {
         TestUtils.assertEqualsWithTolerance(750, globalTimer.getSnapshot().getValue(0.75));
     }

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/TimerTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/TimerTest.java
@@ -155,7 +155,7 @@ public class TimerTest {
 
         PercentileValue[] percentileValues = globalTimer.getSnapshot().percentileValues();
         // Check that there are 5 percentiles - [0.5, 0.75,0.95,0.98,0.99,0.999]
-        Assert.assertTrue(percentileValues.length == 5);
+        Assert.assertTrue(percentileValues.length == 6);
 
         int countDown = 6;
         for (PercentileValue pv : percentileValues) {
@@ -213,7 +213,7 @@ public class TimerTest {
 
     @Test
     public void testSnapshotMax() throws Exception {
-        Assert.assertEquals(990, globalTimer.getSnapshot().getMax());
+        Assert.assertEquals(990, globalTimer.getSnapshot().getMax(), 0.0);
     }
 
     @Test

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/TimerTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/TimerTest.java
@@ -154,7 +154,7 @@ public class TimerTest {
     public void testSnapshotPercentileValuesPresent() throws Exception {
 
         PercentileValue[] percentileValues = globalTimer.getSnapshot().percentileValues();
-        // Check that there are 5 percentiles - [0.5, 0.75,0.95,0.98,0.99,0.999]
+        // Check that there are 6 percentiles - [0.5, 0.75,0.95,0.98,0.99,0.999]
         Assert.assertTrue(percentileValues.length == 6);
 
         int countDown = 6;

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/tags/HistogramTagFieldBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/tags/HistogramTagFieldBeanTest.java
@@ -103,11 +103,13 @@ public class HistogramTagFieldBeanTest {
         bean.updateTwo(valueTwo);
 
         assertThat("Histogram count is incorrect", histogramOne.getCount(), is(equalTo(1L)));
-        assertThat("Histogram size is incorrect", histogramOne.getSnapshot().size(), is(equalTo(1)));
-        assertThat("Histogram max value is incorrect", histogramOne.getSnapshot().getMax(), is(equalTo(value)));
+        assertThat("Histogram size is incorrect", histogramOne.getSnapshot().size(), is(equalTo(1L)));
+        assertThat("Histogram max value is incorrect", histogramOne.getSnapshot().getMax(),
+                is(equalTo((double) value)));
 
         assertThat("Histogram count is incorrect", histogramTwo.getCount(), is(equalTo(1L)));
-        assertThat("Histogram size is incorrect", histogramTwo.getSnapshot().size(), is(equalTo(1)));
-        assertThat("Histogram max value is incorrect", histogramTwo.getSnapshot().getMax(), is(equalTo(valueTwo)));
+        assertThat("Histogram size is incorrect", histogramTwo.getSnapshot().size(), is(equalTo(1L)));
+        assertThat("Histogram max value is incorrect", histogramTwo.getSnapshot().getMax(),
+                is(equalTo((double) valueTwo)));
     }
 }

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/tags/HistogramTagFieldBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/tags/HistogramTagFieldBeanTest.java
@@ -1,6 +1,6 @@
 /*
  **********************************************************************
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICES file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -104,12 +104,10 @@ public class HistogramTagFieldBeanTest {
 
         assertThat("Histogram count is incorrect", histogramOne.getCount(), is(equalTo(1L)));
         assertThat("Histogram size is incorrect", histogramOne.getSnapshot().size(), is(equalTo(1)));
-        assertThat("Histogram min value is incorrect", histogramOne.getSnapshot().getMin(), is(equalTo(value)));
         assertThat("Histogram max value is incorrect", histogramOne.getSnapshot().getMax(), is(equalTo(value)));
 
         assertThat("Histogram count is incorrect", histogramTwo.getCount(), is(equalTo(1L)));
         assertThat("Histogram size is incorrect", histogramTwo.getSnapshot().size(), is(equalTo(1)));
-        assertThat("Histogram min value is incorrect", histogramTwo.getSnapshot().getMin(), is(equalTo(valueTwo)));
         assertThat("Histogram max value is incorrect", histogramTwo.getSnapshot().getMax(), is(equalTo(valueTwo)));
     }
 }


### PR DESCRIPTION
Update Snapshot used by Histogram and Timer

- Removed getMedian, getXXXPercentile, getMin, getStdDev, getValues from Snapshot
- Added inner static class PercentileValue to Snapshot, percentileValues() method to Snapshot
- Spec updates
- TCK updates

^methods removed were those that can not be supported by micrometer

fixes #695
fixes #696