### PR TITLE
Exclude plug-in from runtime path

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -31,7 +31,7 @@
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
-        
+
         <dependency>
             <groupId>org.osgi</groupId>
             <artifactId>org.osgi.annotation.versioning</artifactId>
@@ -39,7 +39,9 @@
         <dependency>
             <groupId>biz.aQute.bnd</groupId>
             <artifactId>bnd-baseline-maven-plugin</artifactId>
+            <!-- Needed to build to resolve annotation but should not be in the runtime path for downstream consumers. -->
+            <scope>provided</scope>
         </dependency>
     </dependencies>
-    
+
 </project>


### PR DESCRIPTION
Additional change for #796 

The plug-in seems to be needed at build-time for the annotation added to the code, but there is no need for it--and it should not be--in the runtime path and in the runtime paths of artifacts that depend on this component.