### PR TITLE
Change from _app and _scope to mp_app and mp_scope

### DIFF
--- a/spec/src/main/asciidoc/architecture.adoc
+++ b/spec/src/main/asciidoc/architecture.adoc
@@ -128,7 +128,7 @@ For portability reasons, the key name for the tag must match the regex `[a-zA-Z_
 If an illegal character is used, the implementation must throw an `IllegalArgumentException`.
 If a duplicate tag is used, the last occurrence of the tag is used.
 
-The tags named `_scope` and `_app` are reserved. If an application attempts to create a metric with either of these tags, the implementation must throw an `IllegalArgumentException`.
+The tags named `mp_scope` and `mp_app` are reserved. If an application attempts to create a metric with either of these tags, the implementation must throw an `IllegalArgumentException`.
 
 The tag value may contain any UTF-8 encoded character.
 
@@ -154,7 +154,7 @@ Global tags and tags registered with the metric are included in the output retur
 
 Global tags MUST NOT be added to the `MetricID` objects. Global tags must be included in list of tags when metrics are exported.
 
-NOTE: In application servers with multiple applications deployed, there is one reserved tag name: `_app`, which serves for
+NOTE: In application servers with multiple applications deployed, there is one reserved tag name: `mp_app`, which serves for
 distinguishing metrics from different applications and must not be used for any other purpose. For details,
  see section <<app-servers>>.
 
@@ -288,13 +288,13 @@ how such application servers should behave if they want to support MicroProfile 
 Metrics from all applications and scopes should be available under a single REST endpoint ending with `/metrics` similarly as
 in case of single-application deployments (microservices).
 
-To help distinguish between metrics pertaining to each deployed application, a tag named `_app` should be added to each metric. 
+To help distinguish between metrics pertaining to each deployed application, a tag named `mp_app` should be added to each metric. 
 
-The value of the `_app` tag should be passed by the application server to the application via a MicroProfile Config property named `mp.metrics.appName`.
+The value of the `mp_app` tag should be passed by the application server to the application via a MicroProfile Config property named `mp.metrics.appName`.
 It should be possible to override this value by bundling the file `META-INF/microprofile-config.properties` within the application archive
 and setting a custom value for the property `mp.metrics.appName` inside it.
 
-It is allowed for application servers to choose to not add the _app tag at all. Implementations may differ in how they handle cases where 
+It is allowed for application servers to choose to not add the mp_app tag at all. Implementations may differ in how they handle cases where 
 metrics are registered with the same name from two or more applications running in the same server.  This behavior is not expected to be 
 portable across vendors.
 

--- a/spec/src/main/asciidoc/architecture.adoc
+++ b/spec/src/main/asciidoc/architecture.adoc
@@ -154,8 +154,8 @@ Global tags and tags registered with the metric are included in the output retur
 
 Global tags MUST NOT be added to the `MetricID` objects. Global tags must be included in list of tags when metrics are exported.
 
-NOTE: In application servers with multiple applications deployed, there is one reserved tag name: `mp_app`, which serves for
-distinguishing metrics from different applications and must not be used for any other purpose. For details,
+NOTE: In application servers with multiple applications deployed, values of the reserved tag `mp_app` distinguishing metrics
+ from different applications and must not be used for any other purpose. For details,
  see section <<app-servers>>.
 
 [[meta-data-def]]
@@ -294,7 +294,7 @@ The value of the `mp_app` tag should be passed by the application server to the 
 It should be possible to override this value by bundling the file `META-INF/microprofile-config.properties` within the application archive
 and setting a custom value for the property `mp.metrics.appName` inside it.
 
-It is allowed for application servers to choose to not add the mp_app tag at all. Implementations may differ in how they handle cases where 
+It is allowed for application servers to choose to not add the `mp_app`` tag at all. Implementations may differ in how they handle cases where 
 metrics are registered with the same name from two or more applications running in the same server.  This behavior is not expected to be 
 portable across vendors.
 

--- a/spec/src/main/asciidoc/architecture.adoc
+++ b/spec/src/main/asciidoc/architecture.adoc
@@ -154,7 +154,7 @@ Global tags and tags registered with the metric are included in the output retur
 
 Global tags MUST NOT be added to the `MetricID` objects. Global tags must be included in list of tags when metrics are exported.
 
-NOTE: In application servers with multiple applications deployed, values of the reserved tag `mp_app` distinguishing metrics
+NOTE: In application servers with multiple applications deployed, values of the reserved tag `mp_app` distinguish metrics
  from different applications and must not be used for any other purpose. For details,
  see section <<app-servers>>.
 
@@ -294,7 +294,7 @@ The value of the `mp_app` tag should be passed by the application server to the 
 It should be possible to override this value by bundling the file `META-INF/microprofile-config.properties` within the application archive
 and setting a custom value for the property `mp.metrics.appName` inside it.
 
-It is allowed for application servers to choose to not add the `mp_app`` tag at all. Implementations may differ in how they handle cases where 
+It is allowed for application servers to choose to not add the `mp_app` tag at all. Implementations may differ in how they handle cases where 
 metrics are registered with the same name from two or more applications running in the same server.  This behavior is not expected to be 
 portable across vendors.
 

--- a/spec/src/main/asciidoc/rest-endpoints.adoc
+++ b/spec/src/main/asciidoc/rest-endpoints.adoc
@@ -43,7 +43,7 @@ Quantile values, as used in Histogram and Timer output, should represent recent 
 ----
 # HELP current_temperature_celsius The current temperature. <1>
 # TYPE current_temperature_celsius gauge <2>
-current_temperature_celsius{_scope="application",server="front_office"} 36.2 <3>
+current_temperature_celsius{mp_scope="application",server="front_office"} 36.2 <3>
 ----
 
 <1> The description of the gauge, from the `getDescription()` method of the `Metadata` associated to the gauge, must be provided in the HELP line
@@ -60,7 +60,7 @@ current_temperature_celsius{_scope="application",server="front_office"} 36.2 <3>
 ----
 # HELP messages_processed_events_total Number of messages handled <1>
 # TYPE messages_processed_events_total counter <2>
-messages_processed_events_total{_scope="application"} 1.0 <3>
+messages_processed_events_total{mp_scope="application"} 1.0 <3>
 ----
 
 <1> The description of the counter must be provided in the HELP line
@@ -77,17 +77,17 @@ messages_processed_events_total{_scope="application"} 1.0 <3>
 ----
 # HELP distance_to_hole_meters_max Distance of golf ball to hole <1>
 # TYPE distance_to_hole_meters_max gauge <2>
-distance_to_hole_meters_max{_scope="golf_stats"} 12.722726616315509 <3>
+distance_to_hole_meters_max{mp_scope="golf_stats"} 12.722726616315509 <3>
 # HELP distance_to_hole_meters Distance of golf ball to hole <1>
 # TYPE distance_to_hole_meters summary <2>
-distance_to_hole_meters{_scope="golf_stats",quantile="0.5"} 2.8748779296875 <3>
-distance_to_hole_meters{_scope="golf_stats",quantile="0.75"} 4.4998779296875 <3>
-distance_to_hole_meters{_scope="golf_stats",quantile="0.95"} 7.9998779296875 <3>
-distance_to_hole_meters{_scope="golf_stats",quantile="0.98"} 9.4998779296875 <3>
-distance_to_hole_meters{_scope="golf_stats",quantile="0.99"} 11.9998779296875 <3>
-distance_to_hole_meters{_scope="golf_stats",quantile="0.999"} 12.9998779296875 <3>
-distance_to_hole_meters_count{_scope="golf_stats"} 487.0 <3>
-distance_to_hole_meters_sum{_scope="golf_stats"} 1569.3785694223322 <3>
+distance_to_hole_meters{mp_scope="golf_stats",quantile="0.5"} 2.8748779296875 <3>
+distance_to_hole_meters{mp_scope="golf_stats",quantile="0.75"} 4.4998779296875 <3>
+distance_to_hole_meters{mp_scope="golf_stats",quantile="0.95"} 7.9998779296875 <3>
+distance_to_hole_meters{mp_scope="golf_stats",quantile="0.98"} 9.4998779296875 <3>
+distance_to_hole_meters{mp_scope="golf_stats",quantile="0.99"} 11.9998779296875 <3>
+distance_to_hole_meters{mp_scope="golf_stats",quantile="0.999"} 12.9998779296875 <3>
+distance_to_hole_meters_count{mp_scope="golf_stats"} 487.0 <3>
+distance_to_hole_meters_sum{mp_scope="golf_stats"} 1569.3785694223322 <3>
 ----
 
 `Histogram` output is comprised of a maximum section and a summary section.
@@ -124,17 +124,17 @@ distance_to_hole_meters_sum{_scope="golf_stats"} 1569.3785694223322 <3>
 ----
 # HELP myClass_myMethod_seconds duration of myMethod <1>
 # TYPE myClass_myMethod_seconds summary <2>
-myClass_myMethod_seconds{_scope="vendor",quantile="0.5"} 0.0524288 <3>
-myClass_myMethod_seconds{_scope="vendor",quantile="0.75"} 0.0524288 <3>
-myClass_myMethod_seconds{_scope="vendor",quantile="0.95"} 0.054525952 <3>
-myClass_myMethod_seconds{_scope="vendor",quantile="0.98"} 0.054525952 <3>
-myClass_myMethod_seconds{_scope="vendor",quantile="0.99"} 0.054525952 <3>
-myClass_myMethod_seconds{_scope="vendor",quantile="0.999"} 0.054525952 <3>
-myClass_myMethod_seconds_count{_scope="vendor"} 100.0 <3>
-myClass_myMethod_seconds_sum{_scope="vendor"} 5.310349419 <3>
+myClass_myMethod_seconds{mp_scope="vendor",quantile="0.5"} 0.0524288 <3>
+myClass_myMethod_seconds{mp_scope="vendor",quantile="0.75"} 0.0524288 <3>
+myClass_myMethod_seconds{mp_scope="vendor",quantile="0.95"} 0.054525952 <3>
+myClass_myMethod_seconds{mp_scope="vendor",quantile="0.98"} 0.054525952 <3>
+myClass_myMethod_seconds{mp_scope="vendor",quantile="0.99"} 0.054525952 <3>
+myClass_myMethod_seconds{mp_scope="vendor",quantile="0.999"} 0.054525952 <3>
+myClass_myMethod_seconds_count{mp_scope="vendor"} 100.0 <3>
+myClass_myMethod_seconds_sum{mp_scope="vendor"} 5.310349419 <3>
 # HELP myClass_myMethod_seconds_max duration of myMethod <1>
 # TYPE myClass_myMethod_seconds_max gauge <2>
-myClass_myMethod_seconds_max{_scope="vendor"} 0.05507899 <3>
+myClass_myMethod_seconds_max{mp_scope="vendor"} 0.05507899 <3>
 ----
 
 `Timer` output is comprised of a maximum section and a summary section.

--- a/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MpMetricTest.java
+++ b/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/MpMetricTest.java
@@ -79,7 +79,7 @@ import jakarta.inject.Inject;
 public class MpMetricTest {
     private static final String TEXT_PLAIN = "text/plain";
 
-    private static final String PROM_APP_LABEL_REGEX = "_app=\"[-/A-Za-z0-9]+\"";
+    private static final String PROM_APP_LABEL_REGEX = "mp_app=\"[-/A-Za-z0-9]+\"";
 
     private static final String DEFAULT_PROTOCOL = "http";
     private static final String DEFAULT_HOST = "localhost";
@@ -170,7 +170,7 @@ public class MpMetricTest {
         resp = responseBuilder.build();
         resp.then().statusCode(200).and().contentType(TEXT_PLAIN).and()
                 .body(containsString("# TYPE thread_max_count"))
-                .body(containsString("thread_max_count{scope=\"base\",tier=\"integration\"}"));
+                .body(containsString("thread_max_count{mp_scope=\"base\",tier=\"integration\"}"));
     }
 
     @Test
@@ -185,7 +185,7 @@ public class MpMetricTest {
         resp = responseBuilder.build();
         resp.then().statusCode(200).and()
                 .contentType(TEXT_PLAIN).and().body(containsString("# TYPE thread_max_count"),
-                        containsString("thread_max_count{scope=\"base\",tier=\"integration\"}"));
+                        containsString("thread_max_count{mp_scope=\"base\",tier=\"integration\"}"));
     }
 
     @Test
@@ -304,37 +304,37 @@ public class MpMetricTest {
                 .body(containsString(
                         "# HELP org_eclipse_microprofile_metrics_test_MetricAppBean_redCount_total red-description"))
                 .body(containsString(
-                        "org_eclipse_microprofile_metrics_test_MetricAppBean_redCount_total{scope=\"application\",tier=\"integration\"} 0"))
+                        "org_eclipse_microprofile_metrics_test_MetricAppBean_redCount_total{mp_scope=\"application\",tier=\"integration\"} 0"))
 
                 .body(containsString("# TYPE org_eclipse_microprofile_metrics_test_MetricAppBean_blue_total counter"))
                 .body(containsString("# HELP org_eclipse_microprofile_metrics_test_MetricAppBean_blue_total"))
                 .body(containsString(
-                        "org_eclipse_microprofile_metrics_test_MetricAppBean_blue_total{scope=\"application\",tier=\"integration\"} 0"))
+                        "org_eclipse_microprofile_metrics_test_MetricAppBean_blue_total{mp_scope=\"application\",tier=\"integration\"} 0"))
 
                 .body(containsString("# TYPE greenCount_total counter"))
                 .body(containsString("# HELP greenCount_total"))
                 .body(containsString(
-                        "greenCount_total{scope=\"application\",tier=\"integration\"} 0"))
+                        "greenCount_total{mp_scope=\"application\",tier=\"integration\"} 0"))
 
                 .body(containsString("# TYPE purple_total counter"))
                 .body(containsString("# HELP purple_total"))
                 .body(containsString(
-                        "purple_total{app=\"myShop\",scope=\"application\",tier=\"integration\"} 0"))
+                        "purple_total{app=\"myShop\",mp_scope=\"application\",tier=\"integration\"} 0"))
 
                 .body(containsString("# HELP metricTest_test1_count_total"))
                 .body(containsString("# TYPE metricTest_test1_count_total counter"))
                 .body(containsString(
-                        "metricTest_test1_count_total{scope=\"application\",tier=\"integration\"} 1"))
+                        "metricTest_test1_count_total{mp_scope=\"application\",tier=\"integration\"} 1"))
 
                 .body(containsString("# HELP metricTest_test1_countMeA_total count-me-a-description"))
                 .body(containsString("# TYPE metricTest_test1_countMeA_total counter"))
                 .body(containsString(
-                        "metricTest_test1_countMeA_total{scope=\"application\",tier=\"integration\"} 1"))
+                        "metricTest_test1_countMeA_total{mp_scope=\"application\",tier=\"integration\"} 1"))
 
                 .body(containsString("# HELP metricTest_test1_countMeB_jellybean_total"))
                 .body(containsString("# TYPE metricTest_test1_countMeB_jellybean_total counter"))
                 .body(containsString(
-                        "metricTest_test1_countMeB_jellybean_total{scope=\"application\",tier=\"integration\"} 1"))
+                        "metricTest_test1_countMeB_jellybean_total{mp_scope=\"application\",tier=\"integration\"} 1"))
 
                 /*
                  * GAUGES
@@ -343,19 +343,19 @@ public class MpMetricTest {
                 .body(containsString("# HELP metricTest_test1_gauge_gigabytes"))
                 .body(containsString("# TYPE metricTest_test1_gauge_gigabytes gauge"))
                 .body(containsString(
-                        "metricTest_test1_gauge_gigabytes{scope=\"application\",tier=\"integration\"} 19"))
+                        "metricTest_test1_gauge_gigabytes{mp_scope=\"application\",tier=\"integration\"} 19"))
 
                 .body(containsString(
                         "# HELP org_eclipse_microprofile_metrics_test_MetricAppBean_gaugeMeA_kibibits gauge-me-a-description"))
                 .body(containsString(
                         "# TYPE org_eclipse_microprofile_metrics_test_MetricAppBean_gaugeMeA_kibibits gauge"))
                 .body(containsString(
-                        "org_eclipse_microprofile_metrics_test_MetricAppBean_gaugeMeA_kibibits{scope=\"application\",tier=\"integration\"} 1000"))
+                        "org_eclipse_microprofile_metrics_test_MetricAppBean_gaugeMeA_kibibits{mp_scope=\"application\",tier=\"integration\"} 1000"))
 
                 .body(containsString("# HELP org_eclipse_microprofile_metrics_test_MetricAppBean_gaugeMeB_hands"))
                 .body(containsString("# TYPE org_eclipse_microprofile_metrics_test_MetricAppBean_gaugeMeB_hands gauge"))
                 .body(containsString(
-                        "org_eclipse_microprofile_metrics_test_MetricAppBean_gaugeMeB_hands{scope=\"application\",tier=\"integration\"} 7777777"))
+                        "org_eclipse_microprofile_metrics_test_MetricAppBean_gaugeMeB_hands{mp_scope=\"application\",tier=\"integration\"} 7777777"))
 
                 /*
                  * HISTOGRAMS
@@ -365,25 +365,25 @@ public class MpMetricTest {
                 .body(containsString("# HELP metricTest_test1_histogram_bytes"))
                 .body(containsString("# TYPE metricTest_test1_histogram_bytes summary"))
                 .body(containsString(
-                        "metricTest_test1_histogram_bytes{scope=\"application\",tier=\"integration\",quantile=\"0.5\"}"))
+                        "metricTest_test1_histogram_bytes{mp_scope=\"application\",tier=\"integration\",quantile=\"0.5\"}"))
                 .body(containsString(
-                        "metricTest_test1_histogram_bytes{scope=\"application\",tier=\"integration\",quantile=\"0.75\"}"))
+                        "metricTest_test1_histogram_bytes{mp_scope=\"application\",tier=\"integration\",quantile=\"0.75\"}"))
                 .body(containsString(
-                        "metricTest_test1_histogram_bytes{scope=\"application\",tier=\"integration\",quantile=\"0.95\"}"))
+                        "metricTest_test1_histogram_bytes{mp_scope=\"application\",tier=\"integration\",quantile=\"0.95\"}"))
                 .body(containsString(
-                        "metricTest_test1_histogram_bytes{scope=\"application\",tier=\"integration\",quantile=\"0.98\"}"))
+                        "metricTest_test1_histogram_bytes{mp_scope=\"application\",tier=\"integration\",quantile=\"0.98\"}"))
                 .body(containsString(
-                        "metricTest_test1_histogram_bytes{scope=\"application\",tier=\"integration\",quantile=\"0.99\"}"))
+                        "metricTest_test1_histogram_bytes{mp_scope=\"application\",tier=\"integration\",quantile=\"0.99\"}"))
                 .body(containsString(
-                        "metricTest_test1_histogram_bytes{scope=\"application\",tier=\"integration\",quantile=\"0.999\"}"))
+                        "metricTest_test1_histogram_bytes{mp_scope=\"application\",tier=\"integration\",quantile=\"0.999\"}"))
                 .body(containsString(
-                        "metricTest_test1_histogram_bytes_count{scope=\"application\",tier=\"integration\"} 1000"))
+                        "metricTest_test1_histogram_bytes_count{mp_scope=\"application\",tier=\"integration\"} 1000"))
                 .body(containsString(
-                        "metricTest_test1_histogram_bytes_sum{scope=\"application\",tier=\"integration\"} 499500"))
+                        "metricTest_test1_histogram_bytes_sum{mp_scope=\"application\",tier=\"integration\"} 499500"))
                 .body(containsString("# HELP metricTest_test1_histogram_bytes_max"))
                 .body(containsString("# TYPE metricTest_test1_histogram_bytes_max gauge"))
                 .body(containsString(
-                        "metricTest_test1_histogram_bytes_max{scope=\"application\",tier=\"integration\"} 999"))
+                        "metricTest_test1_histogram_bytes_max{mp_scope=\"application\",tier=\"integration\"} 999"))
 
                 /*
                  * TIMERS
@@ -394,50 +394,50 @@ public class MpMetricTest {
                 .body(containsString("# HELP metricTest_test1_timer_seconds"))
                 .body(containsString("# TYPE metricTest_test1_timer_seconds summary"))
                 .body(containsString(
-                        "metricTest_test1_timer_seconds{scope=\"application\",tier=\"integration\",quantile=\"0.5\"}"))
+                        "metricTest_test1_timer_seconds{mp_scope=\"application\",tier=\"integration\",quantile=\"0.5\"}"))
                 .body(containsString(
-                        "metricTest_test1_timer_seconds{scope=\"application\",tier=\"integration\",quantile=\"0.75\"}"))
+                        "metricTest_test1_timer_seconds{mp_scope=\"application\",tier=\"integration\",quantile=\"0.75\"}"))
                 .body(containsString(
-                        "metricTest_test1_timer_seconds{scope=\"application\",tier=\"integration\",quantile=\"0.95\"}"))
+                        "metricTest_test1_timer_seconds{mp_scope=\"application\",tier=\"integration\",quantile=\"0.95\"}"))
                 .body(containsString(
-                        "metricTest_test1_timer_seconds{scope=\"application\",tier=\"integration\",quantile=\"0.98\"}"))
+                        "metricTest_test1_timer_seconds{mp_scope=\"application\",tier=\"integration\",quantile=\"0.98\"}"))
                 .body(containsString(
-                        "metricTest_test1_timer_seconds{scope=\"application\",tier=\"integration\",quantile=\"0.99\"}"))
+                        "metricTest_test1_timer_seconds{mp_scope=\"application\",tier=\"integration\",quantile=\"0.99\"}"))
                 .body(containsString(
-                        "metricTest_test1_timer_seconds{scope=\"application\",tier=\"integration\",quantile=\"0.999\"}"))
+                        "metricTest_test1_timer_seconds{mp_scope=\"application\",tier=\"integration\",quantile=\"0.999\"}"))
                 .body(containsString(
-                        "metricTest_test1_timer_seconds_count{scope=\"application\",tier=\"integration\"} 1"))
+                        "metricTest_test1_timer_seconds_count{mp_scope=\"application\",tier=\"integration\"} 1"))
                 .body(containsString(
-                        "metricTest_test1_timer_seconds_sum{scope=\"application\",tier=\"integration\"}"))
+                        "metricTest_test1_timer_seconds_sum{mp_scope=\"application\",tier=\"integration\"}"))
                 .body(containsString("# HELP metricTest_test1_timer_seconds_max"))
                 .body(containsString("# TYPE metricTest_test1_timer_seconds_max gauge"))
                 .body(containsString(
-                        "metricTest_test1_timer_seconds_max{scope=\"application\",tier=\"integration\"}"))
+                        "metricTest_test1_timer_seconds_max{mp_scope=\"application\",tier=\"integration\"}"))
 
                 .body(containsString("# HELP org_eclipse_microprofile_metrics_test_MetricAppBean_timeMeA_seconds"))
                 .body(containsString(
                         "# TYPE org_eclipse_microprofile_metrics_test_MetricAppBean_timeMeA_seconds summary"))
                 .body(containsString(
-                        "org_eclipse_microprofile_metrics_test_MetricAppBean_timeMeA_seconds{scope=\"application\",tier=\"integration\",quantile=\"0.5\"}"))
+                        "org_eclipse_microprofile_metrics_test_MetricAppBean_timeMeA_seconds{mp_scope=\"application\",tier=\"integration\",quantile=\"0.5\"}"))
                 .body(containsString(
-                        "org_eclipse_microprofile_metrics_test_MetricAppBean_timeMeA_seconds{scope=\"application\",tier=\"integration\",quantile=\"0.75\"}"))
+                        "org_eclipse_microprofile_metrics_test_MetricAppBean_timeMeA_seconds{mp_scope=\"application\",tier=\"integration\",quantile=\"0.75\"}"))
                 .body(containsString(
-                        "org_eclipse_microprofile_metrics_test_MetricAppBean_timeMeA_seconds{scope=\"application\",tier=\"integration\",quantile=\"0.95\"}"))
+                        "org_eclipse_microprofile_metrics_test_MetricAppBean_timeMeA_seconds{mp_scope=\"application\",tier=\"integration\",quantile=\"0.95\"}"))
                 .body(containsString(
-                        "org_eclipse_microprofile_metrics_test_MetricAppBean_timeMeA_seconds{scope=\"application\",tier=\"integration\",quantile=\"0.98\"}"))
+                        "org_eclipse_microprofile_metrics_test_MetricAppBean_timeMeA_seconds{mp_scope=\"application\",tier=\"integration\",quantile=\"0.98\"}"))
                 .body(containsString(
-                        "org_eclipse_microprofile_metrics_test_MetricAppBean_timeMeA_seconds{scope=\"application\",tier=\"integration\",quantile=\"0.99\"}"))
+                        "org_eclipse_microprofile_metrics_test_MetricAppBean_timeMeA_seconds{mp_scope=\"application\",tier=\"integration\",quantile=\"0.99\"}"))
                 .body(containsString(
-                        "org_eclipse_microprofile_metrics_test_MetricAppBean_timeMeA_seconds{scope=\"application\",tier=\"integration\",quantile=\"0.999\"}"))
+                        "org_eclipse_microprofile_metrics_test_MetricAppBean_timeMeA_seconds{mp_scope=\"application\",tier=\"integration\",quantile=\"0.999\"}"))
                 .body(containsString(
-                        "org_eclipse_microprofile_metrics_test_MetricAppBean_timeMeA_seconds_count{scope=\"application\",tier=\"integration\"} 1"))
+                        "org_eclipse_microprofile_metrics_test_MetricAppBean_timeMeA_seconds_count{mp_scope=\"application\",tier=\"integration\"} 1"))
                 .body(containsString(
-                        "org_eclipse_microprofile_metrics_test_MetricAppBean_timeMeA_seconds_sum{scope=\"application\",tier=\"integration\"}"))
+                        "org_eclipse_microprofile_metrics_test_MetricAppBean_timeMeA_seconds_sum{mp_scope=\"application\",tier=\"integration\"}"))
                 .body(containsString("# HELP org_eclipse_microprofile_metrics_test_MetricAppBean_timeMeA_seconds_max"))
                 .body(containsString(
                         "# TYPE org_eclipse_microprofile_metrics_test_MetricAppBean_timeMeA_seconds_max gauge"))
                 .body(containsString(
-                        "org_eclipse_microprofile_metrics_test_MetricAppBean_timeMeA_seconds_max{scope=\"application\",tier=\"integration\"}"));
+                        "org_eclipse_microprofile_metrics_test_MetricAppBean_timeMeA_seconds_max{mp_scope=\"application\",tier=\"integration\"}"));
 
     }
 
@@ -499,12 +499,18 @@ public class MpMetricTest {
                 .body(containsString("# TYPE " + prefix + "seconds summary"))
                 .body(containsString(prefix + "seconds_count"))
                 .body(containsString(prefix + "seconds_sum"))
-                .body(containsString(prefix + "seconds{scope=\"application\",tier=\"integration\",quantile=\"0.5\"}"))
-                .body(containsString(prefix + "seconds{scope=\"application\",tier=\"integration\",quantile=\"0.75\"}"))
-                .body(containsString(prefix + "seconds{scope=\"application\",tier=\"integration\",quantile=\"0.95\"}"))
-                .body(containsString(prefix + "seconds{scope=\"application\",tier=\"integration\",quantile=\"0.98\"}"))
-                .body(containsString(prefix + "seconds{scope=\"application\",tier=\"integration\",quantile=\"0.99\"}"))
-                .body(containsString(prefix + "seconds{scope=\"application\",tier=\"integration\",quantile=\"0.999\"}"))
+                .body(containsString(
+                        prefix + "seconds{mp_scope=\"application\",tier=\"integration\",quantile=\"0.5\"}"))
+                .body(containsString(
+                        prefix + "seconds{mp_scope=\"application\",tier=\"integration\",quantile=\"0.75\"}"))
+                .body(containsString(
+                        prefix + "seconds{mp_scope=\"application\",tier=\"integration\",quantile=\"0.95\"}"))
+                .body(containsString(
+                        prefix + "seconds{mp_scope=\"application\",tier=\"integration\",quantile=\"0.98\"}"))
+                .body(containsString(
+                        prefix + "seconds{mp_scope=\"application\",tier=\"integration\",quantile=\"0.99\"}"))
+                .body(containsString(
+                        prefix + "seconds{mp_scope=\"application\",tier=\"integration\",quantile=\"0.999\"}"))
                 .body(containsString("# TYPE " + prefix + "seconds_max gauge"))
                 .body(containsString(prefix + "seconds_max"));
 
@@ -529,12 +535,13 @@ public class MpMetricTest {
                 .body(containsString("# TYPE " + prefix + "bytes summary"))
                 .body(containsString(prefix + "bytes_count"))
                 .body(containsString(prefix + "bytes_sum"))
-                .body(containsString(prefix + "bytes{scope=\"application\",tier=\"integration\",quantile=\"0.5\"}"))
-                .body(containsString(prefix + "bytes{scope=\"application\",tier=\"integration\",quantile=\"0.75\"}"))
-                .body(containsString(prefix + "bytes{scope=\"application\",tier=\"integration\",quantile=\"0.95\"}"))
-                .body(containsString(prefix + "bytes{scope=\"application\",tier=\"integration\",quantile=\"0.98\"}"))
-                .body(containsString(prefix + "bytes{scope=\"application\",tier=\"integration\",quantile=\"0.99\"}"))
-                .body(containsString(prefix + "bytes{scope=\"application\",tier=\"integration\",quantile=\"0.999\"}"))
+                .body(containsString(prefix + "bytes{mp_scope=\"application\",tier=\"integration\",quantile=\"0.5\"}"))
+                .body(containsString(prefix + "bytes{mp_scope=\"application\",tier=\"integration\",quantile=\"0.75\"}"))
+                .body(containsString(prefix + "bytes{mp_scope=\"application\",tier=\"integration\",quantile=\"0.95\"}"))
+                .body(containsString(prefix + "bytes{mp_scope=\"application\",tier=\"integration\",quantile=\"0.98\"}"))
+                .body(containsString(prefix + "bytes{mp_scope=\"application\",tier=\"integration\",quantile=\"0.99\"}"))
+                .body(containsString(
+                        prefix + "bytes{mp_scope=\"application\",tier=\"integration\",quantile=\"0.999\"}"))
                 .body(containsString("# TYPE " + prefix + "bytes_max gauge"))
                 .body(containsString(prefix + "bytes_max"));
     }
@@ -558,12 +565,12 @@ public class MpMetricTest {
                 .body(containsString("# TYPE " + prefix + " summary"))
                 .body(containsString(prefix + "_count"))
                 .body(containsString(prefix + "_sum"))
-                .body(containsString(prefix + "{scope=\"application\",tier=\"integration\",quantile=\"0.5\"}"))
-                .body(containsString(prefix + "{scope=\"application\",tier=\"integration\",quantile=\"0.75\"}"))
-                .body(containsString(prefix + "{scope=\"application\",tier=\"integration\",quantile=\"0.95\"}"))
-                .body(containsString(prefix + "{scope=\"application\",tier=\"integration\",quantile=\"0.98\"}"))
-                .body(containsString(prefix + "{scope=\"application\",tier=\"integration\",quantile=\"0.99\"}"))
-                .body(containsString(prefix + "{scope=\"application\",tier=\"integration\",quantile=\"0.999\"}"))
+                .body(containsString(prefix + "{mp_scope=\"application\",tier=\"integration\",quantile=\"0.5\"}"))
+                .body(containsString(prefix + "{mp_scope=\"application\",tier=\"integration\",quantile=\"0.75\"}"))
+                .body(containsString(prefix + "{mp_scope=\"application\",tier=\"integration\",quantile=\"0.95\"}"))
+                .body(containsString(prefix + "{mp_scope=\"application\",tier=\"integration\",quantile=\"0.98\"}"))
+                .body(containsString(prefix + "{mp_scope=\"application\",tier=\"integration\",quantile=\"0.99\"}"))
+                .body(containsString(prefix + "{mp_scope=\"application\",tier=\"integration\",quantile=\"0.999\"}"))
                 .body(containsString("# TYPE " + prefix + "_max gauge"))
                 .body(containsString(prefix + "_max"));
     }
@@ -600,17 +607,17 @@ public class MpMetricTest {
                 .body(containsString(prefix + "jellybeans_count"))
                 .body(containsString(prefix + "jellybeans_sum"))
                 .body(containsString(
-                        prefix + "jellybeans{scope=\"application\",tier=\"integration\",quantile=\"0.5\"}"))
+                        prefix + "jellybeans{mp_scope=\"application\",tier=\"integration\",quantile=\"0.5\"}"))
                 .body(containsString(
-                        prefix + "jellybeans{scope=\"application\",tier=\"integration\",quantile=\"0.75\"}"))
+                        prefix + "jellybeans{mp_scope=\"application\",tier=\"integration\",quantile=\"0.75\"}"))
                 .body(containsString(
-                        prefix + "jellybeans{scope=\"application\",tier=\"integration\",quantile=\"0.95\"}"))
+                        prefix + "jellybeans{mp_scope=\"application\",tier=\"integration\",quantile=\"0.95\"}"))
                 .body(containsString(
-                        prefix + "jellybeans{scope=\"application\",tier=\"integration\",quantile=\"0.98\"}"))
+                        prefix + "jellybeans{mp_scope=\"application\",tier=\"integration\",quantile=\"0.98\"}"))
                 .body(containsString(
-                        prefix + "jellybeans{scope=\"application\",tier=\"integration\",quantile=\"0.99\"}"))
+                        prefix + "jellybeans{mp_scope=\"application\",tier=\"integration\",quantile=\"0.99\"}"))
                 .body(containsString(
-                        prefix + "jellybeans{scope=\"application\",tier=\"integration\",quantile=\"0.999\"}"))
+                        prefix + "jellybeans{mp_scope=\"application\",tier=\"integration\",quantile=\"0.999\"}"))
                 .body(containsString("# TYPE " + prefix + "jellybeans_max gauge"))
                 .body(containsString(prefix + "jellybeans_max"));
     }
@@ -776,7 +783,7 @@ public class MpMetricTest {
                             containsString(expectedTag + "="));
                 }
                 /*
-                 * example: gc_total{name="global",scope="base",tier="integration",} 14.0 Expect only one space
+                 * example: gc_total{name="global",mp_scope="base",tier="integration",} 14.0 Expect only one space
                  */
                 String[] tmp = line.split(" ");
                 assertEquals("Unexpected format: " + line, tmp.length, 2);
@@ -818,7 +825,8 @@ public class MpMetricTest {
                             containsString(expectedTag + "="));
                 }
                 /*
-                 * example: gc_time_total{name="scavenge",scope="base",tier="integration",} 264.0 Expect only one space
+                 * example: gc_time_total{name="scavenge",mp_scope="base",tier="integration",} 264.0 Expect only one
+                 * space
                  */
                 String[] tmp = line.split(" ");
                 assertEquals("Unexpected format: " + line, tmp.length, 2);
@@ -861,24 +869,24 @@ public class MpMetricTest {
                 .body(containsString(
                         "# TYPE org_eclipse_microprofile_metrics_test_MetricAppBean_noTagCounter_total counter"))
                 .body(containsString(
-                        "org_eclipse_microprofile_metrics_test_MetricAppBean_noTagCounter_total{scope=\"application\",tier=\"integration\"} 0"))
+                        "org_eclipse_microprofile_metrics_test_MetricAppBean_noTagCounter_total{mp_scope=\"application\",tier=\"integration\"} 0"))
 
                 .body(containsString("# HELP org_eclipse_microprofile_metrics_test_MetricAppBean_taggedCounter_total"))
                 .body(containsString(
                         "# TYPE org_eclipse_microprofile_metrics_test_MetricAppBean_taggedCounter_total counter"))
                 .body(containsString(
-                        "org_eclipse_microprofile_metrics_test_MetricAppBean_taggedCounter_total{number=\"one\",scope=\"application\",tier=\"integration\"} 0"))
+                        "org_eclipse_microprofile_metrics_test_MetricAppBean_taggedCounter_total{mp_scope=\"application\",number=\"one\",tier=\"integration\"} 0"))
                 .body(containsString(
-                        "org_eclipse_microprofile_metrics_test_MetricAppBean_taggedCounter_total{number=\"two\",scope=\"application\",tier=\"integration\"} 0"))
+                        "org_eclipse_microprofile_metrics_test_MetricAppBean_taggedCounter_total{mp_scope=\"application\",number=\"two\",tier=\"integration\"} 0"))
                 /**
                  * GAUGES
                  */
                 .body(containsString("# HELP taggedGauge"))
                 .body(containsString("# TYPE taggedGauge gauge"))
                 .body(containsString(
-                        "taggedGauge{number=\"one\",scope=\"application\",tier=\"integration\"} 1000"))
+                        "taggedGauge{mp_scope=\"application\",number=\"one\",tier=\"integration\"} 1000"))
                 .body(containsString(
-                        "taggedGauge{number=\"two\",scope=\"application\",tier=\"integration\"} 1000"))
+                        "taggedGauge{mp_scope=\"application\",number=\"two\",tier=\"integration\"} 1000"))
 
                 /*
                  * HISTOGRAMS ONLY CHECKING THAT COUNT IS 0
@@ -888,70 +896,70 @@ public class MpMetricTest {
                 .body(containsString("# HELP noTagHistogram_marshmallow"))
                 .body(containsString("# TYPE noTagHistogram_marshmallow summary"))
                 .body(containsString(
-                        "noTagHistogram_marshmallow{scope=\"application\",tier=\"integration\",quantile=\"0.5\"} "))
+                        "noTagHistogram_marshmallow{mp_scope=\"application\",tier=\"integration\",quantile=\"0.5\"} "))
                 .body(containsString(
-                        "noTagHistogram_marshmallow{scope=\"application\",tier=\"integration\",quantile=\"0.75\"} "))
+                        "noTagHistogram_marshmallow{mp_scope=\"application\",tier=\"integration\",quantile=\"0.75\"} "))
                 .body(containsString(
-                        "noTagHistogram_marshmallow{scope=\"application\",tier=\"integration\",quantile=\"0.95\"} "))
+                        "noTagHistogram_marshmallow{mp_scope=\"application\",tier=\"integration\",quantile=\"0.95\"} "))
                 .body(containsString(
-                        "noTagHistogram_marshmallow{scope=\"application\",tier=\"integration\",quantile=\"0.98\"} "))
+                        "noTagHistogram_marshmallow{mp_scope=\"application\",tier=\"integration\",quantile=\"0.98\"} "))
                 .body(containsString(
-                        "noTagHistogram_marshmallow{scope=\"application\",tier=\"integration\",quantile=\"0.99\"} "))
+                        "noTagHistogram_marshmallow{mp_scope=\"application\",tier=\"integration\",quantile=\"0.99\"} "))
                 .body(containsString(
-                        "noTagHistogram_marshmallow{scope=\"application\",tier=\"integration\",quantile=\"0.999\"} "))
+                        "noTagHistogram_marshmallow{mp_scope=\"application\",tier=\"integration\",quantile=\"0.999\"} "))
                 .body(containsString(
-                        "noTagHistogram_marshmallow_count{scope=\"application\",tier=\"integration\"} 0"))
+                        "noTagHistogram_marshmallow_count{mp_scope=\"application\",tier=\"integration\"} 0"))
                 .body(containsString(
-                        "noTagHistogram_marshmallow_sum{scope=\"application\",tier=\"integration\"} "))
+                        "noTagHistogram_marshmallow_sum{mp_scope=\"application\",tier=\"integration\"} "))
                 .body(containsString("# HELP noTagHistogram_marshmallow_max"))
                 .body(containsString("# TYPE noTagHistogram_marshmallow_max gauge"))
                 .body(containsString(
-                        "noTagHistogram_marshmallow_max{scope=\"application\",tier=\"integration\"} "))
+                        "noTagHistogram_marshmallow_max{mp_scope=\"application\",tier=\"integration\"} "))
 
                 // tagged histo
                 .body(containsString("# HELP taggedHistogram_marshmallow"))
                 .body(containsString("# TYPE taggedHistogram_marshmallow summary"))
                 // number=one
                 .body(containsString(
-                        "taggedHistogram_marshmallow{number=\"one\",scope=\"application\",tier=\"integration\",quantile=\"0.5\"} "))
+                        "taggedHistogram_marshmallow{mp_scope=\"application\",number=\"one\",tier=\"integration\",quantile=\"0.5\"} "))
                 .body(containsString(
-                        "taggedHistogram_marshmallow{number=\"one\",scope=\"application\",tier=\"integration\",quantile=\"0.75\"} "))
+                        "taggedHistogram_marshmallow{mp_scope=\"application\",number=\"one\",tier=\"integration\",quantile=\"0.75\"} "))
                 .body(containsString(
-                        "taggedHistogram_marshmallow{number=\"one\",scope=\"application\",tier=\"integration\",quantile=\"0.95\"} "))
+                        "taggedHistogram_marshmallow{mp_scope=\"application\",number=\"one\",tier=\"integration\",quantile=\"0.95\"} "))
                 .body(containsString(
-                        "taggedHistogram_marshmallow{number=\"one\",scope=\"application\",tier=\"integration\",quantile=\"0.98\"} "))
+                        "taggedHistogram_marshmallow{mp_scope=\"application\",number=\"one\",tier=\"integration\",quantile=\"0.98\"} "))
                 .body(containsString(
-                        "taggedHistogram_marshmallow{number=\"one\",scope=\"application\",tier=\"integration\",quantile=\"0.99\"} "))
+                        "taggedHistogram_marshmallow{mp_scope=\"application\",number=\"one\",tier=\"integration\",quantile=\"0.99\"} "))
                 .body(containsString(
-                        "taggedHistogram_marshmallow{number=\"one\",scope=\"application\",tier=\"integration\",quantile=\"0.999\"} "))
+                        "taggedHistogram_marshmallow{mp_scope=\"application\",number=\"one\",tier=\"integration\",quantile=\"0.999\"} "))
                 .body(containsString(
-                        "taggedHistogram_marshmallow_count{number=\"one\",scope=\"application\",tier=\"integration\"} 0"))
+                        "taggedHistogram_marshmallow_count{mp_scope=\"application\",number=\"one\",tier=\"integration\"} 0"))
                 .body(containsString(
-                        "taggedHistogram_marshmallow_sum{number=\"one\",scope=\"application\",tier=\"integration\"} "))
+                        "taggedHistogram_marshmallow_sum{mp_scope=\"application\",number=\"one\",tier=\"integration\"} "))
                 .body(containsString("# HELP taggedHistogram_marshmallow_max"))
                 .body(containsString("# TYPE taggedHistogram_marshmallow_max gauge"))
                 .body(containsString(
-                        "taggedHistogram_marshmallow_max{number=\"one\",scope=\"application\",tier=\"integration\"} "))
+                        "taggedHistogram_marshmallow_max{mp_scope=\"application\",number=\"one\",tier=\"integration\"} "))
 
                 // number=two
                 .body(containsString(
-                        "taggedHistogram_marshmallow{number=\"two\",scope=\"application\",tier=\"integration\",quantile=\"0.5\"} "))
+                        "taggedHistogram_marshmallow{mp_scope=\"application\",number=\"two\",tier=\"integration\",quantile=\"0.5\"} "))
                 .body(containsString(
-                        "taggedHistogram_marshmallow{number=\"two\",scope=\"application\",tier=\"integration\",quantile=\"0.75\"} "))
+                        "taggedHistogram_marshmallow{mp_scope=\"application\",number=\"two\",tier=\"integration\",quantile=\"0.75\"} "))
                 .body(containsString(
-                        "taggedHistogram_marshmallow{number=\"two\",scope=\"application\",tier=\"integration\",quantile=\"0.95\"} "))
+                        "taggedHistogram_marshmallow{mp_scope=\"application\",number=\"two\",tier=\"integration\",quantile=\"0.95\"} "))
                 .body(containsString(
-                        "taggedHistogram_marshmallow{number=\"two\",scope=\"application\",tier=\"integration\",quantile=\"0.98\"} "))
+                        "taggedHistogram_marshmallow{mp_scope=\"application\",number=\"two\",tier=\"integration\",quantile=\"0.98\"} "))
                 .body(containsString(
-                        "taggedHistogram_marshmallow{number=\"two\",scope=\"application\",tier=\"integration\",quantile=\"0.99\"} "))
+                        "taggedHistogram_marshmallow{mp_scope=\"application\",number=\"two\",tier=\"integration\",quantile=\"0.99\"} "))
                 .body(containsString(
-                        "taggedHistogram_marshmallow{number=\"two\",scope=\"application\",tier=\"integration\",quantile=\"0.999\"} "))
+                        "taggedHistogram_marshmallow{mp_scope=\"application\",number=\"two\",tier=\"integration\",quantile=\"0.999\"} "))
                 .body(containsString(
-                        "taggedHistogram_marshmallow_count{number=\"two\",scope=\"application\",tier=\"integration\"} 0"))
+                        "taggedHistogram_marshmallow_count{mp_scope=\"application\",number=\"two\",tier=\"integration\"} 0"))
                 .body(containsString(
-                        "taggedHistogram_marshmallow_sum{number=\"two\",scope=\"application\",tier=\"integration\"} "))
+                        "taggedHistogram_marshmallow_sum{mp_scope=\"application\",number=\"two\",tier=\"integration\"} "))
                 .body(containsString(
-                        "taggedHistogram_marshmallow_max{number=\"two\",scope=\"application\",tier=\"integration\"} "))
+                        "taggedHistogram_marshmallow_max{mp_scope=\"application\",number=\"two\",tier=\"integration\"} "))
 
                 /*
                  * TIMERS ONLY CHECKING THAT COUNT IS 0
@@ -960,70 +968,70 @@ public class MpMetricTest {
                 .body(containsString("# HELP noTagTimer_seconds"))
                 .body(containsString("# TYPE noTagTimer_seconds summary"))
                 .body(containsString(
-                        "noTagTimer_seconds{scope=\"application\",tier=\"integration\",quantile=\"0.5\"} "))
+                        "noTagTimer_seconds{mp_scope=\"application\",tier=\"integration\",quantile=\"0.5\"} "))
                 .body(containsString(
-                        "noTagTimer_seconds{scope=\"application\",tier=\"integration\",quantile=\"0.75\"} "))
+                        "noTagTimer_seconds{mp_scope=\"application\",tier=\"integration\",quantile=\"0.75\"} "))
                 .body(containsString(
-                        "noTagTimer_seconds{scope=\"application\",tier=\"integration\",quantile=\"0.95\"} "))
+                        "noTagTimer_seconds{mp_scope=\"application\",tier=\"integration\",quantile=\"0.95\"} "))
                 .body(containsString(
-                        "noTagTimer_seconds{scope=\"application\",tier=\"integration\",quantile=\"0.98\"} "))
+                        "noTagTimer_seconds{mp_scope=\"application\",tier=\"integration\",quantile=\"0.98\"} "))
                 .body(containsString(
-                        "noTagTimer_seconds{scope=\"application\",tier=\"integration\",quantile=\"0.99\"} "))
+                        "noTagTimer_seconds{mp_scope=\"application\",tier=\"integration\",quantile=\"0.99\"} "))
                 .body(containsString(
-                        "noTagTimer_seconds{scope=\"application\",tier=\"integration\",quantile=\"0.999\"} "))
+                        "noTagTimer_seconds{mp_scope=\"application\",tier=\"integration\",quantile=\"0.999\"} "))
                 .body(containsString(
-                        "noTagTimer_seconds_count{scope=\"application\",tier=\"integration\"} 0"))
+                        "noTagTimer_seconds_count{mp_scope=\"application\",tier=\"integration\"} 0"))
                 .body(containsString(
-                        "noTagTimer_seconds_sum{scope=\"application\",tier=\"integration\"} "))
+                        "noTagTimer_seconds_sum{mp_scope=\"application\",tier=\"integration\"} "))
                 .body(containsString("# HELP noTagTimer_seconds_max"))
                 .body(containsString("# TYPE noTagTimer_seconds_max gauge"))
                 .body(containsString(
-                        "noTagTimer_seconds_max{scope=\"application\",tier=\"integration\"} "))
+                        "noTagTimer_seconds_max{mp_scope=\"application\",tier=\"integration\"} "))
 
                 // tagged timer
                 .body(containsString("# HELP taggedTimer_seconds"))
                 .body(containsString("# TYPE taggedTimer_seconds summary"))
                 // number=one
                 .body(containsString(
-                        "taggedTimer_seconds{number=\"one\",scope=\"application\",tier=\"integration\",quantile=\"0.5\"} "))
+                        "taggedTimer_seconds{mp_scope=\"application\",number=\"one\",tier=\"integration\",quantile=\"0.5\"} "))
                 .body(containsString(
-                        "taggedTimer_seconds{number=\"one\",scope=\"application\",tier=\"integration\",quantile=\"0.75\"} "))
+                        "taggedTimer_seconds{mp_scope=\"application\",number=\"one\",tier=\"integration\",quantile=\"0.75\"} "))
                 .body(containsString(
-                        "taggedTimer_seconds{number=\"one\",scope=\"application\",tier=\"integration\",quantile=\"0.95\"} "))
+                        "taggedTimer_seconds{mp_scope=\"application\",number=\"one\",tier=\"integration\",quantile=\"0.95\"} "))
                 .body(containsString(
-                        "taggedTimer_seconds{number=\"one\",scope=\"application\",tier=\"integration\",quantile=\"0.98\"} "))
+                        "taggedTimer_seconds{mp_scope=\"application\",number=\"one\",tier=\"integration\",quantile=\"0.98\"} "))
                 .body(containsString(
-                        "taggedTimer_seconds{number=\"one\",scope=\"application\",tier=\"integration\",quantile=\"0.99\"} "))
+                        "taggedTimer_seconds{mp_scope=\"application\",number=\"one\",tier=\"integration\",quantile=\"0.99\"} "))
                 .body(containsString(
-                        "taggedTimer_seconds{number=\"one\",scope=\"application\",tier=\"integration\",quantile=\"0.999\"} "))
+                        "taggedTimer_seconds{mp_scope=\"application\",number=\"one\",tier=\"integration\",quantile=\"0.999\"} "))
                 .body(containsString(
-                        "taggedTimer_seconds_count{number=\"one\",scope=\"application\",tier=\"integration\"} 0"))
+                        "taggedTimer_seconds_count{mp_scope=\"application\",number=\"one\",tier=\"integration\"} 0"))
                 .body(containsString(
-                        "taggedTimer_seconds_sum{number=\"one\",scope=\"application\",tier=\"integration\"} "))
+                        "taggedTimer_seconds_sum{mp_scope=\"application\",number=\"one\",tier=\"integration\"} "))
                 .body(containsString("# HELP taggedTimer_seconds_max"))
                 .body(containsString("# TYPE taggedTimer_seconds_max gauge"))
                 .body(containsString(
-                        "taggedTimer_seconds_max{number=\"one\",scope=\"application\",tier=\"integration\"} "))
+                        "taggedTimer_seconds_max{mp_scope=\"application\",number=\"one\",tier=\"integration\"} "))
 
                 // number=two
                 .body(containsString(
-                        "taggedTimer_seconds{number=\"two\",scope=\"application\",tier=\"integration\",quantile=\"0.5\"} "))
+                        "taggedTimer_seconds{mp_scope=\"application\",number=\"two\",tier=\"integration\",quantile=\"0.5\"} "))
                 .body(containsString(
-                        "taggedTimer_seconds{number=\"two\",scope=\"application\",tier=\"integration\",quantile=\"0.75\"} "))
+                        "taggedTimer_seconds{mp_scope=\"application\",number=\"two\",tier=\"integration\",quantile=\"0.75\"} "))
                 .body(containsString(
-                        "taggedTimer_seconds{number=\"two\",scope=\"application\",tier=\"integration\",quantile=\"0.95\"} "))
+                        "taggedTimer_seconds{mp_scope=\"application\",number=\"two\",tier=\"integration\",quantile=\"0.95\"} "))
                 .body(containsString(
-                        "taggedTimer_seconds{number=\"two\",scope=\"application\",tier=\"integration\",quantile=\"0.98\"} "))
+                        "taggedTimer_seconds{mp_scope=\"application\",number=\"two\",tier=\"integration\",quantile=\"0.98\"} "))
                 .body(containsString(
-                        "taggedTimer_seconds{number=\"two\",scope=\"application\",tier=\"integration\",quantile=\"0.99\"} "))
+                        "taggedTimer_seconds{mp_scope=\"application\",number=\"two\",tier=\"integration\",quantile=\"0.99\"} "))
                 .body(containsString(
-                        "taggedTimer_seconds{number=\"two\",scope=\"application\",tier=\"integration\",quantile=\"0.999\"} "))
+                        "taggedTimer_seconds{mp_scope=\"application\",number=\"two\",tier=\"integration\",quantile=\"0.999\"} "))
                 .body(containsString(
-                        "taggedTimer_seconds_count{number=\"two\",scope=\"application\",tier=\"integration\"} 0"))
+                        "taggedTimer_seconds_count{mp_scope=\"application\",number=\"two\",tier=\"integration\"} 0"))
                 .body(containsString(
-                        "taggedTimer_seconds_sum{number=\"two\",scope=\"application\",tier=\"integration\"} "))
+                        "taggedTimer_seconds_sum{mp_scope=\"application\",number=\"two\",tier=\"integration\"} "))
                 .body(containsString(
-                        "taggedTimer_seconds_max{number=\"two\",scope=\"application\",tier=\"integration\"} "));
+                        "taggedTimer_seconds_max{mp_scope=\"application\",number=\"two\",tier=\"integration\"} "));
 
     }
 

--- a/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/ReusedMetricsTest.java
+++ b/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/ReusedMetricsTest.java
@@ -52,7 +52,7 @@ import jakarta.inject.Inject;
 @RunWith(Arquillian.class)
 public class ReusedMetricsTest {
 
-    private static final String OPENMETRICS_APP_LABEL_REGEX = "_app=\"[-/A-Za-z0-9]+\"";
+    private static final String OPENMETRICS_APP_LABEL_REGEX = "mp_app=\"[-/A-Za-z0-9]+\"";
     private static final String TEXT_PLAIN = "text/plain";
     private static final String DEFAULT_PROTOCOL = "http";
     private static final String DEFAULT_HOST = "localhost";
@@ -118,7 +118,7 @@ public class ReusedMetricsTest {
     @InSequence(2)
     public void testSharedCounter() {
 
-        Response resp = given().header("Accept", TEXT_PLAIN).get("/metrics?scope=application");
+        Response resp = given().header("Accept", TEXT_PLAIN).get("/metrics?mp_scope=application");
         ResponseBuilder responseBuilder = new ResponseBuilder();
         responseBuilder.clone(resp);
         responseBuilder.setBody(filterOutAppLabelPromMetrics(resp.getBody().asString()));
@@ -127,9 +127,9 @@ public class ReusedMetricsTest {
         resp.then().statusCode(200)
                 .and()
                 .body(containsString("# TYPE countMe2_total counter"))
-                .body(containsString("countMe2_total{scope=\"application\",tier=\"integration\"} 1"))
+                .body(containsString("countMe2_total{mp_scope=\"application\",tier=\"integration\"} 1"))
                 .body(containsString("# TYPE timeMe2_seconds summary"))
-                .body(containsString("timeMe2_seconds_count{scope=\"application\",tier=\"integration\"} 1"));
+                .body(containsString("timeMe2_seconds_count{mp_scope=\"application\",tier=\"integration\"} 1"));
     }
 
     @Test
@@ -144,7 +144,7 @@ public class ReusedMetricsTest {
     @InSequence(4)
     public void testSharedCounterAgain() {
 
-        Response resp = given().header("Accept", TEXT_PLAIN).get("/metrics?scope=application");
+        Response resp = given().header("Accept", TEXT_PLAIN).get("/metrics?mp_scope=application");
         ResponseBuilder responseBuilder = new ResponseBuilder();
         responseBuilder.clone(resp);
         responseBuilder.setBody(filterOutAppLabelPromMetrics(resp.getBody().asString()));
@@ -153,9 +153,9 @@ public class ReusedMetricsTest {
         resp.then().statusCode(200)
                 .and()
                 .body(containsString("# TYPE countMe2_total counter"))
-                .body(containsString("countMe2_total{scope=\"application\",tier=\"integration\"} 2"))
+                .body(containsString("countMe2_total{mp_scope=\"application\",tier=\"integration\"} 2"))
                 .body(containsString("# TYPE timeMe2_seconds summary"))
-                .body(containsString("timeMe2_seconds_count{scope=\"application\",tier=\"integration\"} 2"));
+                .body(containsString("timeMe2_seconds_count{mp_scope=\"application\",tier=\"integration\"} 2"));
     }
 
 }

--- a/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/ReusedMetricsTest.java
+++ b/tck/rest/src/main/java/org/eclipse/microprofile/metrics/test/ReusedMetricsTest.java
@@ -118,7 +118,7 @@ public class ReusedMetricsTest {
     @InSequence(2)
     public void testSharedCounter() {
 
-        Response resp = given().header("Accept", TEXT_PLAIN).get("/metrics?mp_scope=application");
+        Response resp = given().header("Accept", TEXT_PLAIN).get("/metrics?scope=application");
         ResponseBuilder responseBuilder = new ResponseBuilder();
         responseBuilder.clone(resp);
         responseBuilder.setBody(filterOutAppLabelPromMetrics(resp.getBody().asString()));
@@ -144,7 +144,7 @@ public class ReusedMetricsTest {
     @InSequence(4)
     public void testSharedCounterAgain() {
 
-        Response resp = given().header("Accept", TEXT_PLAIN).get("/metrics?mp_scope=application");
+        Response resp = given().header("Accept", TEXT_PLAIN).get("/metrics?scope=application");
         ResponseBuilder responseBuilder = new ResponseBuilder();
         responseBuilder.clone(resp);
         responseBuilder.setBody(filterOutAppLabelPromMetrics(resp.getBody().asString()));


### PR DESCRIPTION
Depends on the following to be merged first.
https://github.com/eclipse/microprofile-metrics/pull/707
*^This PR is based off of this as it needs to change text that was added in #707
and
https://github.com/eclipse/microprofile-metrics/pull/709

Depends on #709 first before TCKs can be updated.

DRAFT as there still requires changed in TCK.

Fixes #705 
(^branch erroneously named as 700 )

REST TCKs in #709 are more explicit in checking Prometheus output in that there are more tests now.
Those tests check for the previous `scope`/`_scope` tag which will now be changed to `mp_scope`. 