### PR TITLE
Update maven-compiler-plugin configuration to reference java 11

### DIFF
--- a/tck/README.adoc
+++ b/tck/README.adoc
@@ -131,8 +131,8 @@ If you use Apache Maven, then the tests are run via the `maven-surefire-plugin` 
             <artifactId>maven-compiler-plugin</artifactId>
             <version>2.3.2</version>
             <configuration>
-                <source>1.8</source>
-                <target>1.8</target>
+                <source>11</source>
+                <target>11</target>
             </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
Related to #752

MP Metrics 5 is dependent on JEE 10 which is Java 11 only.