### PR TITLE
Explicitly set dependency for Jakarata EE technologies used by MP Metrics

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -28,8 +28,16 @@
 
     <dependencies>
         <dependency>
-            <groupId>jakarta.platform</groupId>
-            <artifactId>jakarta.jakartaee-core-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.interceptor</groupId>
+            <artifactId>jakarta.interceptor-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.osgi</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,35 @@
                 <version>${project.version}</version>
                 <scope>provided</scope>
             </dependency>
+            <dependency>
+                <groupId>jakarta.enterprise</groupId>
+                <artifactId>jakarta.enterprise.cdi-api</artifactId>
+                <version>4.0.1</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>*</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                    </exclusions>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.inject</groupId>
+                <artifactId>jakarta.inject-api</artifactId>
+                <version>2.0.1</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.ws.rs</groupId>
+                <artifactId>jakarta.ws.rs-api</artifactId>
+                <version>3.1.0</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.interceptor</groupId>
+                <artifactId>jakarta.interceptor-api</artifactId>
+                <version>2.1.0</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/tck/README.adoc
+++ b/tck/README.adoc
@@ -38,10 +38,13 @@ To enable the tests in your Arquillian based test project you need to add the fo
 ----
 
 <!-- versions should correspond to the value specified in the MicroProfile Parent
-pom.xml and MicroProfile Parent TCK-BOM pom.xml used by the specified version of MicroProfile Metrics -->
+pom.xml, MicroProfile Parent TCK-BOM pom.xml and Jakartaa EE Core API pom.xml 
+used by the specified version of MicroProfile Metrics -->
 <properties>
     <microprofile.metrics.version>5.0.0</microprofile.metrics.version>
     <jakartaee.coreprofile.version>10.0.0</jakartaee.coreprofile.version>
+    <jakarta.enterprise.cdi-api.version>4.0.1</jakartaee.enterprise.cdi-api.version>
+    <jakartaee.ws.rs-api.version>3.1.0</jakartaee.ws.rs-api.version>
     <junit.version>4.13.2</junit.version>
     <arquillian.version>1.7.0.Alpha12</arquillian.version>
     <hamcrest.version>1.3</hamcrest.version>
@@ -70,6 +73,20 @@ pom.xml and MicroProfile Parent TCK-BOM pom.xml used by the specified version of
         <groupId>jakarta.platform</groupId>
         <artifactId>jakarta.jakartaee-core-api</artifactId>
         <version>${jakartaee.coreprofile.version}</version>
+        <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+        <groupId>jakarta.enterprise</groupId>
+        <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        <version>${jakartaee.enterprise.cdi-api.version}</version>
+        <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+        <groupId>jakarta.ws.rs</groupId>
+        <artifactId>jakarta.ws.rs-api</artifactId>
+        <version>${jakartaee.ws.rs-api.version}</version>
         <scope>provided</scope>
     </dependency>
 

--- a/tck/api/pom.xml
+++ b/tck/api/pom.xml
@@ -39,9 +39,15 @@
             <groupId>org.eclipse.microprofile.metrics</groupId>
             <artifactId>microprofile-metrics-api</artifactId>
         </dependency>
+        
         <dependency>
-            <groupId>jakarta.platform</groupId>
-            <artifactId>jakarta.jakartaee-core-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
         </dependency>
 
         <dependency>

--- a/tck/optional/pom.xml
+++ b/tck/optional/pom.xml
@@ -69,8 +69,18 @@
         </dependency>
 
         <dependency>
-            <groupId>jakarta.platform</groupId>
-            <artifactId>jakarta.jakartaee-core-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
         </dependency>
 
     </dependencies>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -55,7 +55,6 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-
         </dependencies>
     </dependencyManagement>    
 </project>

--- a/tck/rest/pom.xml
+++ b/tck/rest/pom.xml
@@ -36,7 +36,7 @@
                 <version>${version.microprofile.tck.bom}</version>
                 <type>pom</type>
                 <scope>import</scope>
-            </dependency>
+           </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -67,9 +67,15 @@
             <groupId>org.eclipse.microprofile.metrics</groupId>
             <artifactId>microprofile-metrics-api</artifactId>
         </dependency>
+
         <dependency>
-            <groupId>jakarta.platform</groupId>
-            <artifactId>jakarta.jakartaee-core-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
Related to : https://github.com/eclipse/microprofile-metrics/issues/752

This PR removes the Jakarta EE 10.0.0 core API dependency in exchange to use the explicit Jakarta EE dependencies needed for MicroProfile Metrics (TCK/API).

In general, MP Metrics relies on `CDI` and `Restful WS`.

Exclusions were used in the MP Metrics `pom.xml`s similar to that of the Jakarta EE 10.0.0 core API  ( i.e. `jakarta.jakartaee-core-api`)at https://repo1.maven.org/maven2/jakarta/platform/jakarta.jakartaee-core-api/10.0.0/jakarta.jakartaee-core-api-10.0.0.pom where _all_ dependencies are excluded and only the dependencies that are _*needed*_ by MP Metrics is is defined in the `pom.xml` (i.e. `jakarta.interceptor-api` and `jakarta.inject-api` ). This creates the lightest foot print for MP Metrics.


---------------------

A proposal was provided before to import the `pom.xml` of the `jakarta.jakartaee-core-api` `pom.xml`. This would not work as the dependencies defined in the `jakarta.jakartaee-core-api` `pom.xml` were not within a `dependencyManagement` element.





