### PR TITLE
Update MicroProfile Metrics Parent to MicroProfile Parent 3.0

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -17,7 +17,6 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.metrics</groupId>
         <artifactId>microprofile-metrics-parent</artifactId>
         <version>5.0.0-SNAPSHOT</version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.microprofile</groupId>
         <artifactId>microprofile-parent</artifactId>
-        <version>2.1</version>
+        <version>3.0-RC2</version>
     </parent>
 
     <groupId>org.eclipse.microprofile.metrics</groupId>
@@ -35,6 +35,9 @@
         <version.osgi.versioning>1.1.0</version.osgi.versioning>
         <inceptionYear>2017</inceptionYear>
         <autorelease>false</autorelease>
+        <version.microprofile.tck.bom>3.0-RC2</version.microprofile.tck.bom>
+        <version.jakarta.cdi>4.0.0</version.jakarta.cdi>
+        <version.jakarta.ws-rs>3.0.0</version.jakarta.ws-rs>
     </properties>
 
     <developers>
@@ -74,6 +77,28 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>jakarta.ws.rs</groupId>
+                <artifactId>jakarta.ws.rs-api</artifactId>
+                <version>${version.jakarta.ws-rs}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.enterprise</groupId>
+                <artifactId>jakarta.enterprise.cdi-api</artifactId>
+                <version>${version.jakarta.cdi}</version>
+                <scope>provided</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>jakarta.el</groupId>
+                        <artifactId>jakarta.el-api</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>jakarta.ejb</groupId>
+                        <artifactId>jakarta.ejb-api</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
             <dependency>
                 <groupId>org.osgi</groupId>
                 <artifactId>org.osgi.annotation.versioning</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.microprofile</groupId>
         <artifactId>microprofile-parent</artifactId>
-        <version>3.0-RC2</version>
+        <version>3.0</version>
     </parent>
 
     <groupId>org.eclipse.microprofile.metrics</groupId>
@@ -35,7 +35,7 @@
         <version.osgi.versioning>1.1.0</version.osgi.versioning>
         <inceptionYear>2017</inceptionYear>
         <autorelease>false</autorelease>
-        <version.microprofile.tck.bom>3.0-RC2</version.microprofile.tck.bom>
+        <version.microprofile.tck.bom>3.0</version.microprofile.tck.bom>
         <version.jakarta.cdi>4.0.0</version.jakarta.cdi>
         <version.jakarta.ws-rs>3.0.0</version.jakarta.ws-rs>
     </properties>

--- a/tck/api/pom.xml
+++ b/tck/api/pom.xml
@@ -21,6 +21,18 @@
     <name>MicroProfile Metrics API-TCK</name>
     <description>MicroProfile Metrics :: API-TCK</description>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.eclipse.microprofile</groupId>
+                <artifactId>microprofile-tck-bom</artifactId>
+                <version>${version.microprofile.tck.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <!-- mp-metrics dependencies: -->
         <dependency>

--- a/tck/optional/pom.xml
+++ b/tck/optional/pom.xml
@@ -35,6 +35,18 @@
         <version.shrinkwrap>2.2.4</version.shrinkwrap>
     </properties>
 
+        <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.eclipse.microprofile</groupId>
+                <artifactId>microprofile-tck-bom</artifactId>
+                <version>${version.microprofile.tck.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
 
         <!-- https://mvnrepository.com/artifact/io.rest-assured/rest-assured -->

--- a/tck/rest/pom.xml
+++ b/tck/rest/pom.xml
@@ -35,7 +35,17 @@
         <version.shrinkwrap>2.2.4</version.shrinkwrap>
     </properties>
 
-   
+       <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.eclipse.microprofile</groupId>
+                <artifactId>microprofile-tck-bom</artifactId>
+                <version>${version.microprofile.tck.bom}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
 


### PR DESCRIPTION
Also update the Metrics TCK poms to pull in MicroProfile Parent TCK BOM
Also filled in properties and dependencies in pom.xml that were removed from MicroProfile Parent.

Fixes #747