### PR TITLE
Add RegistryType and MetricRegistry.Type back in, but deprecated. Upate API, Spec, TCK

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/metrics/MetricRegistry.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/MetricRegistry.java
@@ -33,6 +33,8 @@ import java.util.SortedSet;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import org.eclipse.microprofile.metrics.annotation.RegistryScope;
+
 /**
  * The registry that stores metrics and their metadata. The MetricRegistry provides methods to register, create and
  * retrieve metrics and their respective metadata.
@@ -41,6 +43,61 @@ import java.util.function.Supplier;
  * @see MetricFilter
  */
 public interface MetricRegistry {
+
+    /**
+     * An enumeration representing the provided scopes of the MetricRegistry.
+     * 
+     * @deprecated As of release 5.0, please use either {@link MetricRegistry#APPLICATION_SCOPE},
+     *             {@link MetricRegistry#BASE_SCOPE} or {@link MetricRegistry#VENDOR_SCOPE} with {@link RegistryScope}
+     *             instead.
+     */
+    @Deprecated
+    enum Type {
+        /**
+         * The Application (default) scoped MetricRegistry. Any metric registered/accessed via CDI will use this
+         * MetricRegistry.
+         * 
+         * @deprecated As of release 5.0, please use {@link MetricRegistry#APPLICATION_SCOPE} with {@link RegistryScope}
+         *             instead.
+         */
+        @Deprecated
+        APPLICATION("application"),
+
+        /**
+         * The Base scoped MetricRegistry. This MetricRegistry will contain required metrics specified in the
+         * MicroProfile Metrics specification.
+         * 
+         * @deprecated As of release 5.0, please use {@link MetricRegistry#BASE_SCOPE} with {@link RegistryScope}
+         *             instead.
+         */
+        @Deprecated
+        BASE("base"),
+
+        /**
+         * The Vendor scoped MetricRegistry. This MetricRegistry will contain vendor provided metrics which may vary
+         * between different vendors.
+         * 
+         * @deprecated As of release 5.0, please use {@link MetricRegistry#VENDOR_SCOPE} with {@link RegistryScope}
+         *             instead.
+         */
+        @Deprecated
+        VENDOR("vendor");
+
+        private final String name;
+
+        Type(String name) {
+            this.name = name;
+        }
+
+        /**
+         * Returns the name of the MetricRegistry scope.
+         *
+         * @return the scope
+         */
+        public String getName() {
+            return name;
+        }
+    }
 
     /**
      * String constant to represent the scope value used for the application scope

--- a/api/src/main/java/org/eclipse/microprofile/metrics/MetricRegistry.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/MetricRegistry.java
@@ -47,7 +47,7 @@ public interface MetricRegistry {
     /**
      * An enumeration representing the provided scopes of the MetricRegistry.
      * 
-     * @deprecated As of release 5.0, please use either {@link MetricRegistry#APPLICATION_SCOPE},
+     * @deprecated As of release 5.0, please use {@link MetricRegistry#APPLICATION_SCOPE},
      *             {@link MetricRegistry#BASE_SCOPE} or {@link MetricRegistry#VENDOR_SCOPE} with {@link RegistryScope}
      *             instead.
      */

--- a/api/src/main/java/org/eclipse/microprofile/metrics/annotation/RegistryType.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/annotation/RegistryType.java
@@ -1,0 +1,69 @@
+/*
+ **********************************************************************
+ * Copyright (c) 2017, 2022 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICES file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ **********************************************************************/
+package org.eclipse.microprofile.metrics.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.eclipse.microprofile.metrics.MetricRegistry;
+
+import jakarta.inject.Qualifier;
+
+/**
+ * Qualifies the type of Metric Registry to inject.
+ * <p>
+ * This can be used to obtain the respective scoped {@link MetricRegistry}:
+ * </p>
+ * 
+ * <pre>
+ * <code>
+ *      {@literal @}Inject
+ *      {@literal @}RegistryType(type=MetricRegistry.Type.BASE)
+ *      MetricRegistry baseRegistry;
+ * </code>
+ * </pre>
+ *
+ * @see org.eclipse.microprofile.metrics.MetricRegistry.Type
+ *
+ * @author Raymond Lam
+ * 
+ * @deprecated As of rlease 5.0, please use {@link RegistryScope} instead
+ *
+ */
+@Deprecated
+@Qualifier
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+public @interface RegistryType {
+    /**
+     * The scope of the MetricRegistry.
+     * 
+     * @return Returns the scope of the MetricRegistry. The {@link MetricRegistry.Type} can be {@code APPLICATION},
+     *         {@code BASE}, or {@code VENDOR}.
+     * @see org.eclipse.microprofile.metrics.MetricRegistry.Type
+     */
+    MetricRegistry.Type type() default MetricRegistry.Type.APPLICATION;
+}

--- a/api/src/main/java/org/eclipse/microprofile/metrics/annotation/package-info.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/annotation/package-info.java
@@ -90,8 +90,9 @@
  * <b> This is DEPRECATED. Please use {@link RegistryScope} instead. </b>
  * 
  * The {@link org.eclipse.microprofile.metrics.annotation.RegistryType RegistryType} is used to identify which
- * <code>MetricRegistry</code> (Application, Base, or Vendor) should be injected. By default, no
- * <code>RegistryType</code> will inject the application <code>MetricRegistry</code>.
+ * <code>MetricRegistry</code> (Application, Base, or Vendor) should be injected. Injecting a
+ * <code>MetricRegistry</code> without a <code>RegistryType</code> annotation gives the application-scoped
+ * <code>MetricRegistry</code>.
  *
  * <pre>
  * <code>

--- a/api/src/main/java/org/eclipse/microprofile/metrics/annotation/package-info.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/annotation/package-info.java
@@ -69,7 +69,6 @@
  * </code>
  * </pre>
  *
- *
  * <h2>RegistryScope annotation</h2>
  * <p>
  * The {@link org.eclipse.microprofile.metrics.annotation.RegistryScope RegistryScope} is used to identify which
@@ -84,7 +83,24 @@
  *      MetricRegistry appRegistry;
  * </code>
  * </pre>
+ * 
+ * <h2>RegistryType CDI Qualifier</h2>
+ * <p>
+ * 
+ * <b> This is DEPRECATED. Please use {@link RegistryScope} instead. </b>
+ * 
+ * The {@link org.eclipse.microprofile.metrics.annotation.RegistryType RegistryType} is used to identify which
+ * <code>MetricRegistry</code> (Application, Base, or Vendor) should be injected. By default, no
+ * <code>RegistryType</code> will inject the application <code>MetricRegistry</code>.
  *
+ * <pre>
+ * <code>
+ *      {@literal @}Inject
+ *      {@literal @}RegistryType(type=MetricRegistry.Type.BASE)
+ *      MetricRegistry baseRegistry;
+ * </code>
+ * </pre>
+ * 
  */
 @org.osgi.annotation.versioning.Version("5.0")
 package org.eclipse.microprofile.metrics.annotation;

--- a/spec/src/main/asciidoc/app-programming-model.adoc
+++ b/spec/src/main/asciidoc/app-programming-model.adoc
@@ -470,7 +470,7 @@ If no _scope_ parameter is used, the default `MetricRegistry` returned is the `a
 If using the **deprecated** `@RegistryType`, it will be used as a qualifier to selectively inject one of the `application`, `base` or  `vendor` registries.
 If no qualifier is used, the default `MetricRegistry` returned is the `application` registry. Note that `@RegistryType` is now deprecated. Please use `@RegistryScope` instead.
 
-The `@RegistryScope` annotation and `@RegistryType` qualifer annotation should not be used together for the same `MetricRegistry` injection. The `application`, `base` or `vendor` registry produced by either injection strategies should be the same respective to the scope. That is to say, an injection of a `MetricRegistry` with `@RegistryScope(scope = MetricRegistry.APPLICATION_SCOPE)` will produce the same `MetricRegistry` from using`@RegistryType(type = MetricRegistry.Type.APPLICATION)` and vice-versa.
+The `@RegistryScope` annotation and `@RegistryType` qualifer annotation should not be used together for the same `MetricRegistry` injection. The `application`, `base` or `vendor` registry produced by either injection strategies should be the same respective to the scope. That is to say, an injection of a `MetricRegistry` with `@RegistryScope(scope = MetricRegistry.APPLICATION_SCOPE)` will produce the same `MetricRegistry` from using `@RegistryType(type = MetricRegistry.Type.APPLICATION)` and vice-versa.
 
 Implementations may choose to use a Factory class to produce the injectable `MetricRegistry` bean via CDI. See <<appendix#metric-registry-factory>>. Note: The factory would be an internal class and not exposed to the application.
 
@@ -513,7 +513,7 @@ MetricRegistry metricRegistry;
  * @RegistryType is deprecated. Please use @RegistryScope
  */
 @Inject
-@RegistryType(scope=MetricRegistry.Type.APPLICATION)
+@RegistryType(type=MetricRegistry.Type.APPLICATION)
 MetricRegistry metricRegistry;
 ----
 
@@ -532,7 +532,7 @@ MetricRegistry baseRegistry;
 [source, java]
 ----
 @Inject
-@RegistryType(scope=MetricRegistry.Type.BASE)
+@RegistryType(type=MetricRegistry.Type.BASE)
 MetricRegistry baseRegistry;
 ----
 
@@ -551,7 +551,7 @@ MetricRegistry vendorRegistry;
 [source, java]
 ----
 @Inject
-@RegistryType(scope=MetricRegistry.Type.VENDOR)
+@RegistryType(type=MetricRegistry.Type.VENDOR)
 MetricRegistry vendorRegistry;
 ----
 

--- a/spec/src/main/asciidoc/app-programming-model.adoc
+++ b/spec/src/main/asciidoc/app-programming-model.adoc
@@ -109,11 +109,12 @@ The following Annotations exist, see below for common fields:
 |Annotation | Description | Default
 
 |@RegistryScope| Indicates the scope of Metric Registry to inject when injecting a MetricRegistry. |  _application_ (scope)
+|@RegistryType| Qualifies the scope of Metric Registry to inject when injecting a MetricRegistry. **Note: This is deprecated. Please use @RegistryScope** |  _application_ (scope)
 |===
 
 ==== Fields
 
-All annotations (Except `RegistryScope`) have the following fields that correspond to the metadata fields described
+All annotations (Except `RegistryScope` and `RegistryType`) have the following fields that correspond to the metadata fields described
 in <<architecture#meta-data-def>>.
 
 `String name`:: Optional. Sets the name of the metric. If not explicitly given the name of the annotated object is used.
@@ -466,16 +467,29 @@ When metrics are registered using annotations and no scope is provided, the metr
 When injected, the `@RegistryScope` is used to selectively inject one of the `application`, `base`, `vendor` or custom registries.
 If no _scope_ parameter is used, the default `MetricRegistry` returned is the `application` registry.
 
+If using the **deprecated** `@RegistryType`, it will be used as a qualifier to selectively inject one of the `application`, `base` or  `vendor` registries.
+If no qualifier is used, the default `MetricRegistry` returned is the `application` registry. Note that `@RegistryType` is now deprecated. Please use `@RegistryScope` instead.
+
+The `@RegistryScope` annotation and `@RegistryType` qualifer annotation should not be used together for the same `MetricRegistry` injection. The `application`, `base` or `vendor` registry produced by either injection strategies should be the same respective to the scope. That is to say, an injection of a `MetricRegistry` with `@RegistryScope(scope = MetricRegistry.APPLICATION_SCOPE)` will produce the same `MetricRegistry` from using`@RegistryType(type = MetricRegistry.Type.APPLICATION)` and vice-versa.
+
 Implementations may choose to use a Factory class to produce the injectable `MetricRegistry` bean via CDI. See <<appendix#metric-registry-factory>>. Note: The factory would be an internal class and not exposed to the application.
 
 ==== @RegistryScope
 The `@RegistryScope` can be used to retrieve the `MetricRegistry` for a specific scope.
 The implementation must produce the corresponding `MetricRegistry` specified by the `RegistryScope`.
 
+
+==== @RegistryType
+The `@RegistryType` can be used to retrieve the `MetricRegistry` for a specific scope.
+The implementation must produce the corresponding `MetricRegistry` specified by the `RegistryType`.
+
 NOTE: The implementor can optionally provide a _read_only_ copy of the `MetricRegistry` for _base_ and _vendor_ scopes.
 
+
+NOTE: The `@RegistryType` is **deprecated**. Please use `@RegistryScope` instead.
+
 ==== Application Metric Registry
-The implementation must produce the _application_ `MetricRegistry` when no `RegistryScope` is provided or when the `RegistryScope` is `application` (i.e. `MetricRegistry.APPLICATION_SCOPE`). Application-defined metrics can also be registered to <<pgm-custom-scope,user-defined scopes>>
+The implementation must produce the _application_ `MetricRegistry` when no `RegistryScope` (or `RegistryType`) is provided or when the `RegistryScope` is `application` (i.e. `MetricRegistry.APPLICATION_SCOPE`) or if the **deprecated** `RegistryType` is `application` (i.e. `MetricRegistry.Type.APPLICATION`). Application-defined metrics can also be registered to <<pgm-custom-scope,user-defined scopes>>
 
 .Example of the application injecting the application registry
 [source, java]
@@ -484,7 +498,7 @@ The implementation must produce the _application_ `MetricRegistry` when no `Regi
 MetricRegistry metricRegistry;
 ----
 
-.is equivalent to
+.is equivalent to the following with `@RegistryScope`
 [source, java]
 ----
 @Inject
@@ -492,10 +506,21 @@ MetricRegistry metricRegistry;
 MetricRegistry metricRegistry;
 ----
 
+.or is equivalent to the following with the **deprecated** `@RegistryType`
+[source, java]
+----
+/*
+ * @RegistryType is deprecated. Please use @RegistryScope
+ */
+@Inject
+@RegistryType(scope=MetricRegistry.Type.APPLICATION)
+MetricRegistry metricRegistry;
+----
+
 ==== Base Metric Registry
 The implementation must produce the _base_ `MetricRegistry` when the `RegistryScope` is `base` (i.e. `MetricRegistry.BASE_SCOPE`). The _base_ `MetricRegistry` contains any metrics the vendor has chosen to provide from <<base-metrics#base-metrics>>.
 
-.Example of the application injecting the base registry
+.Example of the application injecting the base registry using `@RegistryScope`
 [source, java]
 ----
 @Inject
@@ -503,14 +528,30 @@ The implementation must produce the _base_ `MetricRegistry` when the `RegistrySc
 MetricRegistry baseRegistry;
 ----
 
+.Example of the application injecting the base registry using the **deprecated** `@RegistryType`
+[source, java]
+----
+@Inject
+@RegistryType(scope=MetricRegistry.Type.BASE)
+MetricRegistry baseRegistry;
+----
+
 ==== Vendor Metric Registry
 The implementation must produce the _vendor_ `MetricRegistry` when the `RegistryScope` is `vendor` (i.e. `MetricRegistry.VENDOR_SCOPE`). The _vendor_ `MetricRegistry` must contain any vendor specific metrics.
 
-.Example of the application injecting the vendor registry
+.Example of the application injecting the vendor registry using `@RegistryScope`
 [source, java]
 ----
 @Inject
 @RegistryScope(scope=MetricRegistry.VENDOR_SCOPE)
+MetricRegistry vendorRegistry;
+----
+
+.Example of the application injecting the vendor registry using the **deprecated** `@RegistryType`
+[source, java]
+----
+@Inject
+@RegistryType(scope=MetricRegistry.Type.VENDOR)
 MetricRegistry vendorRegistry;
 ----
 

--- a/spec/src/main/asciidoc/appendix.adoc
+++ b/spec/src/main/asciidoc/appendix.adoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2016, 2018 Contributors to the Eclipse Foundation
+// Copyright (c) 2016, 2022 Contributors to the Eclipse Foundation
 //
 // See the NOTICE file(s) distributed with this work for additional
 // information regarding copyright ownership.
@@ -119,6 +119,24 @@ public class MetricRegistryFactory {
             String annoScope = registryTypeAnnotation.scope();
             return getOrCreate(annoScope);
         }
+    }
+
+    @Produces
+    @RegistryType(type = MetricRegistry.Type.APPLICATION)
+    public MetricRegistry getApplicationRegistry() {
+        return getOrCreate(MetricRegistry.Type.APPLICATION);
+    }
+
+    @Produces
+    @RegistryType(type = MetricRegistry.Type.BASE)
+    public MetricRegistry getBaseRegistry() {
+        return getOrCreate(MetricRegistry.Type.BASE);
+    }
+
+    @Produces
+    @RegistryType(type = MetricRegistry.Type.VENDOR)
+    public MetricRegistry getVendorRegistry() {
+        return getOrCreate(MetricRegistry.Type.VENDOR);
     }
 
 }

--- a/spec/src/main/asciidoc/changelog.adoc
+++ b/spec/src/main/asciidoc/changelog.adoc
@@ -115,6 +115,7 @@
 * Updated Snapshot class
 ** Added `percentileValues()` method
 ** Added Snapshot.PercentileValue inner class
+* Deprecated @RegistryType and MetricRegistry.Type (https://github.com/eclipse/microprofile-metrics/issues/746[746])
 
 === Functional Changes
 

--- a/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/MetricRegistryTest.java
+++ b/tck/api/src/main/java/org/eclipse/microprofile/metrics/tck/MetricRegistryTest.java
@@ -31,6 +31,7 @@ import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.Tag;
 import org.eclipse.microprofile.metrics.annotation.Metric;
 import org.eclipse.microprofile.metrics.annotation.RegistryScope;
+import org.eclipse.microprofile.metrics.annotation.RegistryType;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.junit.InSequence;
@@ -65,6 +66,18 @@ public class MetricRegistryTest {
     @Inject
     @RegistryScope(scope = CUSTOM_SCOPE)
     private MetricRegistry customScope;
+
+    @Inject
+    @RegistryType(type = MetricRegistry.Type.BASE)
+    private MetricRegistry baseMetrics_RegistryType;
+
+    @Inject
+    @RegistryType(type = MetricRegistry.Type.VENDOR)
+    private MetricRegistry vendorMetrics_RegistryType;
+
+    @Inject
+    @RegistryType(type = MetricRegistry.Type.APPLICATION)
+    private MetricRegistry applicationMetrics_RegistryType;
 
     @Deployment
     public static WebArchive createDeployment() {
@@ -112,6 +125,22 @@ public class MetricRegistryTest {
         Assert.assertEquals(MetricRegistry.BASE_SCOPE, baseMetrics.getScope());
         Assert.assertEquals(MetricRegistry.VENDOR_SCOPE, vendorMetrics.getScope());
         Assert.assertEquals(CUSTOM_SCOPE, customScope.getScope());
+    }
+
+    @Test
+    @InSequence(6)
+    public void testMetricRegistryScopeDeprecatedRegistryType() {
+        Assert.assertEquals(MetricRegistry.APPLICATION_SCOPE, applicationMetrics_RegistryType.getScope());
+        Assert.assertEquals(MetricRegistry.BASE_SCOPE, baseMetrics_RegistryType.getScope());
+        Assert.assertEquals(MetricRegistry.VENDOR_SCOPE, vendorMetrics_RegistryType.getScope());
+    }
+
+    @Test
+    @InSequence(7)
+    public void testMetricRegistryEquivalence() {
+        Assert.assertEquals(metrics, applicationMetrics_RegistryType);
+        Assert.assertEquals(baseMetrics, baseMetrics_RegistryType);
+        Assert.assertEquals(vendorMetrics, vendorMetrics_RegistryType);
     }
 
     private void assertExists(Class<? extends org.eclipse.microprofile.metrics.Metric> expected, MetricID metricID) {


### PR DESCRIPTION
Fixes #746

Up for discussion during MP Metrics call.