### PR TITLE
Fix MPmetricbaseMetricsTest so that it is checking gc.time as a gauge…

### DIFF
--- a/spec/src/main/asciidoc/changelog.adoc
+++ b/spec/src/main/asciidoc/changelog.adoc
@@ -152,6 +152,7 @@ A full list of changes may be found on the link:https://github.com/eclipse/micro
 * (5.0.1) Removed private gauges from TCK (https://github.com/eclipse/microprofile-metrics/pull/770[770])
 * (5.0.1) The `@Timed` annotation defaults to SECONDS when it should be NANOSECONDS (https://github.com/eclipse/microprofile-metrics/issues/760[760])
 * (5.0.1) Errors in MicroProfile 6.0 javadoc generation (https://github.com/eclipse/microprofile-metrics/issues/764[764])
+* (5.0.2) Fix `MPMetricBaseMetricsTest` TCK test where gc.time was being checked as a counter. The `gc.time` metric is a gauge. (https://github.com/eclipse/microprofile-metrics/issues/786[786])
 
 [[release_notes_4_0]]
 == Changes in 4.0

--- a/tck/optional/src/main/java/org/eclipse/microprofile/metrics/test/optional/MPMetricBaseMetricsTest.java
+++ b/tck/optional/src/main/java/org/eclipse/microprofile/metrics/test/optional/MPMetricBaseMetricsTest.java
@@ -1,6 +1,6 @@
 /*
  **********************************************************************
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
  *
  * See the NOTICES file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -303,28 +303,28 @@ public class MPMetricBaseMetricsTest {
         String data = given().header(wantPromMetricsFormat).get("/metrics?scope=base").asString();
 
         Map<String, MiniMeta> baseNames = getExpectedMetadataFromXmlFile(MetricRegistry.BASE_SCOPE);
-        MiniMeta gcCountMetricMeta = baseNames.get("gc.time");
-        Set<String> expectedTags = gcCountMetricMeta.tags.keySet();
+        MiniMeta gcTimeMetricMeta = baseNames.get("gc.time");
+        Set<String> expectedTags = gcTimeMetricMeta.tags.keySet();
 
         String[] lines = data.split("\n");
 
         boolean found = false;
         for (String line : lines) {
             // explicitly check for the metric line wth value (i.e. the use of `{`)
-            if (line.contains("gc_time_seconds_total{")) {
-                final Pattern gcTimeTotalPattern = Pattern.compile("(gc_time_seconds_total\\{.*?\\}) (\\d+\\.\\d+)");
-                assertThat("Line format should be gc_time_seconds_total\\{.*?\\} \\d+\\.\\d+",
+            if (line.contains("gc_time_seconds{")) {
+                final Pattern gcTimeTotalPattern = Pattern.compile("(gc_time_seconds\\{.*?\\}) (\\d+\\.\\d+)");
+                assertThat("Line format should be gc_time_seconds\\{.*?\\} \\d+\\.\\d+",
                         gcTimeTotalPattern.matcher(line).matches());
 
                 final String metricID = gcTimeTotalPattern.matcher(line).replaceAll("$1");
-                final String tags = metricID.replaceAll("^gc_time_seconds_total\\{", "").replaceAll("\\}$", "");
+                final String tags = metricID.replaceAll("^gc_time_seconds\\{", "").replaceAll("\\}$", "");
 
                 for (String expectedTag : expectedTags) {
                     assertThat("The metric should contain a " + expectedTag + " tag", tags,
                             containsString(expectedTag + "="));
                 }
                 final String value = gcTimeTotalPattern.matcher(line).replaceAll("$2");
-                Assert.assertTrue("gc.time.seconds.total value should be numeric and not negative",
+                Assert.assertTrue("gc.time value should be numeric and not negative",
                         Double.valueOf(value).doubleValue() >= 0);
 
                 found = true;


### PR DESCRIPTION
… which does not have a _total appended to it

This PR is for the 5.0.x branch (i.e. for 5.0.2)