### PR TITLE
Fixed 10 javadoc errors with MicroProfile 6.0

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/metrics/annotation/Counted.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/annotation/Counted.java
@@ -138,7 +138,7 @@ public @interface Counted {
     /**
      * The scope that this counter belongs to.
      * 
-     * @return The scope this counter belongs to. By default, the value is {@link MetricRegistry.APPLICATION_SCOPE}.
+     * @return The scope this counter belongs to. By default, the value is {@link MetricRegistry#APPLICATION_SCOPE}.
      *
      */
     @Nonbinding

--- a/api/src/main/java/org/eclipse/microprofile/metrics/annotation/Gauge.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/annotation/Gauge.java
@@ -112,7 +112,7 @@ public @interface Gauge {
     /**
      * The scope that this gauge belongs to.
      * 
-     * @return The scope this gauge belongs to. By default, the value is {@link MetricRegistry.APPLICATION_SCOPE}.
+     * @return The scope this gauge belongs to. By default, the value is {@link MetricRegistry#APPLICATION_SCOPE}.
      *
      */
     @Nonbinding

--- a/api/src/main/java/org/eclipse/microprofile/metrics/annotation/Metric.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/annotation/Metric.java
@@ -108,7 +108,7 @@ public @interface Metric {
     /**
      * The scope that this metric belongs to.
      * 
-     * @return The scope this metric belongs to. By default, the value is {@link MetricRegistry.APPLICATION_SCOPE}.
+     * @return The scope this metric belongs to. By default, the value is {@link MetricRegistry#APPLICATION_SCOPE}.
      *
      */
     @Nonbinding

--- a/api/src/main/java/org/eclipse/microprofile/metrics/annotation/RegistryScope.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/annotation/RegistryScope.java
@@ -48,8 +48,8 @@ import org.eclipse.microprofile.metrics.MetricRegistry;
  * </code>
  * </pre>
  *
- * see {@link MetricRegistry.APPLICATION_SCOPE}, {@link MetricRegistry.BASE_SCOPE} and
- * {@link MetricRegistry.VENDOR_SCOPE}
+ * see {@link MetricRegistry#APPLICATION_SCOPE}, {@link MetricRegistry#BASE_SCOPE} and
+ * {@link MetricRegistry#VENDOR_SCOPE}
  *
  * @author Raymond Lam
  *
@@ -65,8 +65,8 @@ public @interface RegistryScope {
      *         {@code application}, {@code base} and {@code vendor} scopes automatically and creates user-defined scopes
      *         as needed.
      * 
-     *         see {@link MetricRegistry.APPLICATION_SCOPE}, {@link MetricRegistry.BASE_SCOPE} and
-     *         {@link MetricRegistry.VENDOR_SCOPE}
+     *         see {@link MetricRegistry#APPLICATION_SCOPE}, {@link MetricRegistry#BASE_SCOPE} and
+     *         {@link MetricRegistry#VENDOR_SCOPE}
      */
     String scope() default MetricRegistry.APPLICATION_SCOPE;
 }

--- a/api/src/main/java/org/eclipse/microprofile/metrics/annotation/Timed.java
+++ b/api/src/main/java/org/eclipse/microprofile/metrics/annotation/Timed.java
@@ -132,7 +132,7 @@ public @interface Timed {
     /**
      * The scope that this Timer belongs to.
      * 
-     * @return The scope this Timer belongs to. By default, the value is {@link MetricRegistry.APPLICATION_SCOPE}.
+     * @return The scope this Timer belongs to. By default, the value is {@link MetricRegistry#APPLICATION_SCOPE}.
      *
      */
     @Nonbinding


### PR DESCRIPTION
These were found while trying to generate MicroProfile 6.0 javadocs. The html was still produced, but some of the links did not work. The code changes will fix the links by changing the syntax in comments for what the javadoc command generates.

`@link MetricRegistry.APPLICATION_SCOPE` for instance generates just text:
<img width="921" alt="image" src="https://user-images.githubusercontent.com/6392944/215874353-8518ac77-67f6-46ca-a4d3-a587548e793f.png">

This is fixed by changing it to ``@link MetricRegistry#APPLICATION_SCOPE` which generates a link:
<img width="911" alt="image" src="https://user-images.githubusercontent.com/6392944/215874767-150bd9a9-846f-4a9c-a2bc-716895dc0aca.png">
