### PR TITLE
 Clean up any small problems in TCK

### DIFF
--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/DefaultNameMetricMethodBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/DefaultNameMetricMethodBeanTest.java
@@ -1,4 +1,5 @@
 /**
+ * Copyright (c) 2013, 2022 Contributors to the Eclipse Foundation
  * Copyright © 2013 Antonin Stefanutti (antonin.stefanutti@gmail.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -39,11 +40,10 @@ import jakarta.inject.Inject;
 public class DefaultNameMetricMethodBeanTest {
 
     private final static String[] METRIC_NAMES =
-            {"defaultNameCountedMethod", "defaultNameMeteredMethod", "defaultNameTimedMethod"};
+            {"defaultNameCountedMethod", "defaultNameTimedMethod"};
 
     private final static String[] ABSOLUTE_METRIC_NAMES =
-            {"absoluteDefaultNameCountedMethod", "absoluteDefaultNameMeteredMethod",
-                    "absoluteDefaultNameTimedMethod"};
+            {"absoluteDefaultNameCountedMethod", "absoluteDefaultNameTimedMethod"};
 
     private Set<String> metricNames() {
         Set<String> names = MetricsUtil.absoluteMetricNames(DefaultNameMetricMethodBean.class, METRIC_NAMES);

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/MultipleMetricsMethodBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/metrics/MultipleMetricsMethodBeanTest.java
@@ -45,7 +45,7 @@ import jakarta.inject.Inject;
 @RunWith(Arquillian.class)
 public class MultipleMetricsMethodBeanTest {
 
-    private final static String[] METRIC_NAMES = {"counter", "gauge", "meter", "timer"};
+    private final static String[] METRIC_NAMES = {"counter", "gauge", "timer"};
 
     private Set<String> absoluteMetricNames() {
         return MetricsUtil.absoluteMetricNames(MultipleMetricsMethodBean.class, METRIC_NAMES);

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/tags/CounterFieldTagBean.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/tags/CounterFieldTagBean.java
@@ -1,6 +1,6 @@
 /*
  **********************************************************************
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICES file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -29,7 +29,7 @@ import jakarta.inject.Inject;
 public class CounterFieldTagBean {
 
     @Inject
-    @Metric(name = "counterName")
+    @Metric(name = "counterNameNoTag")
     private Counter counterOne;
 
     @Inject

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/tags/CounterFieldTagBeanTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/tags/CounterFieldTagBeanTest.java
@@ -1,6 +1,6 @@
 /*
  **********************************************************************
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019, 2022 Contributors to the Eclipse Foundation
  *
  * See the NOTICES file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -46,6 +46,8 @@ import jakarta.inject.Inject;
 @RunWith(Arquillian.class)
 public class CounterFieldTagBeanTest {
 
+    private final static String COUNTER_NAME_NO_TAG =
+            MetricRegistry.name(CounterFieldTagBean.class, "counterNameNoTag");
     private final static String COUNTER_NAME = MetricRegistry.name(CounterFieldTagBean.class, "counterName");
 
     private final static Tag NUMBER_TWO_TAG = new Tag("number", "two");
@@ -81,7 +83,7 @@ public class CounterFieldTagBeanTest {
          *
          * This will cause client instantiated MetricIDs to throw an exception. (i.e the global MetricIDs)
          */
-        counterMID = new MetricID(COUNTER_NAME);
+        counterMID = new MetricID(COUNTER_NAME_NO_TAG);
         counterTwoMID = new MetricID(COUNTER_NAME, NUMBER_TWO_TAG, COLOUR_RED_TAG);
         counterThreeMID = new MetricID(COUNTER_NAME, NUMBER_THREE_TAG, COLOUR_BLUE_TAG);
     }

--- a/tck/rest/src/main/application_metrics.xml
+++ b/tck/rest/src/main/application_metrics.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
-    Copyright (c) 2017 Contributors to the Eclipse Foundation
+    Copyright (c) 2017, 2022 Contributors to the Eclipse Foundation
 
     See the NOTICES file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -28,6 +28,5 @@
   <metric multi="false" name="metricTest.test1.countMeB" type="counter" unit="jellybean"/>
   <metric multi="false" name="org.eclipse.microprofile.metrics.test.MetricAppBean.gaugeMeA" type="gauge" unit="kibibits" description="gauge-me-a-description" display-name="gauge-me-a-displayname"/>
   <metric multi="false" name="org.eclipse.microprofile.metrics.test.MetricAppBean.gaugeMeB" type="gauge" unit="hands"/>
-  <metric multi="false" name="meterMeA" type="meter" unit="per_second" description="meter-me-a-description" display-name="meter-me-a-display-name"/>
   <metric multi="false" name="org.eclipse.microprofile.metrics.test.MetricAppBean.timeMeA" type="timer" unit="nanoseconds"/>
 </config>

--- a/tck/rest/src/main/resources/application_metrics.xml
+++ b/tck/rest/src/main/resources/application_metrics.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
-    Copyright (c) 2017 Contributors to the Eclipse Foundation
+    Copyright (c) 2017, 2022 Contributors to the Eclipse Foundation
 
     See the NOTICES file(s) distributed with this work for additional
     information regarding copyright ownership.
@@ -28,6 +28,5 @@
   <metric multi="false" name="metricTest.test1.countMeB" type="counter" unit="jellybean"/>
   <metric multi="false" name="org.eclipse.microprofile.metrics.test.MetricAppBean.gaugeMeA" type="gauge" unit="kibibits" description="gauge-me-a-description" display-name="gauge-me-a-displayname"/>
   <metric multi="false" name="org.eclipse.microprofile.metrics.test.MetricAppBean.gaugeMeB" type="gauge" unit="hands"/>
-  <metric multi="false" name="meterMeA" type="meter" unit="per_second" description="meter-me-a-description" display-name="meter-me-a-display-name"/>
   <metric multi="false" name="org.eclipse.microprofile.metrics.test.MetricAppBean.timeMeA" type="timer" unit="nanoseconds"/>
 </config>


### PR DESCRIPTION
    - Ensure metrics that use the same name x tag combination are exactly
    the same (i.e. can't have metrics with same name where one uses tags and
    the other does not, or that all tag keys used are exactly the same
    - remove references remaining references to removed metrics meter (i.e.
    meter)
    
Fixes #714 

May cause conflicts if https://github.com/eclipse/microprofile-metrics/pull/716 is merged first.
Will need to rebase then.